### PR TITLE
Fix Base Camp hyperlink in Farcaster Frames guide

### DIFF
--- a/apps/base-docs/docs/building-with-base/guides/nft-minting-frame.md
+++ b/apps/base-docs/docs/building-with-base/guides/nft-minting-frame.md
@@ -560,7 +560,7 @@ In this tutorial, you learned how to create [Farcaster] frames. You then updated
 
 ---
 
-[Base Camp]: https://base.org.camp
+[Base Camp]: https://docs.base.org/base-camp/docs/welcome
 [ERC-721 Tokens]: https://docs.base.org/base-camp/docs/erc-721-token/erc-721-standard-video
 [testnet version of Opensea]: https://testnets.opensea.io/
 [Farcaster]: https://www.farcaster.xyz/


### PR DESCRIPTION
**What changed? Why?**
Updated hyperlink for Base Camp in Prerequisites section from https://base.org.camp to https://docs.base.org/base-camp/docs/welcome because the original link was dead. 

