### PR TITLE
Update using-pyth-price-feeds.md

### DIFF
--- a/apps/base-docs/docs/building-with-base/guides/using-pyth-price-feeds.md
+++ b/apps/base-docs/docs/building-with-base/guides/using-pyth-price-feeds.md
@@ -114,7 +114,7 @@ forge install pyth-network/pyth-sdk-solidity@v2.2.0 --no-git --no-commit
 Once installed, update your `foundry.toml` file by appending the following line:
 
 ```bash
-remappings = ['@pythnetwork/pyth-sdk-solidity/=lib/pyth-sdk-solidity’]
+remappings = ['@pythnetwork/pyth-sdk-solidity/=lib/pyth-sdk-solidity']
 ```
 
 ---


### PR DESCRIPTION
This commit updates the tutorial documentation on using Pyth Price Feeds with Foundry to fix a TOML parse error encountered by users when setting up the foundry.toml file. The issue was identified in the "Installing Pyth smart contracts" section, where mismatched quotation marks in the remappings line caused a parse error. The original line used inconsistent quotes.

The fix involves correcting the quotation marks to ensure consistency, thereby preventing the TOML parse error: `remappings = ['@pythnetwork/pyth-sdk-solidity/=lib/pyth-sdk-solidity']`

**What changed? Why?**
This commit updates the tutorial documentation on using Pyth Price Feeds with Foundry to fix a TOML parse error encountered by users when setting up the foundry.toml file. The issue was identified in the "Installing Pyth smart contracts" section, where mismatched quotation marks in the remappings line caused a parse error. The original line used inconsistent quotes.

The fix involves correcting the quotation marks to ensure consistency, thereby preventing the TOML parse error: `remappings = ['@pythnetwork/pyth-sdk-solidity/=lib/pyth-sdk-solidity']`

**Notes to reviewers**
https://github.com/base-org/web/issues/313

**How has it been tested?**
Verify that forge build works with implemented fix. 

**Does this PR add a new token to the bridge?**
No. 

- [X ] No, this PR does not add a new token to the bridge
- [ X] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
