### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,15 +21,15 @@ This project and everyone participating in it are governed by our [Code of Condu
 
 ### Reporting Bugs
 
-1. **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/base-org/web/issues).
+1. **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/web/web/issues).
 
 2. If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/base-org/web/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
 
 ### Suggesting Enhancements
 
-1. **Check the [Issues](https://github.com/base-org/base/issues)** to see if there's someone who has already suggested the same enhancement.
+1. **Check the [Issues](https://github.com/base-org/web/issues)** to see if there's someone who has already suggested the same enhancement.
 
-2. If it doesn't exist, [create a new issue](https://github.com/base-org/base/issues/new). Provide a clear and detailed explanation of the feature you want and why it's important to add.
+2. If it doesn't exist, [create a new issue](https://github.com/base-org/web/issues/new). Provide a clear and detailed explanation of the feature you want and why it's important to add.
 
 ### Pull Requests
 


### PR DESCRIPTION
Fix incorrect issue links in CONTRIBUTING.md

This commit updates the 'Suggesting Enhancements' section of the CONTRIBUTING.md file to correct the issue and new issue links. Previously pointing to the base-org/base repository, these links have been corrected to direct contributors to the base-org/web repository's issue tracker. This change ensures that contributors are guided to the correct location for reporting issues or suggesting enhancements for Base.

**What changed? Why?**
_What_
Updated incorrect issue tracker links in the CONTRIBUTING.md document. The links for "Suggesting Enhancements" now correctly point to the base-org/web repository instead of base-org/base.

_Why_
To direct contributors to the correct repository for reporting issues and suggesting enhancements, ensuring contributions are accurately tracked and addressed for the Base Web project. This minor but crucial correction facilitates a smoother contribution process.

**Notes to reviewers**
https://github.com/base-org/web/issues/311

**How has it been tested?**
Verify the links were correct. 

**Does this PR add a new token to the bridge?**
No. 

- [ X] No, this PR does not add a new token to the bridge
- [X ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
