### PR TITLE
Fix error triage instructions to specify >= 1000 for modifier problem

### DIFF
--- a/apps/base-docs/base-camp/docs/error-triage/error-triage-exercise-source.sol
+++ b/apps/base-docs/base-camp/docs/error-triage/error-triage-exercise-source.sol
@@ -23,7 +23,7 @@ contract ErrorTriageExercise {
     }
 
     /**
-     * Changes the _base by the value of _modifier.  Base is always > 1000.  Modifiers can be
+     * Changes the _base by the value of _modifier.  Base is always >= 1000.  Modifiers can be
      * between positive and negative 100;
      */
     function applyModifier(

--- a/apps/base-docs/base-camp/docs/error-triage/error-triage-exercise.md
+++ b/apps/base-docs/base-camp/docs/error-triage/error-triage-exercise.md
@@ -34,7 +34,7 @@ contract ErrorTriageExercise {
     }
 
     /**
-     * Changes the _base by the value of _modifier.  Base is always > 1000.  Modifiers can be
+     * Changes the _base by the value of _modifier.  Base is always >= 1000.  Modifiers can be
      * between positive and negative 100;
      */
     function applyModifier(


### PR DESCRIPTION
**What changed? Why?**
Error triage exercise has a problem that specifies an input of >1000 but tests an input of 1000.

**Notes to reviewers**


**How has it been tested?**
