### PR TITLE
welcome: Add more concise description to Base Camp welcome page

### DIFF
--- a/apps/base-docs/base-camp/docs/welcome.md
+++ b/apps/base-docs/base-camp/docs/welcome.md
@@ -1,6 +1,6 @@
 ---
 title: Welcome to Base Camp
-description: Welcome to Base Camp!
+description: Base Camp is a comprehensive, free guide to learning smart contract development.
 hide_table_of_contents: false
 ---
 


### PR DESCRIPTION
**What changed? Why?**

Add a more concise description to the Base Camp welcome page so that it doesn't appear somewhat duplicated when the link gets shared and the rich snippet appears:

![2023-11-22 at 14 48 56@2x](https://github.com/base-org/web/assets/1130872/8cef6900-b70a-4c12-8088-568a67b43662)

Provides additional context about what Base Camp is.

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost