### PR TITLE
Fix code block line highlighting

### DIFF
--- a/apps/base-docs/src/css/root.css
+++ b/apps/base-docs/src/css/root.css
@@ -17,6 +17,8 @@ html {
 }
 
 :root {
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, .1) !important;
+  
   --ifm-color-white: #ffffff;
   --ifm-color-gray-0: var(--ifm-color-white);
   --ifm-color-gray-100: hsl(0, 0%, 97%);
@@ -222,6 +224,8 @@ html {
 }
 
 html[data-theme='light'] {
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, .1) !important;
+
   --blue0: 245, 248, 255;
   --blue5: 211, 225, 255;
   --blue10: 176, 202, 255;
@@ -391,6 +395,7 @@ html[data-theme='dark'] {
   --ifm-background-surface-color: #1e2025;
   --ifm-footer-background-color: var(--ifm-background-surface-color);
   --feature-title-color: var(--ifm-color-white);
+  --docusaurus-highlighted-code-line-bg: rgba(150, 150, 150, .25) !important;
 
   --blue0: 0, 16, 51;
   --blue5: 1, 29, 91;


### PR DESCRIPTION
**What changed? Why?**
Fix code block line highlighting for dark and light mode.

**Before**
<img width="1013" alt="Screenshot 2024-01-29 at 2 16 02 PM" src="https://github.com/base-org/web/assets/3264051/e1c8cefb-7629-43ff-a79d-1012a144e73d">
<img width="1016" alt="Screenshot 2024-01-29 at 2 15 56 PM" src="https://github.com/base-org/web/assets/3264051/d261c6e1-3482-48c3-a1e6-d914eb84f543">


**After**
<img width="1013" alt="Screenshot 2024-01-29 at 2 15 36 PM" src="https://github.com/base-org/web/assets/3264051/f65af765-ef49-424f-b085-da2e3e410ec4">
<img width="1005" alt="Screenshot 2024-01-29 at 2 15 30 PM" src="https://github.com/base-org/web/assets/3264051/1fec686a-1e9a-4b3c-9c7e-7d447b5ec64e">


**Notes to reviewers**
N/A

**How has it been tested?**
Manually

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
