### PR TITLE
Update OpenZeppelin dependency version for LayerZero V2

### DIFF
--- a/apps/base-docs/docs/building-with-base/guides/cross-chain-with-layerzero.md
+++ b/apps/base-docs/docs/building-with-base/guides/cross-chain-with-layerzero.md
@@ -126,7 +126,7 @@ To install LayerZero smart contracts and their dependencies, run the following c
 
 ```bash
 forge install GNSPS/solidity-bytes-utils --no-commit
-forge install OpenZeppelin/openzeppelin-contracts --no-commit
+forge install OpenZeppelin/openzeppelin-contracts@v4.9.4 --no-commit
 forge install LayerZero-Labs/LayerZero-v2 --no-commit
 ```
 


### PR DESCRIPTION
**What changed? Why?**
Specify OpenZeppelin dependency contracts to be v4 (the version LZ expects)
Not specifying a version will install the latest version (v5) and results in a breaking change. 

![image](https://github.com/base-org/web/assets/3264051/fa1fc9bc-9eeb-46f4-9929-cf2551ed69de)


**Notes to reviewers**
N/A

**How has it been tested?**
Manually

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
