### PR TITLE
Update deploy-smart-contracts.mdx

### DIFF
--- a/apps/base-docs/docs/building-with-base/guides/deploy-smart-contracts.mdx
+++ b/apps/base-docs/docs/building-with-base/guides/deploy-smart-contracts.mdx
@@ -75,7 +75,7 @@ npm install --save-dev hardhat
 To create a new Hardhat project, run:
 
 ```bash
-npx hardhat
+npx hardhat init
 ```
 
 Select `Create a TypeScript project` then press _enter_ to confirm the project root.
@@ -149,7 +149,7 @@ npm install --save-dev dotenv
 Once you have `dotenv` installed, you can create a `.env` file with the following content:
 
 ```
-WALLET_KEY=<YOUR_PRIVATE_KEY>
+WALLET_KEY="<YOUR_PRIVATE_KEY>"
 ```
 
 Substituting `<YOUR_PRIVATE_KEY>` with the private key for your wallet.


### PR DESCRIPTION
Update 'npx hardhat' initialization and .env file syntax in docs

This commit updates the documentation to replace the deprecated 'npx hardhat' command with 'npx hardhat init' for project initialization to align with current Hardhat recommendations. It also modifies the .env file syntax suggestion to include quotes around the WALLET_KEY value, ensuring correct string parsing and preventing potential parsing issues. These changes aim to improve clarity and adherence to best practices for new users setting up Hardhat projects.

**What changed? Why?**
- Replaced the deprecated `npx hardhat` command with the recommended `npx hardhat init` for initializing new Hardhat projects in the documentation. This change aligns the guide with the latest Hardhat practices and ensures users are not using deprecated methods for project setup.
  
- Updated the `.env` file syntax recommendation to include quotes around the `WALLET_KEY` value. This adjustment is to ensure that the environment variable is correctly parsed as a string, especially important for private keys that might contain characters that could be misinterpreted by the parsing mechanism.

**Notes to reviewers**
https://github.com/base-org/web/issues/309

**How has it been tested?**
Tested the changes locally to verify they work when following the tutorial. 

**Does this PR add a new token to the bridge?**
No. 

- [ X] No, this PR does not add a new token to the bridge
- [ X] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
