### PR TITLE
Update mappings-sbs and basic-types

### DIFF
--- a/apps/base-docs/base-camp/docs/contracts-and-basic-functions/basic-types.md
+++ b/apps/base-docs/base-camp/docs/contracts-and-basic-functions/basic-types.md
@@ -160,7 +160,7 @@ enum Flavors { Vanilla, Chocolate, Strawberry, Coffee }
 Flavors chosenFlavor = Flavors.Coffee;
 ```
 
-Enums can be explicitly cast two and from `uint`, but not implicitly. They are limited to 256 members.
+Enums can be explicitly cast to and from `uint`, but not implicitly. They are limited to 256 members.
 
 ---
 

--- a/apps/base-docs/base-camp/docs/mappings/mappings-sbs.md
+++ b/apps/base-docs/base-camp/docs/mappings/mappings-sbs.md
@@ -74,7 +74,7 @@ Update the declaration of `favoriteNumbers` and deploy to test again.
 
 ### Utilizing msg.sender
 
-Another issue with this contract is that `public` means anyone and everyone with a wallet and funds to pay gas fees. As a result, anyone could go in after you and change your favorite number from lucky number **13** to anything, even **7**!
+Another issue with this contract is that a `public` function can be called by anyone and everyone with a wallet and funds to pay gas fees. As a result, anyone could go in after you and change your favorite number from lucky number **13** to anything, even **7**!
 
 That won't do at all!
 


### PR DESCRIPTION
**What changed? Why?**

_mappings-sbs.md_
Update sentence for clarity from "Another issue with this contract is that public means anyone and everyone with a wallet and funds to pay gas fees." to "Another issue with this contract is that a public function can be called by anyone and everyone with a wallet and funds to pay gas fees." 
 
_basic-types.md_
Change from 'two and from' to 'to and from'.
