### PR TITLE
run-a-base-node: Update HDD requirements

### DIFF
--- a/apps/base-docs/docs/building-with-base/guides/run-a-base-node.md
+++ b/apps/base-docs/docs/building-with-base/guides/run-a-base-node.md
@@ -56,7 +56,7 @@ If you're looking to harden your app and avoid rate-limiting for your users, ple
 We recommend you have this configuration to run a node:
 
 - at least 16 GB RAM
-- an SSD drive with at least 1 TB free
+- an SSD drive with at least 2 TB free
 
 :::info
 


### PR DESCRIPTION
**What changed? Why?**

Update hardware requirements in guide for running a full node (current req = 1.8TB, guide says 1TB)

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost