### PR TITLE
Removed outdated line from base camp docs

### DIFF
--- a/apps/base-docs/base-camp/docs/deployment-to-testnet/deployment-to-base-sepolia-sbs.md
+++ b/apps/base-docs/base-camp/docs/deployment-to-testnet/deployment-to-base-sepolia-sbs.md
@@ -46,6 +46,8 @@ Testnet tokens have no real value, but the supply is not unlimited. You can use 
 
 You can find many faucets by searching, and it's good to keep a few bookmarked because they have a tendency to go down from time to time. Faucet providers are constantly combating bad actors and sometimes need to disable their faucets while doing so.
 
+The Coinbase Wallet has faucets built in. You can find them by clicking Settings -> Developer settings -> Testnet faucets.
+
 You can also access the [faucets on the web].
 
 Once you have testnet Base Sepolia Ether, you can view your balance under the _Testnets_ tab in the Coinbase wallet or by selecting the testnet from the network dropdown in Metamask. Sadly, it's not actually worth the amount listed!

--- a/apps/base-docs/base-camp/docs/deployment-to-testnet/deployment-to-base-sepolia-sbs.md
+++ b/apps/base-docs/base-camp/docs/deployment-to-testnet/deployment-to-base-sepolia-sbs.md
@@ -46,8 +46,6 @@ Testnet tokens have no real value, but the supply is not unlimited. You can use 
 
 You can find many faucets by searching, and it's good to keep a few bookmarked because they have a tendency to go down from time to time. Faucet providers are constantly combating bad actors and sometimes need to disable their faucets while doing so.
 
-The Coinbase Wallet has faucets built in. You can find them by clicking Settings -> Developer settings -> Testnet faucets.
-
 You can also access the [faucets on the web].
 
 Once you have testnet Base Sepolia Ether, you can view your balance under the _Testnets_ tab in the Coinbase wallet or by selecting the testnet from the network dropdown in Metamask. Sadly, it's not actually worth the amount listed!


### PR DESCRIPTION
**What changed? Why?**
I omitted this line "The Coinbase Wallet has faucets built in. You can find them by clicking Settings -> Developer settings -> Testnet faucets." from the path: web/apps/base-docs/base-camp/docs/deployment-to-testnet/deployment-to-base-sepolia-sbs.md since the information no longer is valid.

![Screenshot 2024-01-20 155234](https://github.com/base-org/web/assets/95197857/1d5e376d-4509-4171-ac42-162ba424cd4c)

**Notes to reviewers**
This is my first PR. I noticed this issue while reviewing the docs and then checked the issues tab in the repo. It seemed that it was fair game to submit a PR. Forgive me if I didnt anything out of convention, Im just trying to help :)
![Screenshot 2024-01-20 155450](https://github.com/base-org/web/assets/95197857/e6ad093d-0995-477a-aece-2f166e4870fc)


**How has it been tested?**
Its has nothing to do with any functional code and is just a slight adjustment to the docs. 