### PR TITLE
Update node-providers.md

### DIFF
--- a/apps/base-docs/docs/tools/node-providers.md
+++ b/apps/base-docs/docs/tools/node-providers.md
@@ -105,6 +105,17 @@ slug: /tools/node-providers
 
 ---
 
+## Nodies DLB
+
+[Nodies DLB](https://nodies.app) provides highly performant RPC Services for Base, as well as all other OP-stacked chains. They offer free public endpoints, Pay-As-You-Go, and enterprise pricing plans. 
+
+#### Supported Networks
+
+- Base Mainnet
+- Base Testnet (Available on request)
+
+---
+
 ## NOWNodes
 
 [NOWNodes](https://nownodes.io/nodes/basechain-base) is a Web3 development tool that provides shared and dedicated no rate-limit access to Base RPC full nodes.


### PR DESCRIPTION

**What changed? Why?**

added Nodies DLB as an RPC provider. We've been serving Base RPC's since August, 2023. 

**Notes to reviewers**

We spoke with Jesse Pollak who advised us to request this add.

**How has it been tested?**

Feel free to visit https://nodies.app to get a public endpoint for Base. For your convenience, here is a curl request we just did - 

```
curl https://lb.nodies.app/v1/cd20f05d16d24649b06f0e834a4d91c4 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_chainId","params": [],"id":1}'

{"jsonrpc":"2.0","id":1,"result":"0x2105"}
```
