### PR TITLE
Add initial Base Sepolia node providers; Fix URL typo

### DIFF
--- a/apps/base-docs/docs/tools/node-providers.md
+++ b/apps/base-docs/docs/tools/node-providers.md
@@ -74,7 +74,7 @@ slug: /tools/node-providers
 
 ## Chainstack
 
-[Chainstack](https://getblock.io/nodes/base/) allows developers to run high-performing Base nodes and APIs in minutes. They offer elastic Base RPC nodes that provide personal, geographically diverse, and protected API endpoints, as well as archive nodes to query the entire history of the Base Mainnet and Goerli Testnet. Get started with their [free and paid pricing plans](https://chainstack.com/pricing/).
+[Chainstack](https://chainstack.com/build-better-with-base/) allows developers to run high-performing Base nodes and APIs in minutes. They offer elastic Base RPC nodes that provide personal, geographically diverse, and protected API endpoints, as well as archive nodes to query the entire history of the Base Mainnet and Goerli Testnet. Get started with their [free and paid pricing plans](https://chainstack.com/pricing/).
 
 #### Supported Networks
 
@@ -102,6 +102,7 @@ slug: /tools/node-providers
 
 - Base Mainnet
 - Base Goerli (Testnet)
+- Base Sepolia (Testnet)
 
 ---
 
@@ -144,6 +145,7 @@ slug: /tools/node-providers
 
 - Base Mainnet
 - Base Goerli (Testnet)
+- Base Sepolia (Testnet)
 
 ---
 


### PR DESCRIPTION
Resolves https://github.com/base-org/web/issues/155

**What changed? Why?**
- What:
  - Updated 2 node providers (GetBlock, QuickNode) to reflect that they now support Base Sepolia
  - Fixed URL typo, where Chainstack was incorrectly linking to GetBlock
- Why:
  - Hopefully helpful to builders to see initial support for Base Sepolia testnet

**Notes to reviewers**
N/A

**How has it been tested?**
- Manual review test, checking the updated markdown, low risk