### PR TITLE
Docs - Fix typo in Smart Contract Development Overview - Add missing y

### DIFF
--- a/apps/base-docs/base-camp/docs/introduction-to-solidity/introduction-to-solidity-overview.md
+++ b/apps/base-docs/base-camp/docs/introduction-to-solidity/introduction-to-solidity-overview.md
@@ -62,7 +62,7 @@ By the end of this module, you should be able to:
 - **Structs**
   - Construct a struct (user-defined type) that contains several different data types
   - Declare members of the struct to maximize storage efficiency
-  - Describe constraints related to assignment of structs depending on the types the contain
+  - Describe constraints related to assignment of structs depending on the types they contain
 - **Inheritance**
   - Write a smart contract that inherits from another contract
 - **Imports**


### PR DESCRIPTION
Closes #127

**What changed? Why?**
Added the "y" letter missing: "the contain" now says "they contain"

**Notes to reviewers**
This fixes the typo that can be seen at https://docs.base.org/base-camp/docs/introduction-to-solidity/introduction-to-solidity-overview/#objectives

**How has it been tested?**
Ran `yarn workspace @app/base-docs dev` locally and navigated to http://localhost:3000/base-camp/docs/introduction-to-solidity/introduction-to-solidity-overview#objectives to confirm the sentence is now fixed. Screenshot showing sentence now saying "Describe constraints related to assignment of structs depending on the types they contain":
![Screenshot 2023-11-14 at 3 49 17 PM](https://github.com/base-org/web/assets/561749/30713c7c-5f83-4035-9992-aa73f48da571)
