### PR TITLE
Add warning banner on Transactions page

### DIFF
--- a/apps/bridge/pages/transactions.tsx
+++ b/apps/bridge/pages/transactions.tsx
@@ -1,5 +1,6 @@
 import { memo, useMemo, useState } from 'react';
 import { AccountContainer } from 'apps/bridge/src/components/AccountContainer/AccountContainer';
+import { WarningBanner } from 'apps/bridge/src/components/WarningBanner/WarningBanner';
 import { FaqSidebar } from 'apps/bridge/src/components/Faq/FaqSidebar';
 import { Table } from 'apps/bridge/src/components/system/layout/Table/Table';
 import { DepositRow } from 'apps/bridge/src/components/Transactions/DepositRow/DepositRow';
@@ -162,6 +163,7 @@ export default memo(function Transactions() {
       <Head>
         <title>Base</title>
       </Head>
+      <WarningBanner content="Transactions may take a few minutes to appear" />
       <AccountContainer>
         <>
           <div className="grow">{content}</div>

--- a/apps/bridge/src/components/WarningBanner/WarningBanner.tsx
+++ b/apps/bridge/src/components/WarningBanner/WarningBanner.tsx
@@ -1,0 +1,16 @@
+import Image from 'next/image';
+
+type BannerContainerProps = {
+  content: string;
+};
+
+export function WarningBanner({ content }: BannerContainerProps) {
+  return (
+    <div className="flex-col border-t border-sidebar-border bg-[#0A0B0D] px-0 font-sans text-white ">
+      <div className="flex items-center bg-warning-banner-red p-3">
+        <Image alt="tooltip" src="/icons/alert.svg" width={16} height={16} />
+        <span className="ml-2">{content}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/bridge/tailwind.config.js
+++ b/apps/bridge/tailwind.config.js
@@ -20,6 +20,7 @@ module.exports = {
         'cds-background-green-60': 'rgba(39, 173, 117, 1)',
         'cds-background-red-60': 'rgba(240, 97, 109, 1)',
         'cds-background-wash': 'rgba(0, 16, 51, 1)',
+        'warning-banner-red': 'rgba(47, 5, 5, 1)',
         gray: '#1E2025',
         modal: '#464B55',
       },


### PR DESCRIPTION
**What changed? Why?**
Adds a banner to the Transaction page indicating that transactions may take a few minutes to appear

**Notes to reviewers**

**How has it been tested?**
manual inspection
<img width="1138" alt="Screenshot 2024-02-08 at 11 40 54 AM" src="https://github.com/base-org/web/assets/5298503/1298e3f4-eb1d-4ffc-810f-b4d5ba71e88a">

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
