### PR TITLE
Add LegacyERC20ETH contract addresses to Base contracts

### DIFF
--- a/apps/base-docs/docs/building-with-base/base-contracts.md
+++ b/apps/base-docs/docs/building-with-base/base-contracts.md
@@ -40,6 +40,7 @@ keywords:
 | L1FeeVault                    | [0x420000000000000000000000000000000000001a](https://basescan.org/address/0x420000000000000000000000000000000000001a) |
 | EAS                           | [0x4200000000000000000000000000000000000021](https://basescan.org/address/0x4200000000000000000000000000000000000021) |
 | EASSchemaRegistry             | [0x4200000000000000000000000000000000000020](https://basescan.org/address/0x4200000000000000000000000000000000000020) |
+| LegacyERC20ETH                | [0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000](https://basescan.org/address/0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000) |
 
 ### Base Testnet (Sepolia)
 
@@ -60,6 +61,7 @@ keywords:
 | L1FeeVault                    | [0x420000000000000000000000000000000000001a](https://sepolia.basescan.org/address/0x420000000000000000000000000000000000001a) |
 | EAS                           | [0x4200000000000000000000000000000000000021](https://sepolia.basescan.org/address/0x4200000000000000000000000000000000000021) |
 | EASSchemaRegistry             | [0x4200000000000000000000000000000000000020](https://sepolia.basescan.org/address/0x4200000000000000000000000000000000000020) |
+| LegacyERC20ETH                | [0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000](https://sepolia.basescan.org/address/0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000) |
 
 \*_L2 contract addresses are the same on both mainnet and testnet._
 


### PR DESCRIPTION
**What changed? Why?**

Add [LegacyERC20ETH](https://basescan.org/address/0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000) contract address for [Base Mainnet](https://docs.base.org/base-contracts#base-mainnet) and [Base Testnet (Sepolia)](https://docs.base.org/base-contracts#base-testnet-sepolia) in the documentation. 

**Notes to reviewers**
This address [is in the Optimism docs](https://docs.optimism.io/chain/addresses#op-mainnet-l2), but was missing from Base documentation

**How has it been tested?**

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.

![image](https://github.com/base-org/web/assets/116569704/1a767ab4-589a-4e2b-afe9-01d08e812f1c)

