### PR TITLE
generate withdrawal proofs using latest l2 block

### DIFF
--- a/apps/bridge/pages/transactions.tsx
+++ b/apps/bridge/pages/transactions.tsx
@@ -13,7 +13,7 @@ import { mergeAndSortTransactionsLists } from 'apps/bridge/src/utils/array/merge
 import { useAddress } from 'apps/bridge/src/utils/hooks/useAddress';
 import { useChainEnv } from 'apps/bridge/src/utils/hooks/useChainEnv';
 import { useDisclosure } from 'apps/bridge/src/utils/hooks/useDisclosure';
-import { useLatestL2BlockNumber } from 'apps/bridge/src/utils/hooks/useLatestL2BlockNumber';
+import { useBlockNumberOfLatestL2OutputProposal } from 'apps/bridge/src/utils/hooks/useBlockNumberOfLatestL2OutputProposal';
 import Head from 'next/head';
 import Image from 'next/image';
 
@@ -24,7 +24,7 @@ type TransactionTableProps = {
 };
 
 const TransactionsTable = memo(function TransactionsTable({ transactions }: TransactionTableProps) {
-  const latestL2BlockNumber = useLatestL2BlockNumber();
+  const blockNumberOfLatestL2OutputProposal = useBlockNumberOfLatestL2OutputProposal();
 
   const [modalProveTxHash, setModalProveTxHash] = useState<`0x${string}` | undefined>(undefined);
   const [modalFinalizeTxHash, setModalFinalizeTxHash] = useState<`0x${string}` | undefined>(
@@ -64,7 +64,7 @@ const TransactionsTable = memo(function TransactionsTable({ transactions }: Tran
             <WithdrawalRow
               key={transaction.hash}
               transaction={transaction}
-              latestL2BlockNumber={latestL2BlockNumber}
+              blockNumberOfLatestL2OutputProposal={blockNumberOfLatestL2OutputProposal}
               onOpenProveWithdrawalModal={onOpenProveWithdrawalModal}
               onCloseProveWithdrawalModal={onCloseProveWithdrawalModal}
               onOpenFinalizeWithdrawalModal={onOpenFinalizeWithdrawalModal}

--- a/apps/bridge/src/components/Transactions/WithdrawalRow/ProveWithdrawalButton.tsx
+++ b/apps/bridge/src/components/Transactions/WithdrawalRow/ProveWithdrawalButton.tsx
@@ -3,6 +3,7 @@ import { useIsPermittedToBridge } from 'apps/bridge/src/utils/hooks/useIsPermitt
 import { usePrepareProveWithdrawal } from 'apps/bridge/src/utils/hooks/usePrepareProveWithdrawal';
 import getConfig from 'next/config';
 import { useContractWrite, useNetwork, useSwitchNetwork } from 'wagmi';
+import { BigNumber } from 'ethers';
 
 const { publicRuntimeConfig } = getConfig();
 const l1ChainID = parseInt(publicRuntimeConfig.l1ChainID);
@@ -14,6 +15,7 @@ type ProveWithdrawalButtonProps = {
   onCloseProveWithdrawalModal: () => void;
   setProveTxHash: Dispatch<SetStateAction<`0x${string}` | undefined>>;
   setModalProveTxHash: Dispatch<SetStateAction<`0x${string}` | undefined>>;
+  latestL2BlockNumber?: BigNumber;
 };
 
 export const ProveWithdrawalButton = memo(function ProveWithdrawalButton({
@@ -23,10 +25,15 @@ export const ProveWithdrawalButton = memo(function ProveWithdrawalButton({
   onCloseProveWithdrawalModal,
   setProveTxHash,
   setModalProveTxHash,
+  latestL2BlockNumber,
 }: ProveWithdrawalButtonProps) {
   const isPermittedToBridge = useIsPermittedToBridge();
 
-  const proveWithdrawalConfig = usePrepareProveWithdrawal(txHash, isERC20Withdrawal);
+  const proveWithdrawalConfig = usePrepareProveWithdrawal(
+    txHash,
+    isERC20Withdrawal,
+    latestL2BlockNumber,
+  );
   const { writeAsync: submitProof } = useContractWrite(proveWithdrawalConfig);
 
   const { chain } = useNetwork();

--- a/apps/bridge/src/components/Transactions/WithdrawalRow/ProveWithdrawalButton.tsx
+++ b/apps/bridge/src/components/Transactions/WithdrawalRow/ProveWithdrawalButton.tsx
@@ -15,7 +15,7 @@ type ProveWithdrawalButtonProps = {
   onCloseProveWithdrawalModal: () => void;
   setProveTxHash: Dispatch<SetStateAction<`0x${string}` | undefined>>;
   setModalProveTxHash: Dispatch<SetStateAction<`0x${string}` | undefined>>;
-  latestL2BlockNumber?: BigNumber;
+  blockNumberOfLatestL2OutputProposal?: BigNumber;
 };
 
 export const ProveWithdrawalButton = memo(function ProveWithdrawalButton({
@@ -25,14 +25,14 @@ export const ProveWithdrawalButton = memo(function ProveWithdrawalButton({
   onCloseProveWithdrawalModal,
   setProveTxHash,
   setModalProveTxHash,
-  latestL2BlockNumber,
+  blockNumberOfLatestL2OutputProposal,
 }: ProveWithdrawalButtonProps) {
   const isPermittedToBridge = useIsPermittedToBridge();
 
   const proveWithdrawalConfig = usePrepareProveWithdrawal(
     txHash,
     isERC20Withdrawal,
-    latestL2BlockNumber,
+    blockNumberOfLatestL2OutputProposal,
   );
   const { writeAsync: submitProof } = useContractWrite(proveWithdrawalConfig);
 

--- a/apps/bridge/src/components/Transactions/WithdrawalRow/WithdrawalRow.tsx
+++ b/apps/bridge/src/components/Transactions/WithdrawalRow/WithdrawalRow.tsx
@@ -53,21 +53,21 @@ export const WithdrawalRow = memo(function WithdrawalRow({
 
   const date = transaction.blockTimestamp
     ? new Date(Number(transaction.blockTimestamp) * 1000).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    })
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      })
     : undefined;
   const dateMonthDayOnly = transaction.blockTimestamp
     ? new Date(Number(transaction.blockTimestamp) * 1000).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-    })
+        month: 'short',
+        day: 'numeric',
+      })
     : undefined;
   const time = transaction.blockTimestamp
     ? new Date(Number(transaction.blockTimestamp) * 1000).toLocaleTimeString('en-US', {
-      timeStyle: 'short',
-    })
+        timeStyle: 'short',
+      })
     : undefined;
   const withdrawalAmount = utils.formatUnits(
     transaction.amount,
@@ -147,6 +147,7 @@ export const WithdrawalRow = memo(function WithdrawalRow({
         onCloseProveWithdrawalModal={onCloseProveWithdrawalModal}
         setProveTxHash={setProveTxHash}
         setModalProveTxHash={setModalProveTxHash}
+        latestL2BlockNumber={latestL2BlockNumber}
       />
     ),
     PROVE_TX_PENDING: pendingButton,

--- a/apps/bridge/src/components/Transactions/WithdrawalRow/WithdrawalRow.tsx
+++ b/apps/bridge/src/components/Transactions/WithdrawalRow/WithdrawalRow.tsx
@@ -21,7 +21,7 @@ import { ProveWithdrawalButton } from './ProveWithdrawalButton';
 
 type WithdrawalRowProps = {
   transaction: BridgeTransaction;
-  latestL2BlockNumber?: BigNumber;
+  blockNumberOfLatestL2OutputProposal?: BigNumber;
   onOpenProveWithdrawalModal: () => void;
   onCloseProveWithdrawalModal: () => void;
   onOpenFinalizeWithdrawalModal: () => void;
@@ -32,7 +32,7 @@ type WithdrawalRowProps = {
 
 export const WithdrawalRow = memo(function WithdrawalRow({
   transaction,
-  latestL2BlockNumber,
+  blockNumberOfLatestL2OutputProposal,
   onOpenProveWithdrawalModal,
   onCloseProveWithdrawalModal,
   onOpenFinalizeWithdrawalModal,
@@ -45,7 +45,7 @@ export const WithdrawalRow = memo(function WithdrawalRow({
   const [finalizeTxHash, setFinalizeTxHash] = useState<`0x${string}` | undefined>(undefined);
   const { status: withdrawalStatus, challengeWindowEndTime } = useWithdrawalStatus({
     initializeTxHash: transaction.hash,
-    latestL2BlockNumber,
+    blockNumberOfLatestL2OutputProposal,
     isERC20Withdrawal,
     proveTxHash,
     finalizeTxHash,
@@ -147,7 +147,7 @@ export const WithdrawalRow = memo(function WithdrawalRow({
         onCloseProveWithdrawalModal={onCloseProveWithdrawalModal}
         setProveTxHash={setProveTxHash}
         setModalProveTxHash={setModalProveTxHash}
-        latestL2BlockNumber={latestL2BlockNumber}
+        blockNumberOfLatestL2OutputProposal={blockNumberOfLatestL2OutputProposal}
       />
     ),
     PROVE_TX_PENDING: pendingButton,

--- a/apps/bridge/src/utils/hooks/useBlockNumberOfLatestL2OutputProposal.ts
+++ b/apps/bridge/src/utils/hooks/useBlockNumberOfLatestL2OutputProposal.ts
@@ -4,13 +4,13 @@ import { useContractRead } from 'wagmi';
 
 const { publicRuntimeConfig } = getConfig();
 
-export function useLatestL2BlockNumber() {
-  const { data: latestL2BlockNumber } = useContractRead({
+export function useBlockNumberOfLatestL2OutputProposal() {
+  const { data: blockNumberOfLatestL2OutputProposal } = useContractRead({
     address: publicRuntimeConfig.l2OutputOracleProxyAddress,
     abi: L2OutputOracle,
     functionName: 'latestBlockNumber',
     chainId: parseInt(publicRuntimeConfig.l1ChainID),
   });
 
-  return latestL2BlockNumber;
+  return blockNumberOfLatestL2OutputProposal;
 }

--- a/apps/bridge/src/utils/hooks/usePrepareProveWithdrawal.ts
+++ b/apps/bridge/src/utils/hooks/usePrepareProveWithdrawal.ts
@@ -21,7 +21,6 @@ export function usePrepareProveWithdrawal(
   isERC20Withdrawal = false,
   latestL2BlockNumber?: BigNumber,
 ) {
-  console.log({ latestL2BlockNumber });
   const [withdrawalForTx, setWithdrawalForTx] = useState<WithdrawalMessage | null>(null);
   const [proofForTx, setProofForTx] = useState<BedrockCrossChainMessageProof | null>(null);
 

--- a/apps/bridge/src/utils/hooks/usePrepareProveWithdrawal.ts
+++ b/apps/bridge/src/utils/hooks/usePrepareProveWithdrawal.ts
@@ -19,7 +19,7 @@ const { publicRuntimeConfig } = getConfig();
 export function usePrepareProveWithdrawal(
   withdrawalTx: `0x${string}`,
   isERC20Withdrawal = false,
-  latestL2BlockNumber?: BigNumber,
+  blockNumberOfLatestL2OutputProposal?: BigNumber,
 ) {
   const [withdrawalForTx, setWithdrawalForTx] = useState<WithdrawalMessage | null>(null);
   const [proofForTx, setProofForTx] = useState<BedrockCrossChainMessageProof | null>(null);
@@ -28,7 +28,9 @@ export function usePrepareProveWithdrawal(
     hash: withdrawalTx,
     chainId: parseInt(publicRuntimeConfig.l2ChainID),
   });
-  const withdrawalL2OutputIndex = useWithdrawalL2OutputIndex(latestL2BlockNumber?.toNumber());
+  const withdrawalL2OutputIndex = useWithdrawalL2OutputIndex(
+    blockNumberOfLatestL2OutputProposal?.toNumber(),
+  );
   const l2OutputProposal = useL2OutputProposal(withdrawalL2OutputIndex);
   const l2Provider = useProvider({ chainId: parseInt(publicRuntimeConfig.l2ChainID) });
 
@@ -64,7 +66,12 @@ export function usePrepareProveWithdrawal(
 
   useEffect(() => {
     void (async () => {
-      if (withdrawalReceipt && withdrawalL2OutputIndex && l2OutputProposal && latestL2BlockNumber) {
+      if (
+        withdrawalReceipt &&
+        withdrawalL2OutputIndex &&
+        l2OutputProposal &&
+        blockNumberOfLatestL2OutputProposal
+      ) {
         const withdrawalMessage = getWithdrawalMessage(withdrawalReceipt, isERC20Withdrawal);
 
         const messageBedrockOutput = {
@@ -92,7 +99,7 @@ export function usePrepareProveWithdrawal(
 
         const stateTrieProof = await makeStateTrieProof(
           l2Provider as providers.JsonRpcProvider,
-          latestL2BlockNumber.toNumber(),
+          blockNumberOfLatestL2OutputProposal.toNumber(),
           publicRuntimeConfig.l2L1MessagePasserAddress,
           messageSlot,
         );
@@ -123,7 +130,7 @@ export function usePrepareProveWithdrawal(
     l2OutputProposal,
     l2Provider,
     isERC20Withdrawal,
-    latestL2BlockNumber,
+    blockNumberOfLatestL2OutputProposal,
   ]);
 
   return config;

--- a/apps/bridge/src/utils/hooks/useWithdrawalStatus.ts
+++ b/apps/bridge/src/utils/hooks/useWithdrawalStatus.ts
@@ -15,14 +15,14 @@ const { publicRuntimeConfig } = getConfig();
 
 type UseWithdrawalStateProps = {
   initializeTxHash: `0x${string}`;
-  latestL2BlockNumber?: BigNumber;
+  blockNumberOfLatestL2OutputProposal?: BigNumber;
   isERC20Withdrawal: boolean;
   proveTxHash?: `0x${string}`;
   finalizeTxHash?: `0x${string}`;
 };
 export function useWithdrawalStatus({
   initializeTxHash,
-  latestL2BlockNumber,
+  blockNumberOfLatestL2OutputProposal,
   isERC20Withdrawal,
   proveTxHash,
   finalizeTxHash,
@@ -52,10 +52,10 @@ export function useWithdrawalStatus({
 
   const isWithdrawalReadyToProve = useMemo(
     () =>
-      latestL2BlockNumber && withdrawalReceipt?.blockNumber
-        ? latestL2BlockNumber.toNumber() >= withdrawalReceipt?.blockNumber
+      blockNumberOfLatestL2OutputProposal && withdrawalReceipt?.blockNumber
+        ? blockNumberOfLatestL2OutputProposal.toNumber() >= withdrawalReceipt?.blockNumber
         : false,
-    [latestL2BlockNumber, withdrawalReceipt],
+    [blockNumberOfLatestL2OutputProposal, withdrawalReceipt],
   );
 
   useEffect(() => {


### PR DESCRIPTION
**What changed? Why?**
generate withdrawal proofs using latest l2 block. this is valid and does not require archive nodes

**Notes to reviewers**


**How has it been tested?**
