### PR TITLE
Remove Trailing Slashes from CCA Page Path Data

### DIFF
--- a/apps/base-docs/src/components/DocFeedback/index.tsx
+++ b/apps/base-docs/src/components/DocFeedback/index.tsx
@@ -8,12 +8,19 @@ const logDocFeedback = (isHelpful: boolean, reason?: string) => {
   if (window.ClientAnalytics) {
     const { logEvent, ActionType, ComponentType } = window.ClientAnalytics;
 
+    let path: string = window.location.pathname;
+
+    // Remove trailing slash
+    if (path !== '/' && path.endsWith('/')) {
+      path = path.slice(0, -1);
+    }
+
     logEvent('doc_feedback', {
       action: ActionType.click,
       componentType: ComponentType.button,
       doc_helpful: isHelpful,
       doc_feedback_reason: reason ?? null,
-      page_path: window.location.pathname,
+      page_path: path,
     });
   }
 };

--- a/apps/base-docs/src/utils/initCCA.ts
+++ b/apps/base-docs/src/utils/initCCA.ts
@@ -36,13 +36,20 @@ export function onRouteDidUpdate({ location, previousLocation }) {
   if (location.pathname !== previousLocation?.pathname && window.ClientAnalytics) {
     const { logEvent } = window.ClientAnalytics;
 
-    const referrerURL =
-      previousLocation?.pathname === null && document.referrer ? document.referrer : null;
+    let path: string = location.pathname;
+    let prevPath: string = previousLocation?.pathname;
+
+    // Remove trailing slashes
+    if (path !== '/' && path.endsWith('/')) {
+      path = path.slice(0, -1);
+    }
+    if (prevPath && prevPath !== '/' && prevPath.endsWith('/')) {
+      prevPath = prevPath.slice(0, -1);
+    }
 
     logEvent('pageview', {
-      page_path: location.pathname,
-      prev_page_path: previousLocation?.pathname,
-      referrer_url: referrerURL,
+      page_path: path,
+      prev_page_path: prevPath,
     });
   }
 }


### PR DESCRIPTION
**What changed? Why?**

To ensure more consistent data, trailing slashes are now removed from page paths before CCA logs `pageview` or `doc_feedback` events.

**Notes to reviewers**

Also removed referrerURL from `src/utils/initCCA.ts` because CCA collects that data without needing to add it as a custom attribute.

**How has it been tested?**

Triggered `pageview` and `doc_feedback` events and reviewed local debug logs to confirm the resulting data is correct.