### PR TITLE
add withdrawal L1 fee info modal

### DIFF
--- a/apps/bridge/src/components/Tooltip/Tooltip.tsx
+++ b/apps/bridge/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,16 @@
+import Image from 'next/image';
+
+type TooltipProps = {
+  children: string;
+};
+
+export function Tooltip({ children }: TooltipProps) {
+  return (
+    <div className="has-tooltip">
+      <span className="tooltip -mt-10 ml-6 rounded-lg bg-cds-background-gray-90 p-2 text-black shadow-lg">
+        {children}
+      </span>
+      <Image alt="tooltip" src="/icons/question-mark-circled.svg" width={16} height={16} />
+    </div>
+  );
+}

--- a/apps/bridge/src/components/Tooltip/Tooltip.tsx
+++ b/apps/bridge/src/components/Tooltip/Tooltip.tsx
@@ -7,7 +7,7 @@ type TooltipProps = {
 export function Tooltip({ children }: TooltipProps) {
   return (
     <div className="has-tooltip">
-      <span className="tooltip -mt-10 ml-6 rounded-lg bg-cds-background-gray-90 p-2 text-black shadow-lg">
+      <span className="tooltip -mt-10 ml-6 max-w-sm rounded-lg bg-cds-background-gray-90 p-2 text-black shadow-lg">
         {children}
       </span>
       <Image alt="tooltip" src="/icons/question-mark-circled.svg" width={16} height={16} />

--- a/apps/bridge/src/components/WithdrawContainer/TransactionSummaryModal.tsx
+++ b/apps/bridge/src/components/WithdrawContainer/TransactionSummaryModal.tsx
@@ -39,11 +39,11 @@ export function TransactionSummaryModal({
   const fiatAmount = usdFormatter(parseFloat(amount) * (assetConversionRate ?? 0));
 
   const proveTooltipText =
-    "To withdraw, you'll need to submit 2 additional transactions on L1. Submitting these transactions requires enough ETH to pay for the L1 gas fees.";
+    'In order to complete a withdrawal, you must submit two additional L1 transactions, each of which requires enough ETH to pay for L1 gas fees charged by the Ethereum network.';
   const finalizeTooltipText =
     selectedAsset.protocol === 'CCTP'
-      ? "To withdraw, you'll need to submit an additional transaction on L1. Submitting this transaction requires enough ETH to pay for the L1 gas fee."
-      : "To withdraw, you'll need to submit 2 additional transactions on L1. Submitting these transactions requires enough ETH to pay for the L1 gas fees.";
+      ? 'In order to complete a withdrawal, you must submit an additional L1 transaction which requires enough ETH to pay for L1 gas fees charged by the Ethereum network.'
+      : 'In order to complete a withdrawal, you must submit two additional L1 transactions, each of which requires enough ETH to pay for L1 gas fees charged by the Ethereum network.';
 
   const content = (
     <div className="flex w-96 flex-col space-y-4">
@@ -78,7 +78,7 @@ export function TransactionSummaryModal({
             <Tooltip>{proveTooltipText}</Tooltip>
           </div>
           <div className="flex flex-col items-end">
-            <span className="text-white">{feesInETH.prove.toFixed(4)} ETH</span>
+            <span className="text-white">{feesInETH.prove} ETH</span>
             <span>{feesInUSD.prove}</span>
           </div>
         </div>
@@ -89,8 +89,17 @@ export function TransactionSummaryModal({
           <Tooltip>{finalizeTooltipText}</Tooltip>
         </div>
         <div className="flex flex-col items-end">
-          <span className="text-white">{feesInETH.finalize.toFixed(4)} ETH</span>
+          <span className="text-white">{feesInETH.finalize} ETH</span>
           <span>{feesInUSD.finalize}</span>
+        </div>
+      </div>
+      <div className="flex w-full flex-row items-center justify-between pt-8">
+        <div className="flex flex-col items-start">
+          <span className="text-white">Fee total (est.)</span>
+        </div>
+        <div className="flex flex-col items-end">
+          <span className="text-white">{feesInETH.total} ETH</span>
+          <span>{feesInUSD.total}</span>
         </div>
       </div>
     </div>

--- a/apps/bridge/src/components/WithdrawContainer/TransactionSummaryModal.tsx
+++ b/apps/bridge/src/components/WithdrawContainer/TransactionSummaryModal.tsx
@@ -38,6 +38,13 @@ export function TransactionSummaryModal({
   const assetConversionRate = useConversionRate({ asset: selectedAsset.apiId });
   const fiatAmount = usdFormatter(parseFloat(amount) * (assetConversionRate ?? 0));
 
+  const proveTooltipText =
+    "To withdraw, you'll need to submit 2 additional transactions on L1. Submitting these transactions requires enough ETH to pay for the L1 gas fees.";
+  const finalizeTooltipText =
+    selectedAsset.protocol === 'CCTP'
+      ? "To withdraw, you'll need to submit an additional transaction on L1. Submitting this transaction requires enough ETH to pay for the L1 gas fee."
+      : "To withdraw, you'll need to submit 2 additional transactions on L1. Submitting these transactions requires enough ETH to pay for the L1 gas fees.";
+
   const content = (
     <div className="flex w-96 flex-col space-y-4">
       <div className="flex w-full flex-row items-center justify-between pt-8">
@@ -68,10 +75,7 @@ export function TransactionSummaryModal({
         <div className="flex w-full flex-row items-center justify-between pt-8">
           <div className="flex flex-row items-center space-x-2">
             <span className="text-white">Verification fee (est.)</span>
-            <Tooltip>
-              To withdraw, you&apos;ll need to submit 2 additional transactions on L1. Submitting
-              these requires enough ETH to pay for the L1 gas fees.
-            </Tooltip>
+            <Tooltip>{proveTooltipText}</Tooltip>
           </div>
           <div className="flex flex-col items-end">
             <span className="text-white">{feesInETH.prove.toFixed(4)} ETH</span>
@@ -82,10 +86,7 @@ export function TransactionSummaryModal({
       <div className="flex w-full flex-row items-center justify-between pt-8">
         <div className="flex flex-row items-center space-x-2">
           <span className="text-white">Completion fee (est.)</span>
-          <Tooltip>
-            To withdraw, you&apos;ll need to submit 2 additional transactions on L1. Submitting
-            these requires enough ETH to pay for the L1 gas fees.
-          </Tooltip>
+          <Tooltip>{finalizeTooltipText}</Tooltip>
         </div>
         <div className="flex flex-col items-end">
           <span className="text-white">{feesInETH.finalize.toFixed(4)} ETH</span>

--- a/apps/bridge/src/components/WithdrawContainer/TransactionSummaryModal.tsx
+++ b/apps/bridge/src/components/WithdrawContainer/TransactionSummaryModal.tsx
@@ -1,0 +1,122 @@
+import { Modal } from 'apps/bridge/src/components/Modal/Modal';
+import { Asset, BridgeProtocol } from 'apps/bridge/src/types/Asset';
+import { usdFormatter } from 'apps/bridge/src/utils/formatter/balance';
+import { useConversionRate } from 'apps/bridge/src/utils/hooks/useConversionRate';
+import { useGetWithdrawalFeeEstimates } from 'apps/bridge/src/utils/hooks/useGetWithdrawalFeeEstimates';
+import { Tooltip } from 'apps/bridge/src/components/Tooltip/Tooltip';
+
+const chainIdToNetwork: Record<number, string> = {
+  1: 'Ethereum Mainnet',
+  5: 'Goerli Testnet',
+  11155111: 'Sepolia Testnet',
+};
+
+const chainIdToTransferTime: Record<number, string> = {
+  1: 'About 7 days',
+  5: 'A few minutes',
+  11155111: 'A few minutes',
+};
+
+type TransactionSummaryModalProps = {
+  selectedAsset: Asset;
+  amount: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onProceed: () => void;
+  protocol: BridgeProtocol;
+};
+
+export function TransactionSummaryModal({
+  selectedAsset,
+  amount,
+  isOpen,
+  onClose,
+  onProceed,
+  protocol,
+}: TransactionSummaryModalProps) {
+  const { eth: feesInETH, usd: feesInUSD } = useGetWithdrawalFeeEstimates({ selectedAsset });
+  const assetConversionRate = useConversionRate({ asset: selectedAsset.apiId });
+  const fiatAmount = usdFormatter(parseFloat(amount) * (assetConversionRate ?? 0));
+
+  const content = (
+    <div className="flex w-96 flex-col space-y-4">
+      <div className="flex w-full flex-row items-center justify-between pt-8">
+        <div className="flex flex-col items-start">
+          <span className="text-white">Receive {selectedAsset.L1symbol}</span>
+          <span>On {chainIdToNetwork[selectedAsset.L1chainId]}</span>
+        </div>
+        <div className="flex flex-col items-end">
+          <span className="text-white">
+            {amount} {selectedAsset.L1symbol}
+          </span>
+          <span>{fiatAmount}</span>
+        </div>
+      </div>
+      <div className="flex w-full flex-row items-center justify-between pt-8">
+        <div className="flex flex-col items-start">
+          <span className="text-white">Transfer time</span>
+        </div>
+        <div className="flex flex-col items-end">
+          <span className="text-white">
+            {selectedAsset.protocol === 'CCTP'
+              ? 'A few minutes'
+              : chainIdToTransferTime[selectedAsset.L1chainId]}
+          </span>
+        </div>
+      </div>
+      {protocol === 'OP' && (
+        <div className="flex w-full flex-row items-center justify-between pt-8">
+          <div className="flex flex-row items-center space-x-2">
+            <span className="text-white">Verification fee (est.)</span>
+            <Tooltip>
+              To withdraw, you&apos;ll need to submit 2 additional transactions on L1. Submitting
+              these requires enough ETH to pay for the L1 gas fees.
+            </Tooltip>
+          </div>
+          <div className="flex flex-col items-end">
+            <span className="text-white">{feesInETH.prove.toFixed(4)} ETH</span>
+            <span>{feesInUSD.prove}</span>
+          </div>
+        </div>
+      )}
+      <div className="flex w-full flex-row items-center justify-between pt-8">
+        <div className="flex flex-row items-center space-x-2">
+          <span className="text-white">Completion fee (est.)</span>
+          <Tooltip>
+            To withdraw, you&apos;ll need to submit 2 additional transactions on L1. Submitting
+            these requires enough ETH to pay for the L1 gas fees.
+          </Tooltip>
+        </div>
+        <div className="flex flex-col items-end">
+          <span className="text-white">{feesInETH.finalize.toFixed(4)} ETH</span>
+          <span>{feesInUSD.finalize}</span>
+        </div>
+      </div>
+    </div>
+  );
+
+  const footer = (
+    <div className="flex flex-row justify-center space-x-12">
+      <button
+        className="w-48 border border-white bg-black py-2 text-lg text-white"
+        type="button"
+        onClick={onClose}
+      >
+        Cancel
+      </button>
+      <button className="w-48 bg-white py-2 text-lg text-black" type="button" onClick={onProceed}>
+        Continue
+      </button>
+    </div>
+  );
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Transaction Summary"
+      content={content}
+      footer={footer}
+    />
+  );
+}

--- a/apps/bridge/src/utils/hooks/useConversionRate.ts
+++ b/apps/bridge/src/utils/hooks/useConversionRate.ts
@@ -3,16 +3,20 @@ import { request } from 'apps/bridge/src/http/fetchJSON';
 
 type UseConversionRateParams = {
   asset: string;
+  refetch?: boolean;
 };
 
 type CoinGeckoResponseType = Record<
-string,
-{
-  usd: number;
-}
+  string,
+  {
+    usd: number;
+  }
 >;
 
-export function useConversionRate({ asset }: UseConversionRateParams): number | undefined {
+export function useConversionRate({
+  asset,
+  refetch = true,
+}: UseConversionRateParams): number | undefined {
   const { data } = useQuery(
     asset,
     async () => {
@@ -25,8 +29,11 @@ export function useConversionRate({ asset }: UseConversionRateParams): number | 
     },
     {
       suspense: false,
-      staleTime: 15000,
-      refetchInterval: 1000 * 30,
+      staleTime: refetch ? 15000 : Infinity,
+      refetchInterval: refetch ? 1000 * 30 : false,
+      refetchOnMount: refetch,
+      refetchOnReconnect: refetch,
+      refetchIntervalInBackground: refetch,
     },
   );
 

--- a/apps/bridge/src/utils/hooks/useGetWithdrawalFeeEstimates.ts
+++ b/apps/bridge/src/utils/hooks/useGetWithdrawalFeeEstimates.ts
@@ -6,6 +6,10 @@ import { useFeeData } from 'wagmi';
 
 // prove: ~300_000
 // finalize: ~100_000 for ETH, ~215_000 for ERC20, ~170_000 for CCTP
+const OP_PROVE_GAS = 300000n;
+const OP_FINALIZE_ETH_GAS = 100000n;
+const OP_FINALIZE_ERC20_GAS = 215000n;
+const CCTP_FINALIZE_GAS = 170000n;
 
 type UseGetWithdrawalFeeEstimatesProps = {
   selectedAsset: Asset;
@@ -15,28 +19,30 @@ export function useGetWithdrawalFeeEstimates({ selectedAsset }: UseGetWithdrawal
   const { data: feeData } = useFeeData({ chainId: selectedAsset.L1chainId });
   const ethConversionRate = useConversionRate({ asset: 'ethereum', refetch: false });
 
-  const proveGas = selectedAsset.protocol === 'CCTP' ? 0n : 300000n;
+  const proveGas = selectedAsset.protocol === 'CCTP' ? 0n : OP_PROVE_GAS;
   let finalizeGas;
   if (selectedAsset.protocol === 'CCTP') {
-    finalizeGas = 170000n;
+    finalizeGas = CCTP_FINALIZE_GAS;
   } else {
-    finalizeGas = selectedAsset.L2symbol === 'ETH' ? 100000n : 215000n;
+    finalizeGas = selectedAsset.L2symbol === 'ETH' ? OP_FINALIZE_ETH_GAS : OP_FINALIZE_ERC20_GAS;
   }
 
-  const proveEstimate = parseFloat(formatEther((feeData?.maxFeePerGas ?? 0n) * proveGas));
-  const finalizeEstimate = parseFloat(formatEther((feeData?.maxFeePerGas ?? 0n) * finalizeGas));
+  const proveEstimate = parseFloat(formatEther((feeData?.gasPrice ?? 0n) * proveGas));
+  const finalizeEstimate = parseFloat(formatEther((feeData?.gasPrice ?? 0n) * finalizeGas));
 
-  const proveEstimateFormatted = usdFormatter(proveEstimate * (ethConversionRate ?? 0));
-  const finalizeEstimateFormatted = usdFormatter(finalizeEstimate * (ethConversionRate ?? 0));
+  const proveEstimateFormatted = proveEstimate * (ethConversionRate ?? 0);
+  const finalizeEstimateFormatted = finalizeEstimate * (ethConversionRate ?? 0);
 
   const fees = {
     eth: {
-      prove: proveEstimate,
-      finalize: finalizeEstimate,
+      prove: proveEstimate.toFixed(4),
+      finalize: finalizeEstimate.toFixed(4),
+      total: (proveEstimate + finalizeEstimate).toFixed(4),
     },
     usd: {
-      prove: proveEstimateFormatted,
-      finalize: finalizeEstimateFormatted,
+      prove: usdFormatter(proveEstimateFormatted),
+      finalize: usdFormatter(finalizeEstimateFormatted),
+      total: usdFormatter(proveEstimateFormatted + finalizeEstimateFormatted),
     },
   };
 

--- a/apps/bridge/src/utils/hooks/useGetWithdrawalFeeEstimates.ts
+++ b/apps/bridge/src/utils/hooks/useGetWithdrawalFeeEstimates.ts
@@ -1,0 +1,44 @@
+import { Asset } from 'apps/bridge/src/types/Asset';
+import { usdFormatter } from 'apps/bridge/src/utils/formatter/balance';
+import { useConversionRate } from 'apps/bridge/src/utils/hooks/useConversionRate';
+import { formatEther } from 'viem';
+import { useFeeData } from 'wagmi';
+
+// prove: ~300_000
+// finalize: ~100_000 for ETH, ~215_000 for ERC20, ~170_000 for CCTP
+
+type UseGetWithdrawalFeeEstimatesProps = {
+  selectedAsset: Asset;
+};
+
+export function useGetWithdrawalFeeEstimates({ selectedAsset }: UseGetWithdrawalFeeEstimatesProps) {
+  const { data: feeData } = useFeeData({ chainId: selectedAsset.L1chainId });
+  const ethConversionRate = useConversionRate({ asset: 'ethereum', refetch: false });
+
+  const proveGas = selectedAsset.protocol === 'CCTP' ? 0n : 300000n;
+  let finalizeGas;
+  if (selectedAsset.protocol === 'CCTP') {
+    finalizeGas = 170000n;
+  } else {
+    finalizeGas = selectedAsset.L2symbol === 'ETH' ? 100000n : 215000n;
+  }
+
+  const proveEstimate = parseFloat(formatEther((feeData?.maxFeePerGas ?? 0n) * proveGas));
+  const finalizeEstimate = parseFloat(formatEther((feeData?.maxFeePerGas ?? 0n) * finalizeGas));
+
+  const proveEstimateFormatted = usdFormatter(proveEstimate * (ethConversionRate ?? 0));
+  const finalizeEstimateFormatted = usdFormatter(finalizeEstimate * (ethConversionRate ?? 0));
+
+  const fees = {
+    eth: {
+      prove: proveEstimate,
+      finalize: finalizeEstimate,
+    },
+    usd: {
+      prove: proveEstimateFormatted,
+      finalize: finalizeEstimateFormatted,
+    },
+  };
+
+  return fees;
+}


### PR DESCRIPTION
**What changed? Why?**
- added modal that shows before initiating withdrawals with L1 gas estimates for proving & finalizing withdrawal transactions

**Notes to reviewers**


**How has it been tested?**
![Screenshot 2023-11-18 at 4 53 59 PM](https://github.com/base-org/web/assets/36800180/d8d021fe-55ab-4229-8826-1d4d337401b2)
![Screenshot 2023-11-18 at 4 53 34 PM](https://github.com/base-org/web/assets/36800180/e2319ede-b293-4750-a570-715c0ab7039f)
