### PR TITLE
Merge transactions from indexer and explorer for redundancy

### DIFF
--- a/apps/bridge/src/utils/array/dedupeTransactions.ts
+++ b/apps/bridge/src/utils/array/dedupeTransactions.ts
@@ -1,0 +1,13 @@
+import { BridgeTransaction } from 'apps/bridge/src/types/BridgeTransaction';
+
+export function dedupeTransactions(transactions: BridgeTransaction[]) {
+  const deduped = [];
+  const hashes = new Set();
+  for (const transaction of transactions) {
+    if (!hashes.has(transaction.hash)) {
+      deduped.push(transaction);
+      hashes.add(transaction.hash);
+    }
+  }
+  return deduped;
+}

--- a/apps/bridge/src/utils/transactions/isETHOrERC20Deposit.ts
+++ b/apps/bridge/src/utils/transactions/isETHOrERC20Deposit.ts
@@ -1,3 +1,4 @@
+import { l1StandardBridgeABI } from '@eth-optimism/contracts-ts';
 import { decodeFunctionData } from 'viem';
 import { BlockExplorerTransaction } from 'apps/bridge/src/types/API';
 import getConfig from 'next/config';
@@ -44,4 +45,59 @@ export function isIndexerTxETHOrERC20Deposit(tx: DepositItem) {
   );
 
   return Boolean(token);
+}
+
+const ETH_DEPOSIT_ADDRESS = (
+  publicRuntimeConfig?.l1OptimismPortalProxyAddress ?? '0xe93c8cD0D409341205A592f8c4Ac1A5fe5585cfA'
+).toLowerCase();
+
+const ERC20_DEPOSIT_ADDRESS = (
+  publicRuntimeConfig?.l1BridgeProxyAddress ?? '0xfA6D8Ee5BE770F84FC001D098C4bD604Fe01284a'
+).toLowerCase();
+
+export function isETHOrERC20OrCCTPDeposit(tx: BlockExplorerTransaction) {
+  // Immediately filter out if tx is not to an address we don't care about
+  if (
+    tx.to !== ETH_DEPOSIT_ADDRESS &&
+    tx.to !== ERC20_DEPOSIT_ADDRESS &&
+    tx.to !== CCTP_DEPOSIT_ADDRESS
+  ) {
+    return false;
+  }
+
+  // ETH deposit
+  if (tx.to === ETH_DEPOSIT_ADDRESS && tx.value !== '0') {
+    return true;
+  }
+
+  // ERC-20 desposit
+  if (tx.to === ERC20_DEPOSIT_ADDRESS) {
+    const { functionName, args } = decodeFunctionData({
+      abi: l1StandardBridgeABI,
+      data: tx.input,
+    });
+    if (functionName === 'depositERC20' || functionName === 'depositERC20To') {
+      const token = assetList.find(
+        (asset) =>
+          asset.L1chainId === parseInt(publicRuntimeConfig.l1ChainID) &&
+          asset.L1contract?.toLowerCase() === (args?.[0] as string).toLowerCase() &&
+          asset.protocol === 'OP',
+      );
+      // Return true if this is a depositERC20 call to the L1StandardBridge and is a token the UI supports
+      return Boolean(token);
+    }
+  }
+
+  // CCTP deposit
+  if (tx.to === CCTP_DEPOSIT_ADDRESS && publicRuntimeConfig.cctpEnabled === 'true') {
+    const { functionName } = decodeFunctionData({
+      abi: TokenMessenger,
+      data: tx.input,
+    });
+    if (functionName === 'depositForBurn') {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/apps/bridge/src/utils/transactions/isETHOrERCWithdrawal.ts
+++ b/apps/bridge/src/utils/transactions/isETHOrERCWithdrawal.ts
@@ -5,6 +5,8 @@ import { getAssetListForChainEnv } from 'apps/bridge/src/utils/assets/getAssetLi
 import getConfig from 'next/config';
 import { decodeFunctionData } from 'viem';
 
+import { l2StandardBridgeABI } from '@eth-optimism/contracts-ts';
+
 const { publicRuntimeConfig } = getConfig();
 
 const assetList = getAssetListForChainEnv();
@@ -42,4 +44,53 @@ export function isIndexerTxETHOrERC20Withdrawal(tx: WithdrawalItem) {
   );
 
   return Boolean(token);
+}
+
+const ETH_WITHDRAWAL_ADDRESS = (
+  publicRuntimeConfig?.l2L1MessagePasserAddress ?? '0x4200000000000000000000000000000000000016'
+).toLowerCase();
+
+const ERC20_WITHDRAWAL_ADDRESS = (
+  publicRuntimeConfig?.L2StandardBridge ?? '0x4200000000000000000000000000000000000010'
+).toLowerCase();
+
+export function isETHOrERC20OrCCTPWithdrawal(tx: BlockExplorerTransaction) {
+  // Immediately filter out if tx is not to an address we don't care about
+  if (
+    tx.to !== ETH_WITHDRAWAL_ADDRESS &&
+    tx.to !== ERC20_WITHDRAWAL_ADDRESS &&
+    tx.to !== CCTP_WITHDRAWAL_ADDRESS
+  ) {
+    return false;
+  }
+
+  // ETH withdrawal
+  if (tx.to === ETH_WITHDRAWAL_ADDRESS && tx.value !== '0') {
+    return true;
+  }
+
+  // ERC-20 Withdrawal
+  if (tx.to === ERC20_WITHDRAWAL_ADDRESS) {
+    const { functionName, args } = decodeFunctionData({ abi: l2StandardBridgeABI, data: tx.input });
+    if (functionName === 'withdraw' || functionName === 'withdrawTo') {
+      const token = assetList.find(
+        (asset) =>
+          asset.L2chainId === parseInt(publicRuntimeConfig.l2ChainID) &&
+          asset.L2contract?.toLowerCase() === ((args?.[0] as string) ?? '').toLowerCase() &&
+          asset.protocol === 'OP',
+      );
+      // Return true if this is a withdraw call to the L2StandardBridge and is a token the UI supports
+      return Boolean(token);
+    }
+  }
+
+  // CCTP Withdrawal
+  if (tx.to === CCTP_WITHDRAWAL_ADDRESS && publicRuntimeConfig.cctpEnabled === 'true') {
+    const { functionName } = decodeFunctionData({ abi: TokenMessenger, data: tx.input });
+    if (functionName === 'depositForBurn') {
+      return true;
+    }
+  }
+
+  return false;
 }


### PR DESCRIPTION
**What changed? Why?**

In order to get around our problem with the Goerli indexer, but also more robust in general.

**Notes to reviewers**

**How has it been tested?**

Manually.

**Does this PR add a new token to the bridge?**

- [ ] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
