### PR TITLE
Remove cbhq URL from CSP

### DIFF
--- a/apps/base-docs/server.js
+++ b/apps/base-docs/server.js
@@ -60,7 +60,6 @@ const contentSecurityPolicy = {
     "'unsafe-inline'",
     'https://static-assets.coinbase.com/js/cca/v0.0.1.js', // CCA Lite
     'https://cca-lite.coinbase.com', // CCA Lite
-    'https://analytics-service-dev.cbhq.net', // CCA Lite
   ],
   'style-src': ["'self'", "'unsafe-inline'"],
   'img-src': ["'self'", 'data:'],

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -56,7 +56,6 @@ const baseXYZDomains = 'https://base.mirror.xyz';
 const greenhouseDomains = 'https://boards.greenhouse.io';
 const ccaDomain = 'https://static-assets.coinbase.com/js/cca/v0.0.1.js';
 const ccaLiteDomains = 'https://cca-lite.coinbase.com';
-const analyticsDomains = 'https://analytics-service-dev.cbhq.net';
 
 const contentSecurityPolicy = {
   'default-src': [
@@ -67,7 +66,6 @@ const contentSecurityPolicy = {
     greenhouseDomains,
     ccaDomain,
     ccaLiteDomains,
-    analyticsDomains,
   ],
   'frame-ancestors': ["'self'", baseXYZDomains],
   'form-action': ["'self'", baseXYZDomains],


### PR DESCRIPTION
**What changed? Why?**

Removed the cbhq analytics URL from the Web and Docs CSP. This was only needed to get the CSP working in local dev, but the URL is not necessary for analytics to work in prod and should not be committed to the codebase.

**Notes to reviewers**

N/A

**How has it been tested?**

I removed the cbhq URL in [this test PR](https://github.cbhq.net/protocols/base-web/pull/490/files) to protocols/base-web to validate that analytics still works in the deployed Web and Docs apps with that URL removed from the CSP.