### PR TITLE
Update sidebars.js to add NFT Checkout

### DIFF
--- a/apps/base-docs/sidebars.js
+++ b/apps/base-docs/sidebars.js
@@ -234,6 +234,7 @@ module.exports = {
         'tools/data-indexers',
         'tools/cross-chain',
         'tools/account-abstraction',
+        'tools/nft-checkout',
         'tools/onramps',
         'tools/onboarding',
         {


### PR DESCRIPTION
https://docs.base.org/tools/nft-checkout/

This category was not showing up on the sidebar under "Tools". Committing this change to add it

