### PR TITLE
update-node-providers-add-1rpc-base-support

### DIFF
--- a/apps/base-docs/docs/tools/node-providers.md
+++ b/apps/base-docs/docs/tools/node-providers.md
@@ -7,6 +7,16 @@ slug: /tools/node-providers
 
 ---
 
+## 1RPC
+
+[1RPC](https://1rpc.io/) is the first and only on-chain attested privacy preserving RPC that eradicate metadata exposure and leakage when interacting with blockchains. 1RPC offers free and [paid plans](https://www.1rpc.io/#pricing) with additional features and increased request limits. 
+
+#### Supported Networks
+
+- Base Mainnet
+
+---
+
 ## Alchemy
 
 [Alchemy](https://www.alchemy.com/base) is a popular API provider and developer platform. Its robust, free tier offers access to enhanced features like SDKs, [JSON-RPC APIs](https://docs.alchemy.com/reference/base-api-quickstart), and hosted mainnet and testnet nodes for Base.


### PR DESCRIPTION
**What changed? Why?**

Added 1RPC Base support to node provider list

**Notes to reviewers**

1RPC has relayed over 250 million+ requests on Base Mainnet since launch. 

https://docs.1rpc.io/overview/supported-networks

https://blog.ata.network/build-on-base-mainnet-with-1rpc-a8a1ee52d72a

**How has it been tested?**

Tested on local and dev environment. RPC is now live for public use - https://1rpc.io/base
