### PR TITLE
Update LearnWeb3's faucet link to point to Base Sepolia

### DIFF
--- a/apps/base-docs/docs/tools/network-faucets.md
+++ b/apps/base-docs/docs/tools/network-faucets.md
@@ -73,7 +73,7 @@ Requests to QuickNode Faucet are limited to one drip every 12 hours.
 
 ## LearnWeb3 Faucet
 
-[LearnWeb3 Faucet](https://learnweb3.io/faucets/base_goerli) is a multi-chain faucet by LearnWeb3. You can use the LearnWeb3 faucet to claim Base Goerli testnet ETH for free - one claim every 24 hours.
+[LearnWeb3 Faucet](https://learnweb3.io/faucets) is a multi-chain faucet by LearnWeb3. You can use the LearnWeb3 faucet to claim Base Goerli testnet ETH for free - one claim every 24 hours.
 
 :::info
 

--- a/apps/base-docs/docs/tools/network-faucets.md
+++ b/apps/base-docs/docs/tools/network-faucets.md
@@ -73,7 +73,7 @@ Requests to QuickNode Faucet are limited to one drip every 12 hours.
 
 ## LearnWeb3 Faucet
 
-[LearnWeb3 Faucet](https://learnweb3.io/faucets) is a multi-chain faucet by LearnWeb3. You can use the LearnWeb3 faucet to claim Base Goerli testnet ETH for free - one claim every 24 hours.
+[LearnWeb3 Faucet](https://learnweb3.io/faucets/base_sepolia) is a multi-chain faucet by LearnWeb3. You can use the LearnWeb3 faucet to claim Base Sepolia testnet ETH for free - one claim every 24 hours.
 
 :::info
 


### PR DESCRIPTION
**What changed? Why?**
Instead of pointing directly to Base Goerli's faucet, we point to our main faucets page so users can choose between Base Goerli and Base Sepolia themselves

**Notes to reviewers**
N/A

**How has it been tested?**
N/A