### PR TITLE
add Envio to Data Indexers section

### DIFF
--- a/apps/base-docs/docs/tools/data-indexers.md
+++ b/apps/base-docs/docs/tools/data-indexers.md
@@ -38,6 +38,24 @@ To get started, [sign up](https://www.covalenthq.com/platform/?utm_source=base&u
 
 ---
 
+## Envio
+
+[Envio](https://envio.dev) is a full-featured data indexing solution that provides application developers with a seamless and efficient way to index and aggregate real-time and historical blockchain data for any EVM. The indexed data is easily accessible through custom GraphQL queries, providing developers with the flexibility and power to retrieve specific information. 
+  
+Envio [HyperSync](https://docs.envio.dev/docs/hypersync) is an indexed layer of the Base blockchain for the hyper-speed syncing of historical data (JSON-RPC bypass). What would usually take hours to sync ~100,000 events can now be done in the order of less than a minute.
+
+Designed to optimize the user experience, Envio offers automatic code generation, flexible language support, multi-chain data aggregation, and a reliable cost-effective hosted service.
+
+To get started, visit the [documentation](https://docs.envio.dev/docs/overview) or follow the [quickstart](https://docs.envio.dev/docs/quickstart) guide.
+
+
+#### Supported Networks
+
+- Base Mainnet
+- Base Goerli (Testnet)
+
+---
+
 ## SubQuery
 
 [SubQuery](https://subquery.network/) is a data indexer that provides developers with fast, reliable, decentralized, and customized APIs for accessing rich indexed data from over 80+ ecosystems (including Base) within their projects.


### PR DESCRIPTION
What changed? Why?
Added Envio to the data indexers section under tools within the developer docs that support Base. 

Notes to reviewers
Envio was listed on Base Ecosystem as part of a new partnership.

How has it been tested?
Previewed page and links within my own fork
