### PR TITLE
Update snapshot URLs

### DIFF
--- a/apps/base-docs/docs/building-with-base/guides/run-a-base-node.md
+++ b/apps/base-docs/docs/building-with-base/guides/run-a-base-node.md
@@ -94,12 +94,12 @@ Syncing your node may take **days** and will consume a vast amount of your reque
 
 ### Snapshots
 
-If you're a prospective or current Base Node operator and would like to restore from a snapshot to save time on the initial sync, it's possible to always get the latest available snapshot of the Base chain on mainnet and/or testnet by using the following CLI commands. The snapshots are updated every hour.
+If you're a prospective or current Base Node operator and would like to restore from a snapshot to save time on the initial sync, it's possible to always get the latest available snapshot of the Base chain on mainnet and/or testnet by using the following CLI commands. The snapshots are updated every week.
 
 **Mainnet**
 
 ```
-wget https://base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com/$(curl https://base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com/latest)
+wget https://base-snapshots-mainnet-archive.s3.amazonaws.com/$(curl https://base-snapshots-mainnet-archive.s3.amazonaws.com/latest)
 ```
 
 **Testnet (Sepolia)**
@@ -111,7 +111,7 @@ wget https://base-snapshots-sepolia-archive.s3.amazonaws.com/$(curl https://base
 **Testnet (Goerli)**
 
 ```
-wget https://base-goerli-archive-snapshots.s3.us-east-1.amazonaws.com/$(curl https://base-goerli-archive-snapshots.s3.us-east-1.amazonaws.com/latest)
+wget https://base-snapshots-goerli-archive.s3.amazonaws.com/$(curl https://base-snapshots-goerli-archive.s3.amazonaws.com/latest)
 ```
 
 ### Syncing


### PR DESCRIPTION
**What changed? Why?**
Update the snapshot URLs and frequency information.

**How has it been tested?**
Locally
![Screenshot 2023-12-08 at 11 37 00 AM](https://github.com/base-org/web/assets/672580/7dde0838-882d-442a-856f-eac955b79e2d)
