### PR TITLE
chore(bootcamp): replace backtick with apostrophe

### DIFF
--- a/apps/web/src/components/Bootcamp/WhatsIncluded.tsx
+++ b/apps/web/src/components/Bootcamp/WhatsIncluded.tsx
@@ -3,21 +3,32 @@ export function WhatsIncluded() {
     <div className="flex w-full max-w-[1440px] flex-col space-y-20 bg-black px-8 pt-12">
       <div className="grid grid-cols-2">
         <div className="flex w-full flex-col font-display text-3xl text-white md:text-5xl lg:text-6xl">
-          <p>What's included?</p>
+          <p>What&apos;s included?</p>
         </div>
-  
+
         <div className="text-md font-sans text-white">
           <p className="font-bold">Base Camp Curriculum</p>
-          <p>Participants will work through the <a href="https://docs.base.org/base-camp/docs/welcome/">Base Camp</a> content, which is publicly available. However, as part of the Base Bootcamp program, they will also have access to supplemental resources and graded projects, reviewed by Coinbase engineers.</p>
+          <p>
+            Participants will work through the{' '}
+            <a href="https://docs.base.org/base-camp/docs/welcome/">Base Camp</a> content, which is
+            publicly available. However, as part of the Base Bootcamp program, they will also have
+            access to supplemental resources and graded projects, reviewed by Coinbase engineers.
+          </p>
           <br />
           <p className="font-bold">Mentors</p>
           <p>Each student is paired with a mentor whom you will meet with once a week.</p>
           <br />
           <p className="font-bold">Office Hours</p>
-          <p>Base Bootcamp staff will host regular open office hours via Google Meet to answer questions.</p>
+          <p>
+            Base Bootcamp staff will host regular open office hours via Google Meet to answer
+            questions.
+          </p>
           <br />
           <p className="font-bold">Discord</p>
-          <p>All students will have access to a private channel in the Base Discord where they can interact with Coinbase staff, mentors and other Base Bootcamp students.</p>
+          <p>
+            All students will have access to a private channel in the Base Discord where they can
+            interact with Coinbase staff, mentors and other Base Bootcamp students.
+          </p>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/Bootcamp/WhatsIncluded.tsx
+++ b/apps/web/src/components/Bootcamp/WhatsIncluded.tsx
@@ -3,7 +3,7 @@ export function WhatsIncluded() {
     <div className="flex w-full max-w-[1440px] flex-col space-y-20 bg-black px-8 pt-12">
       <div className="grid grid-cols-2">
         <div className="flex w-full flex-col font-display text-3xl text-white md:text-5xl lg:text-6xl">
-          <p>What`s included?</p>
+          <p>What's included?</p>
         </div>
   
         <div className="text-md font-sans text-white">


### PR DESCRIPTION
Small nit, replaces a backtick that should be an apostrophe

**What changed? Why?**

### Before

![2023-10-05 at 11 12 46@2x](https://github.com/base-org/web/assets/1130872/442c9a4d-0469-4508-8949-0ef52666526d)

### After

![2023-10-05 at 11 13 36@2x](https://github.com/base-org/web/assets/1130872/475656b9-28f5-4055-8532-fd2c104207a0)

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost