### PR TITLE
improve type safety in chains.ts

### DIFF
--- a/apps/bridge/chains.ts
+++ b/apps/bridge/chains.ts
@@ -250,4 +250,4 @@ export default [
     },
     testnet: true,
   },
-] satisfies (Chain & ChainMetadata)[];
+] as const satisfies Readonly<(Chain & ChainMetadata)[]>;

--- a/apps/bridge/chains.ts
+++ b/apps/bridge/chains.ts
@@ -1,5 +1,15 @@
 import { Chain } from 'wagmi/chains';
 
+type ChainMetadata = {
+  summary: {
+    location: string;
+    svg: string;
+  };
+  svg: string;
+  description: string;
+  iconUrl?: string;
+};
+
 export default [
   {
     id: 1,
@@ -240,4 +250,4 @@ export default [
     },
     testnet: true,
   },
-] as unknown as Chain[];
+] satisfies (Chain & ChainMetadata)[];


### PR DESCRIPTION
**What changed? Why?**
* Using `satisfies Chain[]` lets typescript complain if the provided object doesn't match the expected type
* There are a couple custom props that are not part of `Chain`, so I added a `ChainMetadata` type describing those (otherwise `satisfies Chain[]` would cause typescript to complain about unknown props) 
* Using `as const` slightly improves the devex because each the string literals for each chain can be inferred by typescript and displayed by the IDE

**How has it been tested?**
* Running `dev` and `build` without issues