### PR TITLE
fix(docs): ensure code blocks use monofont

### DIFF
--- a/apps/base-docs/src/css/fonts.css
+++ b/apps/base-docs/src/css/fonts.css
@@ -35,7 +35,7 @@
   font-family: CoinbaseMono;
   font-style: normal;
   font-weight: 400;
-  src: url('/static/fonts/CoinbaseText-Regular.woff2') format('woff2');
+  src: url('/static/fonts/CoinbaseMono-Regular.woff2') format('woff2');
 }
 
 @font-face {
@@ -43,7 +43,7 @@
   font-family: CoinbaseMono;
   font-style: normal;
   font-weight: 500;
-  src: url('/static/fonts/CoinbaseText-Medium.woff2') format('woff2');
+  src: url('/static/fonts/CoinbaseMono-Medium.woff2') format('woff2');
 }
 
 @font-face {


### PR DESCRIPTION
**What changed? Why?**

- Resolves #259
- Incorrect font file was referenced in `fonts.css` causing code blocks to render fonts in `sans-serif`

**Screenshots**

|Before|After|
|---|---|
|![before](https://github.com/base-org/web/assets/12480362/956bde6a-9ac0-4286-a4e6-01072f141f98)|![after](https://github.com/base-org/web/assets/12480362/99cf041e-0306-4def-8f02-164aae79bc3e)|

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20