### PR TITLE
Remove external link icons from nav.

### DIFF
--- a/apps/web/src/components/Layout/Nav/DesktopNav.tsx
+++ b/apps/web/src/components/Layout/Nav/DesktopNav.tsx
@@ -27,13 +27,7 @@ function DropdownLink({ href, label, color, externalLink }: DropdownLinkProps) {
       target="_blank"
       rel="noreferrer noopener"
     >
-      <span className="mr-2">{label}</span>
-      <Icon
-        name="external-link"
-        width="14"
-        height="14"
-        color={color === 'black' ? 'white' : 'black'}
-      />
+      {label}
     </a>
   ) : (
     <Link
@@ -124,13 +118,7 @@ function DesktopNav({ color }: DesktopNavProps) {
           target="_blank"
           rel="noreferrer noopener"
         >
-          <span className="mr-2">Bridge</span>
-          <Icon
-            name="external-link"
-            width="14"
-            height="14"
-            color={color === 'black' ? 'black' : 'white'}
-          />
+          Bridge
         </a>
         <Dropdown label="Developers" color={color}>
           <DropdownLink

--- a/apps/web/src/components/Layout/Nav/MobileMenu.tsx
+++ b/apps/web/src/components/Layout/Nav/MobileMenu.tsx
@@ -23,8 +23,7 @@ function DropdownLink({ href, label, externalLink }: DropdownLinkProps) {
       target="_blank"
       rel="noreferrer noopener"
     >
-      <span className="mr-4">{label}</span>
-      <Icon name="external-link" width="16" height="16" color="white" />
+      {label}
     </a>
   ) : (
     <Link href={href} className="w-full pt-4 font-mono text-3xl text-white hover:underline">
@@ -181,8 +180,7 @@ function MobileMenu({ color }: MobileMenuProps) {
                   target="_blank"
                   rel="noreferrer noopener"
                 >
-                  <span className="mr-4">Bridge</span>
-                  <Icon name="external-link" width="16" height="16" color="white" />
+                  Bridge
                 </a>
                 <Dropdown
                   dropdownKey="developers"


### PR DESCRIPTION
**What changed? Why?**

Sangita designed the new nav and asked for the external link icons to be removed.

**Before**

<img width="1790" alt="Screenshot 2023-10-26 at 10 16 23 AM" src="https://github.com/base-org/web/assets/144269024/5054586c-4703-45e0-be28-da4156a66188">

**After**

<img width="1790" alt="Screenshot 2023-10-26 at 10 17 19 AM" src="https://github.com/base-org/web/assets/144269024/0edcb2af-5d53-453b-bc2b-e765f7709e4d">

**Notes to reviewers**

N/A

**How has it been tested?**

Removed the icons and checked results locally.