### PR TITLE
Fix typo in image url for drawtech

### DIFF
--- a/apps/web/src/data/ecosystem.json
+++ b/apps/web/src/data/ecosystem.json
@@ -141,7 +141,7 @@
     "tags": [
       "gaming"
     ],
-    "imageUrl": "/images/partners/drawtech.png"
+    "imageUrl": "/images/partners/drawtechlogo.png"
   },
   {
     "name": "TokenTerminal",


### PR DESCRIPTION
**What changed? Why?**
The URL for the drawtech has a typo. The full logo is [drawtechlogo.png](https://github.com/base-org/web/blob/master/apps/web/public/images/partners/drawtechlogo.png)