### PR TITLE
Add CCA Lite domains to Base Docs CSP.

### DIFF
--- a/apps/base-docs/server.js
+++ b/apps/base-docs/server.js
@@ -55,7 +55,13 @@ const contentSecurityPolicy = {
   'default-src': ["'self'"],
   'frame-ancestors': ["'self'"],
   'form-action': ["'self'"],
-  'script-src': ["'self'", "'unsafe-inline'"],
+  'script-src': [
+    "'self'",
+    "'unsafe-inline'",
+    'https://static-assets.coinbase.com/js/cca/v0.0.1.js', // CCA Lite
+    'https://cca-lite.coinbase.com', // CCA Lite
+    'https://analytics-service-dev.cbhq.net', // CCA Lite
+  ],
   'style-src': ["'self'", "'unsafe-inline'"],
   'img-src': ["'self'", 'data:'],
   'connect-src': [
@@ -64,6 +70,7 @@ const contentSecurityPolicy = {
     'wss://relay.walletconnect.com', // WalletConnect
     'wss://relay.walletconnect.org',
     'https://goerli.base.org', // Base Goerli RPC
+    'https://cca-lite.coinbase.com', // CCA Lite
   ],
   'frame-src': ["'self'", 'https://player.vimeo.com'],
 };


### PR DESCRIPTION
**What changed? Why?**

I added another CCA Lite domain to the CSP. This domain was not causing CSP errors in local dev, but once deployed to prod, the following was logged in the console:
 
<img width="584" alt="Screenshot 2023-10-03 at 3 28 01 PM" src="https://github.com/base-org/web/assets/144269024/8eea54dd-eaed-4b8d-b2d0-47cb7354abda">

**Notes to reviewers**

N/A

**How has it been tested?**

I opened a PR (but didn't merge) in protocols/base-web and validated with a dev deployment that the new Docs CSP fixed the error. Looks to be working fine in [dev](https://base-docs.cbhq.net/using-base).