### PR TITLE
Revert explorerTx transform logic to handle all transaction types

### DIFF
--- a/apps/bridge/src/utils/transactions/explorerTxToBridgeDeposit.ts
+++ b/apps/bridge/src/utils/transactions/explorerTxToBridgeDeposit.ts
@@ -3,6 +3,7 @@ import { Asset } from 'apps/bridge/src/types/Asset';
 import { decodeFunctionData } from 'viem';
 import { BridgeTransaction } from 'apps/bridge/src/types/BridgeTransaction';
 import { getAssetListForChainEnv } from 'apps/bridge/src/utils/assets/getAssetListForChainEnv';
+import { l1StandardBridgeABI } from '@eth-optimism/contracts-ts';
 import getConfig from 'next/config';
 import TokenMessenger from 'apps/bridge/src/contract-abis/TokenMessenger';
 
@@ -10,28 +11,77 @@ const assetList = getAssetListForChainEnv();
 
 const { publicRuntimeConfig } = getConfig();
 
+const ETH_DEPOSIT_ADDRESS = (
+  publicRuntimeConfig?.l1OptimismPortalProxyAddress ?? '0xe93c8cD0D409341205A592f8c4Ac1A5fe5585cfA'
+).toLowerCase();
+
+const CCTP_DEPOSIT_ADDRESS = (
+  publicRuntimeConfig?.l1CCTPTokenMessengerAddress ?? '0xd0c3da58f55358142b8d3e06c1c30c5c6114efe8'
+).toLowerCase();
+
 export function explorerTxToBridgeDeposit(tx: BlockExplorerTransaction): BridgeTransaction {
-  // CCTP deposit (CCTP)
-  const { args } = decodeFunctionData({
-    abi: TokenMessenger,
+  if (tx.to === ETH_DEPOSIT_ADDRESS) {
+    // ETH deposit (OP)
+    return {
+      type: 'Deposit',
+      from: tx.from,
+      to: tx.to,
+      assetSymbol: 'ETH',
+      amount: tx.value,
+      blockTimestamp: tx.timeStamp,
+      hash: tx.hash as `0x${string}`,
+      status: 'Complete',
+      priceApiId: 'ethereum',
+      assetDecimals: 18,
+      protocol: 'OP',
+    };
+  } else if (tx.to === CCTP_DEPOSIT_ADDRESS) {
+    // CCTP deposit (CCTP)
+    const { args } = decodeFunctionData({
+      abi: TokenMessenger,
+      data: tx.input,
+    });
+    const token = assetList.find(
+      (asset) =>
+        asset.L1chainId === parseInt(publicRuntimeConfig.l1ChainID) &&
+        asset.L1contract?.toLowerCase() === (args?.[3] as string).toLowerCase() &&
+        asset.protocol === 'CCTP',
+    ) as Asset;
+    return {
+      type: 'Deposit',
+      from: tx.from,
+      to: tx.to,
+      assetSymbol: token.L1symbol ?? '',
+      amount: (args?.[0] as bigint).toString(),
+      blockTimestamp: tx.timeStamp,
+      hash: tx.hash as `0x${string}`,
+      priceApiId: token.apiId,
+      assetDecimals: token.decimals,
+      protocol: 'CCTP',
+    };
+  }
+
+  const { functionName, args } = decodeFunctionData({
+    abi: l1StandardBridgeABI,
     data: tx.input,
   });
   const token = assetList.find(
     (asset) =>
       asset.L1chainId === parseInt(publicRuntimeConfig.l1ChainID) &&
-      asset.L1contract?.toLowerCase() === (args?.[3] as string).toLowerCase() &&
-      asset.protocol === 'CCTP',
+      asset.L1contract?.toLowerCase() === (args?.[0] as string).toLowerCase() &&
+      asset.protocol === 'OP',
   ) as Asset;
   return {
     type: 'Deposit',
     from: tx.from,
     to: tx.to,
     assetSymbol: token.L1symbol ?? '',
-    amount: (args?.[0] as bigint).toString(),
+    amount: ((functionName === 'depositERC20' ? args?.[2] : args?.[3]) as bigint).toString(),
     blockTimestamp: tx.timeStamp,
     hash: tx.hash as `0x${string}`,
+    status: 'Complete',
     priceApiId: token.apiId,
     assetDecimals: token.decimals,
-    protocol: 'CCTP',
+    protocol: 'OP',
   };
 }

--- a/apps/bridge/src/utils/transactions/explorerTxToBridgeWithdrawal.ts
+++ b/apps/bridge/src/utils/transactions/explorerTxToBridgeWithdrawal.ts
@@ -1,3 +1,4 @@
+import { l2StandardBridgeABI } from '@eth-optimism/contracts-ts';
 import TokenMessenger from 'apps/bridge/src/contract-abis/TokenMessenger';
 import { BlockExplorerTransaction } from 'apps/bridge/src/types/API';
 import { Asset } from 'apps/bridge/src/types/Asset';
@@ -10,25 +11,67 @@ const assetList = getAssetListForChainEnv();
 
 const { publicRuntimeConfig } = getConfig();
 
+const ETH_WITHDRAWAL_ADDRESS = (
+  publicRuntimeConfig?.l2L1MessagePasserAddress ?? '0x4200000000000000000000000000000000000016'
+).toLowerCase();
+
+const CCTP_WITHDRAWAL_ADDRESS = (
+  publicRuntimeConfig?.l2CCTPTokenMessengerAddress ?? '0x877b8e8c9e2383077809787ED6F279ce01CB4cc8'
+).toLowerCase();
+
 export function explorerTxToBridgeWithdrawal(tx: BlockExplorerTransaction): BridgeTransaction {
-  // CCTP withdrawal (CCTP)
-  const { args } = decodeFunctionData({ abi: TokenMessenger, data: tx.input });
+  if (tx.to === ETH_WITHDRAWAL_ADDRESS) {
+    // ETH withdrawal (OP)
+    return {
+      type: 'Withdrawal',
+      from: tx.from,
+      to: tx.to,
+      assetSymbol: 'ETH',
+      amount: tx.value,
+      blockTimestamp: tx.timeStamp,
+      hash: tx.hash as `0x${string}`,
+      priceApiId: 'ethereum',
+      protocol: 'OP',
+    };
+  } else if (tx.to === CCTP_WITHDRAWAL_ADDRESS) {
+    // CCTP withdrawal (CCTP)
+    const { args } = decodeFunctionData({ abi: TokenMessenger, data: tx.input });
+    const token = assetList.find(
+      (asset) =>
+        asset.L1chainId === parseInt(publicRuntimeConfig.l1ChainID) &&
+        asset.L2contract?.toLowerCase() === (args?.[3] as string).toLowerCase() &&
+        asset.protocol === 'CCTP',
+    ) as Asset;
+    return {
+      type: 'Withdrawal',
+      from: tx.from,
+      to: tx.to,
+      assetSymbol: token.L2symbol ?? '',
+      amount: (args?.[0] as bigint).toString(),
+      blockTimestamp: tx.timeStamp,
+      hash: tx.hash as `0x${string}`,
+      priceApiId: token.apiId,
+      assetDecimals: token.decimals,
+      protocol: 'CCTP',
+    };
+  }
+
+  const { functionName, args } = decodeFunctionData({ abi: l2StandardBridgeABI, data: tx.input });
   const token = assetList.find(
     (asset) =>
-      asset.L1chainId === parseInt(publicRuntimeConfig.l1ChainID) &&
-      asset.L2contract?.toLowerCase() === (args?.[3] as string).toLowerCase() &&
-      asset.protocol === 'CCTP',
+      asset.L2chainId === parseInt(publicRuntimeConfig.l2ChainID) &&
+      asset.L2contract?.toLowerCase() === ((args?.[0] as string) ?? '').toLowerCase() &&
+      asset.protocol === 'OP',
   ) as Asset;
   return {
     type: 'Withdrawal',
     from: tx.from,
     to: tx.to,
-    assetSymbol: token.L2symbol ?? '',
-    amount: (args?.[0] as bigint).toString(),
+    assetSymbol: token?.L2symbol ?? 'Unlisted',
+    amount: ((functionName === 'withdraw' ? args?.[1] : args?.[2]) as bigint).toString(),
     blockTimestamp: tx.timeStamp,
     hash: tx.hash as `0x${string}`,
-    priceApiId: token.apiId,
-    assetDecimals: token.decimals,
-    protocol: 'CCTP',
+    priceApiId: token?.apiId,
+    protocol: 'OP',
   };
 }


### PR DESCRIPTION
**What changed? Why?**

Now that we've changed to use `explorer` and `indexer` endpoints as redundant sources of data we no longer use the `explorer` only for CCTP transactions, therefore we need to re-enable handling other transaction types in the explorer transaction transforms.

**Notes to reviewers**

**How has it been tested?**

Manually on the three support tickets.

**Does this PR add a new token to the bridge?**

- [ ] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
