### PR TITLE
Move Foundry and Hardhat to Top of Basecamp

### DIFF
--- a/apps/base-docs/base-camp/docs/development-tools/overview.md
+++ b/apps/base-docs/base-camp/docs/development-tools/overview.md
@@ -1,0 +1,18 @@
+---
+title: Overview
+description: Learn about development environment options
+keywords:
+  [Hardhat, Foundry, Remix, smart contract development, development, development environments]
+hide_table_of_contents: false
+---
+
+As the popularity and possibilities of building onchain have increased, so has the number, quality, and ease of setup for a variety of smart contract development environments. Most of the smart contract development content in Base Camp is done in [Remix], an online IDE that allows you to dive right into learning without worrying about setup.
+
+However, the setup of professional tools for local development is far less burdensome than it used to be. [Foundry] and [Hardhat] are two popular choices, both with excellent communities.
+
+You may wish to select and install one of these now, but feel free to skip those sections and go to right [Smart Contract Development] if your happy learning with an online editor!
+
+[Remix]: https://remix.ethereum.org/
+[Foundry]: https://book.getfoundry.sh/
+[Hardhat]: https://hardhat.org/
+[Smart Contract Development]: ../introduction-to-solidity/introduction-to-solidity-overview

--- a/apps/base-docs/base-camp/docs/events/hardhat-events-sbs.md
+++ b/apps/base-docs/base-camp/docs/events/hardhat-events-sbs.md
@@ -6,6 +6,12 @@ hide_table_of_contents: false
 
 In this article, you'll learn how events work in Solidity by reviewing some practical examples and common use cases of events.
 
+:::caution
+
+This tutorial has been moved as part of a reorganization! It assumes you are using Hardhat. Everything in this lesson will work with minor adjustments if you are working in Foundry or Remix.
+
+:::
+
 ---
 
 ## Objectives

--- a/apps/base-docs/base-camp/docs/interfaces/calling-another-contract-vid.md
+++ b/apps/base-docs/base-camp/docs/interfaces/calling-another-contract-vid.md
@@ -4,6 +4,12 @@ description: Call the functions in another contract from your own contract.
 hide_table_of_contents: false
 ---
 
+:::caution
+
+This tutorial has been moved as part of a reorganization! It assumes you are using Hardhat. Everything in this lesson will work with minor adjustments if you are working in Foundry or Remix.
+
+:::
+
 import Video from '../../../src/components/VideoPlayer/index.jsx'
 
 <Video videoId='877157748' title='Calling Another Contract' />

--- a/apps/base-docs/base-camp/docs/interfaces/contract-to-contract-interaction.md
+++ b/apps/base-docs/base-camp/docs/interfaces/contract-to-contract-interaction.md
@@ -6,6 +6,12 @@ hide_table_of_contents: false
 
 In this article, you'll learn how to interact with other smart contracts using interfaces and the `.call()` function, which allows you to interact with other smart contracts without using an interface.
 
+:::caution
+
+This tutorial has been moved as part of a reorganization! It assumes you are using Hardhat. Everything in this lesson will work with minor adjustments if you are working in Foundry or Remix.
+
+:::
+
 ---
 
 ## Objectives

--- a/apps/base-docs/base-camp/docs/interfaces/intro-to-interfaces-vid.md
+++ b/apps/base-docs/base-camp/docs/interfaces/intro-to-interfaces-vid.md
@@ -4,6 +4,12 @@ description: Use interfaces to tell your contract how another works.
 hide_table_of_contents: false
 ---
 
+:::caution
+
+This tutorial has been moved as part of a reorganization! It assumes you are using Hardhat. Everything in this lesson will work with minor adjustments if you are working in Foundry or Remix.
+
+:::
+
 import Video from '../../../src/components/VideoPlayer/index.jsx'
 
 <Video videoId='877151475' title='Intro to Interfaces' />

--- a/apps/base-docs/base-camp/docs/interfaces/testing-the-interface-vid.md
+++ b/apps/base-docs/base-camp/docs/interfaces/testing-the-interface-vid.md
@@ -4,6 +4,12 @@ description: Start writing tests for interfaces.
 hide_table_of_contents: false
 ---
 
+:::caution
+
+This tutorial has been moved as part of a reorganization! It assumes you are using Hardhat. Everything in this lesson will work with minor adjustments if you are working in Foundry or Remix.
+
+:::
+
 import Video from '../../../src/components/VideoPlayer/index.jsx'
 
 <Video videoId='877160111' title='Testing the Interface' />

