### PR TITLE
Configure additional backup public ETH RPCs

### DIFF
--- a/apps/bridge/next.config.js
+++ b/apps/bridge/next.config.js
@@ -51,6 +51,8 @@ const contentSecurityPolicy = {
   'connect-src': [
     "'self'",
     'https://ethereum.publicnode.com', // ETH rpc,
+    'https://cloudflare-eth.com', // ETH rpc,
+    'https://eth.llamarpc.com', // ETH rpc
     'https://mainnet.base.org', // Base rpc
     'https://rpc.ankr.com/eth_goerli', // Goerli rpc
     'https://goerli.base.org', // Base Goerli rpc

--- a/apps/bridge/src/wallet/connect.ts
+++ b/apps/bridge/src/wallet/connect.ts
@@ -10,14 +10,31 @@ import {
 } from '@rainbow-me/rainbowkit/wallets';
 import chainList from 'apps/bridge/chains';
 import getConfig from 'next/config';
-import { configureChains, createConfig } from 'wagmi';
+import { Chain, configureChains, createConfig } from 'wagmi';
 import { publicProvider } from 'wagmi/providers/public';
+import { jsonRpcProvider } from 'wagmi/providers/jsonRpc';
 
 const { publicRuntimeConfig } = getConfig();
 
+function configureBackupJsonRpcProvider<TChain extends Chain>(url: string) {
+  return jsonRpcProvider<TChain>({
+    rpc: (chain) => {
+      if (chain.id !== 1) return null;
+      return { http: url };
+    },
+  });
+}
+
 export function connectWallet(activeChainIds: number[]) {
   const customChains = chainList.filter((chain) => activeChainIds?.includes(chain.id));
-  const { chains, publicClient } = configureChains([...customChains], [publicProvider()]);
+  const { chains, publicClient } = configureChains(
+    [...customChains],
+    [
+      publicProvider(),
+      configureBackupJsonRpcProvider('https://cloudflare-eth.com'),
+      configureBackupJsonRpcProvider('https://eth.llamarpc.com'),
+    ],
+  );
   let autoConnect = false;
   if (typeof window !== 'undefined') {
     autoConnect = localStorage.getItem('autoconnect') === '1';


### PR DESCRIPTION
**What changed? Why?**

https://chainlist.org/chain/1

Adds `cloudflare-eth` and `llamarpc.com` as additional backup public nodes.


**Notes to reviewers**


**How has it been tested?**
