### PR TITLE
 modified: "imports-exercise.md" to include a custom-styled block of text to inform @dev about contract verification best practices

### DIFF
--- a/apps/base-docs/base-camp/docs/imports/imports-exercise.md
+++ b/apps/base-docs/base-camp/docs/imports/imports-exercise.md
@@ -57,6 +57,18 @@ Remember, the compiler will automatically create a getter for `public` `struct`s
 
 ## Submit your Contract and Earn an NFT Badge! (BETA)
 
+:::caution 
+
+#### Contract Verification Best Practices
+
+To simplify the verification of your contract on a blockchain explorer like BaseScan.org, consider these two common strategies:
+
+1. **Flattening**: This method involves combining your main contract and all of its imported dependencies into a single file. This makes it easier for explorers to verify the code since they only have to process one file. 
+
+2. **Modular Deployment**: Alternatively, you can deploy each imported contract separately and then reference them in your main contract via their deployed addresses. This approach maintains the modularity and readability of your code. Each contract is deployed and verified independently, which can facilitate easier updates and reusability.
+
+:::
+
 :::info
 
 #### Hey, where'd my NFT go!?


### PR DESCRIPTION

**What changed? Why?**
I updated the imports-exercise doc to include a custom-styled block of text to inform @dev about contract verification best practices. 

**Notes to reviewers**
I kept running into this issue with contract verification where I couldnt verified my contract that included import statements unless I flattened the contract or deployed the "imported" contracts individually and then interacted in my "main" contract via their deployed addresses.
I tried to use concise, yet descriptive language. If this was known to me initially while working on the contract exercises it wouldve saved me time and frustration so thats why I figured the update is valuable. 
Thanks team! Im honored to be able to contribute. 
![Screenshot 2024-01-24 071514](https://github.com/base-org/web/assets/95197857/24b99b6e-efc8-4036-9740-5d952eaeffbd)

**How has it been tested?**
I tested the changes locally using a Markdown preview extension. 

**Does this PR add a new token to the bridge?**

- [X] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
