### PR TITLE
Add hardware requirements, snapshots instrux and EBS callout to Node guide

### DIFF
--- a/apps/base-docs/docs/building-with-base/guides/run-a-base-node.md
+++ b/apps/base-docs/docs/building-with-base/guides/run-a-base-node.md
@@ -27,6 +27,13 @@ If you're looking to harden your dapp and avoid rate-limiting for your users, pl
 
 :::
 
+### Hardware requirements
+
+We recommend you have this configuration to run a node:
+
+- at least 16 GB RAM
+- an SSD drive with at least 1 TB free
+
 ### Docker
 
 This guide assumes you are familiar with [Docker] and have it running on your machine.

--- a/apps/base-docs/docs/building-with-base/guides/run-a-base-node.md
+++ b/apps/base-docs/docs/building-with-base/guides/run-a-base-node.md
@@ -56,6 +56,22 @@ Syncing your node may take **days** and will consume a vast amount of your reque
 
 :::
 
+### Snapshots
+
+If you're a prospective or current Base Node operator and would like to restore from a snapshot to save time on the initial sync, it's possible to always get the latest available snapshot of the Base chain on mainnet and/or testnet by using the following CLI commands. The snapshots are updated every hour.
+
+**Mainnet**
+
+```
+wget https://base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com/$(curl https://base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com/latest)
+```
+
+**Testnet**
+
+```
+wget https://base-goerli-archive-snapshots.s3.us-east-1.amazonaws.com/$(curl https://base-goerli-archive-snapshots.s3.us-east-1.amazonaws.com/latest)
+```
+
 ### Syncing
 
 You can monitor the progress of your sync with:

--- a/apps/base-docs/docs/building-with-base/guides/run-a-base-node.md
+++ b/apps/base-docs/docs/building-with-base/guides/run-a-base-node.md
@@ -34,6 +34,12 @@ We recommend you have this configuration to run a node:
 - at least 16 GB RAM
 - an SSD drive with at least 1 TB free
 
+:::info
+
+If utilizing Amazon Elastic Block Store (EBS), ensure timing buffered disk reads are fast enough in order to avoid latency issues alongside the rate of new blocks added to Base during the initial synchronization process.
+
+:::
+
 ### Docker
 
 This guide assumes you are familiar with [Docker] and have it running on your machine.


### PR DESCRIPTION
**What changed? Why?**

### Added hardware requirements w/ EBS callout:
![2023-10-03 at 22 44 39@2x](https://github.com/base-org/web/assets/1130872/987eba83-c553-45c2-97e4-a0b9123b712c)

**Note:** EBS callout is due to multiple reports in https://github.com/base-org/node/issues/105

### Added snapshot instructions:
![2023-10-03 at 22 28 27@2x](https://github.com/base-org/web/assets/1130872/5d967c6c-8021-464f-8147-8daf2e012459)

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost preview
