### PR TITLE
Add WalletKit to onboarding and AA docs

### DIFF
--- a/apps/base-docs/docs/tools/account-abstraction.md
+++ b/apps/base-docs/docs/tools/account-abstraction.md
@@ -16,6 +16,7 @@ keywords:
     Alchemy,
     Biconomy,
     Stackup,
+    WalletKit,
     Zerodev,
   ]
 ---
@@ -51,6 +52,16 @@ keywords:
 ## Stackup
 
 [Stackup](https://www.stackup.sh) provides smart account tooling for building account abstraction within your apps. They offer Paymaster and Bundler APIs for sponsoring gas and sending account abstraction transactions.
+
+---
+
+## WalletKit
+
+[WalletKit](https://walletkit.com) is an all-in-one platform for adding smart, gasless wallets to your app. It has integrated support for ERC 4337 and comes with a paymaster and bundler included, requiring no extra setup. 
+
+WalletKit also offers pre-built components for onboarding users with email and social logins, which can be integrated in under 15 minutes using their React SDK or the wagmi connector. Alternatively, build completely bespoke experiences for your users using WalletKit's Wallets API.
+
+WalletKit is compatible with most EVM chains, including Base. You can check out the [WalletKit documentation here](https://docs.walletkit.com). Start building for free on the Base testnet today.
 
 ---
 

--- a/apps/base-docs/docs/tools/onboarding.md
+++ b/apps/base-docs/docs/tools/onboarding.md
@@ -15,6 +15,7 @@ keywords:
     Privy,
     Dynamic,
     Particle Network,
+    WalletKit,
     user wallet,
     accounts,
     user account,
@@ -42,5 +43,15 @@ You can [get started with Privy here](https://docs.privy.io/guide/quickstart) an
 ## Particle Network
 
 [Particle Network](https://particle.network/) is the intent-centric, modular access layer of Web3. With Particle's Smart Wallet-as-a-Service, developers can curate an seamless user experience through modular and customizable EOA/AA embedded wallet components. Using MPC-TSS for key management, Particle can streamline user onboarding via familiar web2 accounts - such as Google accounts, email addresses, and phone numbers. Particle Network's Smart Wallet-as-a-Service is compatible with most EVM chains, including Base.
+
+---
+
+## WalletKit
+
+[WalletKit](https://walletkit.com) is an all-in-one platform for adding smart, gasless wallets to your app. WalletKit offers pre-built components for onboarding users with email and social logins, which can be integrated in under 15 minutes using their React SDK or the wagmi connector. Alternatively, build completely bespoke experiences for your users using WalletKit's Wallets API.
+
+WalletKit is compatible with most EVM chains, including Base. It has integrated support for ERC 4337 and comes with a paymaster and bundler included, requiring no extra setup.
+
+You can check out the [WalletKit documentation here](https://docs.walletkit.com). Start building for free on the Base testnet today.
 
 ---


### PR DESCRIPTION
Hi team, this PR adds [WalletKit](https://walletkit.com) to the onboarding and AA docs alongside similar services. WalletKit has full support for Base and generally defaults to it

We're here to answer any questions. Thanks!