### PR TITLE
Includes Particle Network within onboarding.md

### DIFF
--- a/apps/base-docs/docs/tools/onboarding.md
+++ b/apps/base-docs/docs/tools/onboarding.md
@@ -14,6 +14,7 @@ keywords:
     onboarding,
     Privy,
     Dynamic,
+    Particle Network,
     user wallet,
     accounts,
     user account,
@@ -33,5 +34,11 @@ keywords:
 ## Privy
 
 [Privy](https://www.privy.dev/) is a library designed for progressive user onboarding and authentication. It enables users to connect to your app using traditional methods such as email addresses, phone numbers, or social profiles, as well as through web3 methods like crypto wallets. Additionally, Privy supports embedded wallets, eliminating the need for users to have a self-custodial wallet prior to exploring your app. Privy is compatible with most EVM chains, including Base.
+
+---
+
+## Particle Network
+
+[Particle Network](https://particle.network/) is the intent-centric, modular access layer of Web3. With Particle's Smart Wallet-as-a-Service, developers can curate an seamless user experience through modular and customizable EOA/AA embedded wallet components. Using MPC-TSS for key management, Particle can streamline user onboarding via familiar web2 accounts - such as Google accounts, email addresses, and phone numbers. Particle Network's Smart Wallet-as-a-Service is compatible with most EVM chains, including Base.
 
 ---


### PR DESCRIPTION
This PR adds **Particle Network** (Wallet-as-a-Service provider) to onboarding.md alongside Dynamic and Privy. Particle has full support for Base, both on the EOA (traditional account) and AA (smart account) side. The "Particle Network" keyword has also been added to this page.