### PR TITLE
Fix Seamless ecosystem link (#215)

### DIFF
--- a/apps/web/src/data/ecosystem.json
+++ b/apps/web/src/data/ecosystem.json
@@ -100,7 +100,7 @@
   },
   {
     "name": "Seamless Protocol",
-    "url": "seamlessprotocol.com",
+    "url": "https://www.seamlessprotocol.com/",
     "description": "Seamless is the first native, decentralized lending protocol on Base. Seamless enables a new form of undercollateralized borrowing—integrated liquidity markets—which are isolated, smart contract-to-smart contract markets for amplifying strategies.",
     "tags": [
       "defi"


### PR DESCRIPTION
**What changed? Why?**

Updated the Seamless URL to include the scheme and full prefix. Fixes broken link on the ecosystem page.

Related https://github.com/base-org/web/issues/215.

![image](https://github.com/base-org/web/assets/19230462/cbd66d1f-33d3-43bb-97f5-9f5b07bc0880)

**Notes to reviewers**

n/a

**How has it been tested?**

n/a