### PR TITLE
Move codeflow alerts to seperate channel

### DIFF
--- a/.codeflow.yml
+++ b/.codeflow.yml
@@ -22,3 +22,7 @@ build:
     - BaldurECR:
         name: sepolia-bridge
         path: ./apps/bridge/Dockerfile
+
+operate:
+  slack_channels:
+    - "#base-codeflow-notifications"


### PR DESCRIPTION
**What changed? Why?**
Move codeflow notifications to a separate channel
