### PR TITLE
Fix withdrawal tx list when token is not supported

### DIFF
--- a/apps/bridge/src/utils/transactions/explorerTxToBridgeWithdrawal.ts
+++ b/apps/bridge/src/utils/transactions/explorerTxToBridgeWithdrawal.ts
@@ -52,12 +52,12 @@ export function explorerTxToBridgeWithdrawal(tx: BlockExplorerTransaction): Brid
     type: 'Withdrawal',
     from: tx.from,
     to: tx.to,
-    assetSymbol: token.L2symbol ?? '',
+    assetSymbol: token?.L2symbol ?? 'Unlisted',
     amount: (
       (functionName === 'withdraw' ? decodedWithdrawData[1] : decodedWithdrawData[2]) as BigNumber
     ).toString(),
     blockTimestamp: tx.timeStamp,
     hash: tx.hash as `0x${string}`,
-    priceApiId: token.apiId,
+    priceApiId: token?.apiId,
   };
 }


### PR DESCRIPTION
**What changed? Why?**
After starting a withdrawal of an unlisted token, there was a missing null check while getting the asset symbol on the transaction list making it incomplete.

**Notes to reviewers**
Small fix

**How has it been tested?**

Current version
<img width="1243" alt="Screen Shot 2023-10-02 at 14 47 24" src="https://github.com/base-org/web/assets/5704575/22dd861f-7200-433f-8280-af779f38a182">

Fixed version
<img width="765" alt="Screen Shot 2023-10-02 at 14 42 36" src="https://github.com/base-org/web/assets/5704575/b0df376d-59f2-42be-8770-2b921f900a4f">

