### PR TITLE
update error-triage, simple-storage & new-keyword

### DIFF
--- a/apps/base-docs/base-camp/docs/error-triage/error-triage.md
+++ b/apps/base-docs/base-camp/docs/error-triage/error-triage.md
@@ -193,7 +193,7 @@ CompilerError: Stack too deep. Try compiling with --via-ir (cli) or the equivale
    |                 ^^^^^^
 ```
 
-Resolve this error buy breaking up large functions and separating operations into different levels of scope.
+Resolve this error by breaking up large functions and separating operations into different levels of scope.
 
 ```solidity
 function stackDepthLimitFixed() public pure returns (uint) {

--- a/apps/base-docs/base-camp/docs/new-keyword/new-keyword-exercise.md
+++ b/apps/base-docs/base-camp/docs/new-keyword/new-keyword-exercise.md
@@ -36,7 +36,7 @@ It should include the following functions:
 
 ### Add Contact
 
-The `addContact` function should be usable only by the owner of the contract. It should take in the necessary arguments to add a given contact's information to `contacts`
+The `addContact` function should be usable only by the owner of the contract. It should take in the necessary arguments to add a given contact's information to `contacts`.
 
 ### Delete Contact
 

--- a/apps/base-docs/base-camp/docs/new-keyword/new-keyword-exercise.md
+++ b/apps/base-docs/base-camp/docs/new-keyword/new-keyword-exercise.md
@@ -58,7 +58,7 @@ For bonus points (that only you will know about), explain why we can't just use 
 
 The `getAllContacts` function returns an array with all of the user's current, non-deleted contacts.
 
-::: caution
+:::caution
 
 You shouldn't use `onlyOwner` for the two _get_ functions. Doing so won't prevent a third party from accessing the information, because all information on the blockchain is public. However, it may give the mistaken impression that information is hidden, which could lead to a security incident.
 

--- a/apps/base-docs/base-camp/docs/new-keyword/new-keyword-sbs.md
+++ b/apps/base-docs/base-camp/docs/new-keyword/new-keyword-sbs.md
@@ -81,7 +81,7 @@ Switch the _CONTRACT_ to be deployed to `Complimenter`, then paste the address y
 
 ![At address button](../../assets/images/new-keyword/at-address.png)
 
-Click _At Address_ and the instance of `Complimenter` should appear below `ComplimenterFactor`. Test to confirm it works, then try deploying more instances with the factory.
+Click _At Address_ and the instance of `Complimenter` should appear below `ComplimenterFactory`. Test to confirm it works, then try deploying more instances with the factory.
 
 ![Deployed](../../assets/images/new-keyword/deployed.png)
 

--- a/apps/base-docs/base-camp/docs/storage/simple-storage-sbs.md
+++ b/apps/base-docs/base-camp/docs/storage/simple-storage-sbs.md
@@ -186,3 +186,4 @@ In this lesson, you've explored how to persistently store values on the blockcha
 ---
 
 [packed]: https://docs.soliditylang.org/en/v0.8.17/internals/layout_in_storage.html
+[layout]: https://docs.soliditylang.org/en/v0.8.17/internals/layout_in_storage.html


### PR DESCRIPTION
**What changed? Why?**
typos, caution ui and added missing link to docs.

Caution Section
| Before | After |
| ------------- | ------------- |
| <img width="400" alt="Screenshot 2023-12-05 at 11 39 54 AM" src="https://github.com/base-org/web/assets/60794961/88214c4b-f976-40d0-af1e-09fde0bc4a1f">  | <img width="400" alt="Screenshot 2023-12-05 at 11 42 01 AM" src="https://github.com/base-org/web/assets/60794961/9f80e5d6-802c-45df-8234-59ca6f719b48"> |

