### PR TITLE
fix(doc search): Refactor search box for optimal display on handheld devices

### DIFF
--- a/apps/base-docs/src/theme/SearchBar.jsx
+++ b/apps/base-docs/src/theme/SearchBar.jsx
@@ -40,10 +40,6 @@ export default function SearchBar() {
         <SearchIcon />
         Search
       </div>
-      <div className={styles.keys}>
-        <kbd className={styles.command}>⌘</kbd>
-        <kbd>K</kbd>
-      </div>
     </div>
   );
 }

--- a/apps/base-docs/src/theme/kbar.module.css
+++ b/apps/base-docs/src/theme/kbar.module.css
@@ -66,7 +66,7 @@ html[data-theme='light'] .result__active {
   border: 1px solid rgba(138, 145, 158, 0.68);
   border-radius: 24px;
   height: 44px;
-  width: 200px;
+  width: 150px;
   cursor: pointer;
   padding: 0 16px;
   justify-content: space-between;

--- a/apps/base-docs/src/theme/kbar.module.css
+++ b/apps/base-docs/src/theme/kbar.module.css
@@ -66,10 +66,10 @@ html[data-theme='light'] .result__active {
   border: 1px solid rgba(138, 145, 158, 0.68);
   border-radius: 24px;
   height: 44px;
-  width: 150px;
   cursor: pointer;
   padding: 0 16px;
   justify-content: space-between;
+  flex-grow: 1;
 }
 
 .searchBar:hover {


### PR DESCRIPTION
**What changed? Why?**

Fix search box that is overflowing into logo on handheld devices in docs

**Notes to reviewers**

### Before

![2023-10-05 at 11 46 33@2x](https://github.com/base-org/web/assets/1130872/f3b3af57-97ca-496e-b73f-866e44e83095)

### After

![2023-10-05 at 11 48 10@2x](https://github.com/base-org/web/assets/1130872/219ffa49-d524-4b9c-b4fa-8e764fbcc99f)

**How has it been tested?**

Localhost