### PR TITLE
Don't append 0x01 to calldata for explicit deposit/withdrawal destinations

### DIFF
--- a/apps/bridge/src/components/DepositContainer/DepositContainer.tsx
+++ b/apps/bridge/src/components/DepositContainer/DepositContainer.tsx
@@ -86,7 +86,7 @@ export function DepositContainer() {
 
   const chainEnv = useChainEnv();
   const isMainnet = chainEnv === 'mainnet';
-  const includeTosVersionByte = isMainnet;
+  const includeTosVersionByte = isMainnet && depositTo === '';
   const isUserPermittedToBridge = useIsPermittedToBridge();
   const isPermittedToBridgeTo = useIsPermittedToBridgeTo(depositTo as `0x${string}`);
   const isPermittedToBridge = isSmartContractWallet

--- a/apps/bridge/src/components/WithdrawContainer/WithdrawContainer.tsx
+++ b/apps/bridge/src/components/WithdrawContainer/WithdrawContainer.tsx
@@ -48,7 +48,7 @@ export function WithdrawContainer() {
 
   const chainEnv = useChainEnv();
   const isMainnet = chainEnv === 'mainnet';
-  const includeTosVersionByte = isMainnet;
+  const includeTosVersionByte = isMainnet && withdrawTo === '';
   const isUserPermittedToBridge = useIsPermittedToBridge();
   const isPermittedToBridgeTo = useIsPermittedToBridgeTo(withdrawTo as `0x${string}`);
   const isPermittedToBridge = isSmartContractWallet


### PR DESCRIPTION
**What changed? Why?**
Remove the `0x01` magic byte for deposits / withdrawals that have explicit destination addresses. This can cause reverts if the destination is a smart contract: https://basescan.org/tx/0x0f0ef64e24df6d8ccd8c56839672101c8ad1669f127dd2aa29e931cb696e9827.

**How has it been tested?**
Existing tests.