### PR TITLE
Add CCA Lite domain to CSP

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -55,6 +55,7 @@ const isLocalDevelopment = process.env.NODE_ENV === 'development';
 const baseXYZDomains = 'https://base.mirror.xyz';
 const greenhouseDomains = 'https://boards.greenhouse.io';
 const ccaDomain = 'https://static-assets.coinbase.com/js/cca/v0.0.1.js';
+const ccaLiteDomains = 'https://cca-lite.coinbase.com';
 const analyticsDomains = 'https://analytics-service-dev.cbhq.net';
 
 const contentSecurityPolicy = {
@@ -65,6 +66,7 @@ const contentSecurityPolicy = {
     baseXYZDomains,
     greenhouseDomains,
     ccaDomain,
+    ccaLiteDomains,
     analyticsDomains,
   ],
   'frame-ancestors': ["'self'", baseXYZDomains],


### PR DESCRIPTION
**What changed? Why?**

I added another CCA Lite domain to the CSP. This domain was not causing CSP errors in local dev, but once deployed to prod, the following was logged in the console:

<img width="718" alt="Screenshot 2023-10-03 at 1 07 29 PM" src="https://github.com/base-org/web/assets/144269024/76d9b87c-a508-479d-b989-a78620ce8585">

**Notes to reviewers**

N/A

**How has it been tested?**

I opened a PR (but didn't merge) in protocols/base-web and validated with a dev deployment that the new CSP fixed the error. Looks to be working fine in [dev](https://base.cbhq.net/).