### PR TITLE
Add support for Sepolia testnet in documentation

### DIFF
--- a/apps/base-docs/docs/tools/hardhat.md
+++ b/apps/base-docs/docs/tools/hardhat.md
@@ -46,6 +46,12 @@ networks: {
      accounts: [process.env.PRIVATE_KEY as string]
      gasPrice: 1000000000,
    },
+   // for Sepolia testnet
+   "base-sepolia": {
+     url: "https://sepolia.base.org",
+     accounts: [process.env.PRIVATE_KEY as string]
+     gasPrice: 1000000000,
+   },
    // for local dev environment
    "base-local": {
      url: "http://localhost:8545",


### PR DESCRIPTION
This seeks to introduce support for the Sepolia testnet in the [toolchains guide for Hardhat configurations](https://docs.base.org/tools/hardhat/), since Sepolia is recommended for smart contract development where Goerli was depreciated in Q1 2023 with support terminating in Q4 2023.

The addition includes updating the example `hardhat.config.ts` file to include the Sepolia network settings with the appropriate endpoints on base, but retains Goerli in the hopes that its removal in the documentation can occur in phases.

This change does not remove or alter any existing functionality, and all tests have passed.