### PR TITLE
Add Link to Edit Doc on GitHub

### DIFF
--- a/apps/base-docs/src/components/DocFeedback/index.tsx
+++ b/apps/base-docs/src/components/DocFeedback/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { useDoc } from '@docusaurus/theme-common/internal';
 import FeedbackModal from './FeedbackModal';
 import Icon from '../Icon';
 
@@ -78,6 +79,9 @@ export default function DocFeedback() {
     setVisible(false);
   }, []);
 
+  const { metadata } = useDoc();
+  const docFilePath = metadata.source.slice(6); // Remove @site/ from file path
+
   return (
     <div className={styles.docFeedbackContainer}>
       <p className={styles.feedbackPrompt}>Was this helpful?</p>
@@ -91,6 +95,14 @@ export default function DocFeedback() {
           {helpful === false && <Icon name="thumbs-down-filled" width="20" height="20" />}
         </button>
       </div>
+      <a
+        href={`https://github.com/base-org/web/blob/master/apps/base-docs/${docFilePath}?plain=1`}
+        target="_blank"
+        className={styles.editDocLink}
+      >
+        Edit this page on GitHub
+        <Icon name="external-link" width="11" height="11" />
+      </a>
       {helpful && (
         <FeedbackModal
           visible={visible}

--- a/apps/base-docs/src/components/DocFeedback/styles.module.css
+++ b/apps/base-docs/src/components/DocFeedback/styles.module.css
@@ -15,6 +15,20 @@
   gap: 0.5rem;
 }
 
+.editDocLink {
+  margin: 12px 0;
+  font-size: 0.9rem;
+  text-decoration: underline;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: currentColor;
+  fill: currentColor;
+}
+.editDocLink:hover {
+  color: currentColor;
+}
+
 /* Helpful/Not Helpful Buttons */
 .helpfulButton,
 .notHelpfulButton {

--- a/apps/base-docs/src/components/Icon/index.tsx
+++ b/apps/base-docs/src/components/Icon/index.tsx
@@ -90,5 +90,25 @@ export default function Icon({ name, color = 'white', width = '24', height = '24
       </svg>
     );
   }
+  if (name === 'external-link') {
+    return (
+      <svg
+        width={width}
+        height={height}
+        viewBox="0 0 24 24"
+        fill="current"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.4437 2.49805H19.8102L8.65655 14.0648L10.4562 15.8002L21.5021 4.34514V9.06774H24.0021V-0.00195312H14.4437V2.49805Z"
+          fill="current"
+        />
+        <path
+          d="M-0.00207138 5.86301V24.0024H19.1147V11.9666H16.6147V21.5024H2.49793V8.36301H12.3258V5.86301H-0.00207138Z"
+          fill="current"
+        />
+      </svg>
+    );
+  }
   return null;
 }


### PR DESCRIPTION
**What changed? Why?**

Added a link to 'edit doc on GitHub' at the bottom of the doc layout.

<img width="1788" alt="Screenshot 2023-11-13 at 10 01 13 AM" src="https://github.com/base-org/web/assets/144269024/dde407f8-5c15-4eec-a225-39557d71467e">
<img width="1788" alt="Screenshot 2023-11-13 at 10 01 20 AM" src="https://github.com/base-org/web/assets/144269024/006ae629-fdda-4ccd-b058-e7d6714f373a">

**How has it been tested?**

Opened base camp links and docs links from all directories of the nav to confirm they all lead to the expected file in GitHub.