### PR TITLE
Add Scopescan.ai to the explorer doc section

### DIFF
--- a/apps/base-docs/docs/tools/block-explorers.md
+++ b/apps/base-docs/docs/tools/block-explorers.md
@@ -30,6 +30,16 @@ Arkham is a crypto intelligence platform that systematically analyzes blockchain
 
 ---
 
+## Scopescan
+
+Scopescan supports [Platform](https://scopescan.ai/home?network=base) Base on their platform.
+
+Base voyagers can check Base transaction records, addresses, tokens, and even smart moneys on their platforms. 
+Scopescan also supports visualizing capital flows and checking token holder graphs on Base.
+
+Scopescan is an on-chain data analytics platform that greatly enhances the on-chain analytical experience."
+---
+
 ## Blockscout
 
 A Blockscout explorer is available for [Base](https://base.blockscout.com/).


### PR DESCRIPTION
**What changed? Why?**

I add Scopescan, a data analytic platform (similar to Arkham & Nansen) to the block explorer documentation page.

This is because since we have Arkham on this page, Scopescan also support to check Base transactions & tokens & addresses, they also have other nice features like:

1. moneyflow tool to visualize token flows
2. Token holder graph to visualize token holder distributions
3. Smartmoney dashboard to check who made the most money on Base

**Notes to reviewers**

Scopescan is power by 0xscope, they received legit fundings from OKX and Hashkey.

I believe Scopescan can help a lot with Base users with their data and tooling ability. That's why i propose this change. Hope it get approved, thanks!

Scopescan.ai is their platform link, you can try and decide.
