### PR TITLE
Add Algolia indexer Github Action and config.

### DIFF
--- a/.github/workflows/update-algolia.yml
+++ b/.github/workflows/update-algolia.yml
@@ -1,0 +1,28 @@
+name: 'Update Algolia Search Results'
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  schedule:
+    # The CRON duration for the job: At 2:30 AM UTC MON-FRI
+    - cron: '30 2 * * 1-5'
+
+# permission can be added at job level or workflow level
+permissions:
+  id-token: write
+  contents: read # This is required for actions/checkout
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Get the content of algolia.json as config
+        id: algolia_config
+        run: echo "::set-output name=config::$(cat apps/base-docs/algolia.json | jq -r tostring)"
+      - name: Push indices to Algolia
+        uses: signcl/docsearch-scraper-action@master
+        env:
+          APPLICATION_ID: ${{ secrets.ALGOLIA_APPLICATION_ID }}
+          API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+          CONFIG: ${{ steps.algolia_config.outputs.config }}

--- a/apps/base-docs/algolia.json
+++ b/apps/base-docs/algolia.json
@@ -1,0 +1,22 @@
+{
+  "index_name": "prod",
+  "start_urls": [
+    "https://docs.base.org"
+  ],
+  "sitemap_urls": [
+    "https://docs.base.org/sitemap.xml"
+  ],
+  "selectors": {
+    "default": {
+      "lvl0": "article h1",
+      "lvl1": "article h2",
+      "lvl2": "article h3",
+      "lvl3": "article h4",
+      "lvl4": "article h5",
+      "lvl5": "article td:first-child",
+      "lvl6": "article not(td:first-child)",
+      "text": "article p, article li"
+    }
+  },
+  "strip_chars": " .,;:#"
+}

--- a/apps/base-docs/algolia.json
+++ b/apps/base-docs/algolia.json
@@ -14,7 +14,7 @@
       "lvl3": "article h4",
       "lvl4": "article h5",
       "lvl5": "article td:first-child",
-      "lvl6": "article not(td:first-child)",
+      "lvl6": "article td:not(td:first-child)",
       "text": "article p, article li"
     }
   },


### PR DESCRIPTION
**What changed? Why?**

We're preparing to replace the existing docs search with an Algolia-powered search. This Github Action (emulating [this cloud docs example](https://github.com/bisontrails/cloud-docs/blob/f92053379575629b461f9c84159db01b1b2e6e08/.github/workflows/update-algolia.yml)) will crawl docs.base.org following its sitemap and using the selectors defined in the algolia.json config file.

**Notes to reviewers**

N/A

**How has it been tested?**

We'll be testing the action once it's on master.