### PR TITLE
update Dockerfile to use public image and remove base bugsnag params

### DIFF
--- a/apps/bridge/Dockerfile
+++ b/apps/bridge/Dockerfile
@@ -1,19 +1,12 @@
-FROM 652969937640.dkr.ecr.us-east-1.amazonaws.com/containers/node:v16
+FROM node:18-alpine3.17
 
-RUN apt-get update && apt-get install -y zip
+RUN apk update && apk add zip
 
 ENV NODE_ENV=production
 
 WORKDIR /repo
 
 COPY . .
-
-ARG CODEFLOW_COMMIT_TAG
-ENV BUILD_ID ${CODEFLOW_COMMIT_TAG}
-ENV BUGSNAG_API_KEY 8f7b6e984693922aac5021ee82d0bb8f
-ENV BUGSNAG_SOURCEMAPS_URL https://sourcemaps.coinbase.com
-ENV BUGSNAG_NOTIFY_URL https://exceptions.coinbase.com
-ENV BUGSNAG_SESSIONS_URL https://sessions.coinbase.com
 
 # Install dependencies
 RUN yarn --immutable

--- a/apps/bridge/Dockerfile
+++ b/apps/bridge/Dockerfile
@@ -1,12 +1,19 @@
-FROM node:18-alpine3.17
+FROM 652969937640.dkr.ecr.us-east-1.amazonaws.com/containers/node:v16
 
-RUN apk update && apk add zip
+RUN apt-get update && apt-get install -y zip
 
 ENV NODE_ENV=production
 
 WORKDIR /repo
 
 COPY . .
+
+ARG CODEFLOW_COMMIT_TAG
+ENV BUILD_ID ${CODEFLOW_COMMIT_TAG}
+ENV BUGSNAG_API_KEY 8f7b6e984693922aac5021ee82d0bb8f
+ENV BUGSNAG_SOURCEMAPS_URL https://sourcemaps.coinbase.com
+ENV BUGSNAG_NOTIFY_URL https://exceptions.coinbase.com
+ENV BUGSNAG_SESSIONS_URL https://sessions.coinbase.com
 
 # Install dependencies
 RUN yarn --immutable

--- a/apps/bridge/Dockerfile.example
+++ b/apps/bridge/Dockerfile.example
@@ -1,0 +1,18 @@
+FROM node:18-alpine3.17
+
+RUN apk update && apk add zip
+
+ENV NODE_ENV=production
+
+WORKDIR /repo
+
+COPY . .
+
+# Install dependencies
+RUN yarn --immutable
+
+RUN yarn workspace @app/bridge next build
+RUN yarn workspaces focus --all --production
+
+EXPOSE 3000
+CMD ["yarn", "workspace", "@app/bridge", "start", "-p", "3000"]


### PR DESCRIPTION
**What changed? Why?**
* The `apps/bridge` dockerfile used an internal image, and included Base specific config params (ie a Bugsnag API key).
* This PR changes the base image to a public node docker image and removes the Base specific config params

**How has it been tested?**
* Tested by building with docker locally using ` docker build -f apps/bridge/Dockerfile .` from the root directory and running with docker afterwards
