### PR TITLE
Update of tools docs with addition of Arkham to block explorers and data indexers

### DIFF
--- a/apps/base-docs/docs/tools/block-explorers.md
+++ b/apps/base-docs/docs/tools/block-explorers.md
@@ -5,6 +5,14 @@ slug: /tools/block-explorers
 
 # Block Explorers
 
+## Arkham
+
+The Arkham [Platform](https://platform.arkhamintelligence.com/) supports Base. 
+
+Arkham is a crypto intelligence platform that systematically analyzes blockchain transactions, showing users the people and companies behind blockchain activity, with a suite of advanced tools for analyzing their activity.
+
+---
+
 ## Blockscout
 
 A Blockscout explorer is available for [Base](https://base.blockscout.com/).

--- a/apps/base-docs/docs/tools/data-indexers.md
+++ b/apps/base-docs/docs/tools/data-indexers.md
@@ -7,6 +7,19 @@ slug: /tools/data-indexers
 
 ---
 
+## Arkham
+
+[Arkham](https://platform.arkhamintelligence.com/) is a crypto intelligence platform that systematically analyzes blockchain transactions, showing users the people and companies behind blockchain activity, with a suite of advanced tools for analyzing their activity.
+
+References:
+
+- [Platform guide](https://www.arkhamintelligence.com/guide)
+- [Whitepaper](https://www.arkhamintelligence.com/whitepaper)
+- [Codex](https://codex.arkhamintelligence.com/)
+- [Demos](https://www.youtube.com/@arkhamintel)
+
+---
+
 ## Covalent
 
 [Covalent](https://www.covalenthq.com/?utm_source=base&utm_medium=partner-docs) is a hosted blockchain data solution providing access to historical and current on-chain data for [100+ supported blockchains](https://www.covalenthq.com/docs/networks/?utm_source=base&utm_medium=partner-docs), including [Base](https://www.covalenthq.com/docs/networks/base/?utm_source=base&utm_medium=partner-docs).


### PR DESCRIPTION
**What changed? Why?**
Arkham was added to the set of block explorers and data indexers that support Base under tools within the developer docs since it was missing from the respective lists.


**Notes to reviewers**
Was referred here and advised to submit a PR by the Base team.

**How has it been tested?**
Previewed the verbiage and links within my own fork. 