--- a/apps/base-docs/base-camp/sidebars.js
+++ b/apps/base-docs/base-camp/sidebars.js
@@ -41,6 +41,168 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'Development Tools',
+      collapsible: true,
+      items: [
+        {
+          type: 'doc',
+          id: 'docs/development-tools/overview',
+        },
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Development with Hardhat',
+      collapsible: true,
+      items: [
+        {
+          type: 'category',
+          label: 'Hardhat Setup and Overview',
+          items: [
+            {
+              type: 'doc',
+              id: 'docs/hardhat-setup-overview/hardhat-overview-vid',
+              className: 'sidebar-video',
+            },
+            {
+              type: 'doc',
+              id: 'docs/hardhat-setup-overview/creating-a-project-vid',
+              className: 'sidebar-video',
+            },
+            {
+              type: 'doc',
+              id: 'docs/hardhat-setup-overview/hardhat-setup-overview-sbs',
+              className: 'sidebar-coding',
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Testing with Typescript',
+          items: [
+            {
+              type: 'doc',
+              id: 'docs/hardhat-testing/testing-overview-vid',
+              className: 'sidebar-video',
+            },
+            {
+              type: 'doc',
+              id: 'docs/hardhat-testing/writing-tests-vid',
+              className: 'sidebar-video',
+            },
+            {
+              type: 'doc',
+              id: 'docs/hardhat-testing/contract-abi-and-testing-vid',
+              className: 'sidebar-video',
+            },
+            {
+              type: 'doc',
+              id: 'docs/hardhat-testing/hardhat-testing-sbs',
+              className: 'sidebar-coding',
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Etherscan',
+          items: [
+            {
+              type: 'doc',
+              id: 'docs/etherscan/etherscan-sbs',
+              className: 'sidebar-coding',
+            },
+            {
+              type: 'doc',
+              id: 'docs/etherscan/etherscan-vid',
+              className: 'sidebar-video',
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Deploying Smart Contracts',
+          items: [
+            {
+              type: 'doc',
+              id: 'docs/hardhat-deploy/installing-hardhat-deploy-vid',
+              className: 'sidebar-video',
+            },
+            {
+              type: 'doc',
+              id: 'docs/hardhat-deploy/setup-deploy-script-vid',
+              className: 'sidebar-video',
+            },
+            {
+              type: 'doc',
+              id: 'docs/hardhat-deploy/testing-our-deployment-vid',
+              className: 'sidebar-video',
+            },
+            {
+              type: 'doc',
+              id: 'docs/hardhat-deploy/test-network-configuration-vid',
+              className: 'sidebar-video',
+            },
+            {
+              type: 'doc',
+              id: 'docs/hardhat-deploy/deployment-vid',
+              className: 'sidebar-video',
+            },
+            {
+              type: 'doc',
+              id: 'docs/hardhat-deploy/hardhat-deploy-sbs',
+              className: 'sidebar-coding',
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Verifying Smart Contracts',
+          items: [
+            {
+              type: 'doc',
+              id: 'docs/hardhat-verify/hardhat-verify-vid',
+              className: 'sidebar-video',
+            },
+            {
+              type: 'doc',
+              id: 'docs/hardhat-verify/hardhat-verify-sbs',
+              className: 'sidebar-coding',
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Mainnet Forking',
+          items: [
+            {
+              type: 'doc',
+              id: 'docs/hardhat-forking/mainnet-forking-vid',
+              className: 'sidebar-video',
+            },
+            {
+              type: 'doc',
+              id: 'docs/hardhat-forking/hardhat-forking',
+              className: 'sidebar-coding',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Development With Foundry',
+      collapsible: true,
+      items: [
+        {
+          type: 'link',
+          label: 'Introduction to Foundry',
+          href: 'http://localhost:3000/building-with-base/guides/building-with-base-and-foundry/introduction',
+          className: 'sidebar-coding',
+        },
+      ],
+    },
+    {
+      type: 'category',
       label: 'Smart Contract Development',
       collapsible: true,
       items: [
@@ -432,6 +594,43 @@ const sidebars = {
             },
           ],
         },
+        {
+          type: 'category',
+          label: 'Contract to Contract Interactions',
+          items: [
+            {
+              type: 'doc',
+              id: 'docs/interfaces/intro-to-interfaces-vid',
+              className: 'sidebar-video',
+            },
+            {
+              type: 'doc',
+              id: 'docs/interfaces/calling-another-contract-vid',
+              className: 'sidebar-video',
+            },
+            {
+              type: 'doc',
+              id: 'docs/interfaces/testing-the-interface-vid',
+              className: 'sidebar-video',
+            },
+            {
+              type: 'doc',
+              id: 'docs/interfaces/contract-to-contract-interaction',
+              className: 'sidebar-coding',
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Events',
+          items: [
+            {
+              type: 'doc',
+              id: 'docs/events/hardhat-events-sbs',
+              className: 'sidebar-coding',
+            },
+          ],
+        },
       ],
     },
     {
@@ -560,181 +759,6 @@ const sidebars = {
               type: 'doc',
               id: 'docs/erc-721-token/erc-721-exercise',
               className: 'sidebar-exercise',
-            },
-          ],
-        },
-      ],
-    },
-    {
-      type: 'category',
-      label: 'Development with Hardhat',
-      collapsible: true,
-      items: [
-        {
-          type: 'category',
-          label: 'Hardhat Setup and Overview',
-          items: [
-            {
-              type: 'doc',
-              id: 'docs/hardhat-setup-overview/hardhat-overview-vid',
-              className: 'sidebar-video',
-            },
-            {
-              type: 'doc',
-              id: 'docs/hardhat-setup-overview/creating-a-project-vid',
-              className: 'sidebar-video',
-            },
-            {
-              type: 'doc',
-              id: 'docs/hardhat-setup-overview/hardhat-setup-overview-sbs',
-              className: 'sidebar-coding',
-            },
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Testing with Typescript',
-          items: [
-            {
-              type: 'doc',
-              id: 'docs/hardhat-testing/testing-overview-vid',
-              className: 'sidebar-video',
-            },
-            {
-              type: 'doc',
-              id: 'docs/hardhat-testing/writing-tests-vid',
-              className: 'sidebar-video',
-            },
-            {
-              type: 'doc',
-              id: 'docs/hardhat-testing/contract-abi-and-testing-vid',
-              className: 'sidebar-video',
-            },
-            {
-              type: 'doc',
-              id: 'docs/hardhat-testing/hardhat-testing-sbs',
-              className: 'sidebar-coding',
-            },
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Etherscan',
-          items: [
-            {
-              type: 'doc',
-              id: 'docs/etherscan/etherscan-sbs',
-              className: 'sidebar-coding',
-            },
-            {
-              type: 'doc',
-              id: 'docs/etherscan/etherscan-vid',
-              className: 'sidebar-video',
-            },
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Deploying Smart Contracts',
-          items: [
-            {
-              type: 'doc',
-              id: 'docs/hardhat-deploy/installing-hardhat-deploy-vid',
-              className: 'sidebar-video',
-            },
-            {
-              type: 'doc',
-              id: 'docs/hardhat-deploy/setup-deploy-script-vid',
-              className: 'sidebar-video',
-            },
-            {
-              type: 'doc',
-              id: 'docs/hardhat-deploy/testing-our-deployment-vid',
-              className: 'sidebar-video',
-            },
-            {
-              type: 'doc',
-              id: 'docs/hardhat-deploy/test-network-configuration-vid',
-              className: 'sidebar-video',
-            },
-            {
-              type: 'doc',
-              id: 'docs/hardhat-deploy/deployment-vid',
-              className: 'sidebar-video',
-            },
-            {
-              type: 'doc',
-              id: 'docs/hardhat-deploy/hardhat-deploy-sbs',
-              className: 'sidebar-coding',
-            },
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Verifying Smart Contracts',
-          items: [
-            {
-              type: 'doc',
-              id: 'docs/hardhat-verify/hardhat-verify-vid',
-              className: 'sidebar-video',
-            },
-            {
-              type: 'doc',
-              id: 'docs/hardhat-verify/hardhat-verify-sbs',
-              className: 'sidebar-coding',
-            },
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Mainnet Forking',
-          items: [
-            {
-              type: 'doc',
-              id: 'docs/hardhat-forking/mainnet-forking-vid',
-              className: 'sidebar-video',
-            },
-            {
-              type: 'doc',
-              id: 'docs/hardhat-forking/hardhat-forking',
-              className: 'sidebar-coding',
-            },
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Contract to Contract Interactions',
-          items: [
-            {
-              type: 'doc',
-              id: 'docs/interfaces/intro-to-interfaces-vid',
-              className: 'sidebar-video',
-            },
-            {
-              type: 'doc',
-              id: 'docs/interfaces/calling-another-contract-vid',
-              className: 'sidebar-video',
-            },
-            {
-              type: 'doc',
-              id: 'docs/interfaces/testing-the-interface-vid',
-              className: 'sidebar-video',
-            },
-            {
-              type: 'doc',
-              id: 'docs/interfaces/contract-to-contract-interaction',
-              className: 'sidebar-coding',
-            },
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Events',
-          items: [
-            {
-              type: 'doc',
-              id: 'docs/events/hardhat-events-sbs',
-              className: 'sidebar-coding',
             },
           ],
         },


### PR DESCRIPTION
**What changed? Why?**
Hardhat and Foundry are much easier to setup now than when the first series of Remix videos was created.  In response to feedback from Builder channel, moved them to to the top to make it easier for devs to make an informed choice for which tools to do the content using.

**Notes to reviewers**
Also moved the evens and interfaces sections to be inside Smart Contract Development, and added a warning that they're done with hardhat, but will still work in Remix.

**How has it been tested?**
