### PR TITLE
swap '_mint' for 'transfer'

### DIFF
--- a/apps/base-docs/base-camp/docs/erc-20-token/erc-20-token-sbs.md
+++ b/apps/base-docs/base-camp/docs/erc-20-token/erc-20-token-sbs.md
@@ -97,7 +97,7 @@ Try using the `transfer` function to move tokens around.
 
 What happens if you try to burn a token by sending it to the zero address? Give it a try!
 
-You'll get an error, because protecting from burning is built into the `_mint` function.
+You'll get an error, because protecting from burning is built into the `transfer` function.
 
 ```text
 transact to MyERC20Token.transfer pending ...

--- a/apps/base-docs/base-camp/docs/erc-20-token/erc-20-token-sbs.md
+++ b/apps/base-docs/base-camp/docs/erc-20-token/erc-20-token-sbs.md
@@ -97,7 +97,7 @@ Try using the `transfer` function to move tokens around.
 
 What happens if you try to burn a token by sending it to the zero address? Give it a try!
 
-You'll get an error, because protecting from burning is built into the `transfer` function.
+You'll get an error, because protecting from burning is built into the `_transfer` function.
 
 ```text
 transact to MyERC20Token.transfer pending ...


### PR DESCRIPTION
**What changed? Why?**
I´m changing the name of a function referred to in an explanation within the ERC20 token section.
'transfer' instead of '_mint' 


