### PR TITLE
Add a more obvious button to the transaction page within withdraw flow

### DIFF
--- a/apps/bridge/src/components/WithdrawProgressBar/WithdrawProgressBar.tsx
+++ b/apps/bridge/src/components/WithdrawProgressBar/WithdrawProgressBar.tsx
@@ -51,15 +51,20 @@ const BarStatusToBadgeStatuses: Record<BarStatus, BadgeStatus[]> = {
 
 const DisclaimerContent: Record<BarStatus, ReactNode> = {
   REQUEST_SENT: (
-    <>
-      In order to minimize security risk, withdrawals using the official Base Bridge take up to{' '}
-      {challengeWindow}. After your withdrawal request is proposed onchain (within an hour) you must
-      verify and complete the transaction in order to access your funds, on{' '}
-      <Link href="/transactions" className="underline">
-        the transactions page
+    <div className="flex flex-col">
+      <p>
+        In order to minimize security risk, withdrawals using the official Base Bridge take up to{' '}
+        {challengeWindow}. After your withdrawal request is proposed onchain (within an hour) you
+        must verify and complete the transaction in order to access your funds, on{' '}
+        <Link href="/transactions" className="underline">
+          the transactions page
+        </Link>
+        .
+      </p>
+      <Link href="/transactions" className="mt-4 rounded-md bg-white p-4 text-black">
+        Go to Transactions
       </Link>
-      .
-    </>
+    </div>
   ),
   VERIFYING: (
     <>
@@ -93,7 +98,7 @@ export function WithdrawProgressBar({ status }: WithdrawProgressBarProps) {
           <span>Takes up to 1 hr</span>
         </div>
       </div>
-      <span className="font-base">{DisclaimerContent[status]}</span>
+      <div className="font-base">{DisclaimerContent[status]}</div>
       <span className="text-white underline">
         <Link href="https://docs.base.org/tools/bridge-faq">Learn more</Link>
       </span>


### PR DESCRIPTION
**What changed? Why?**

Adding a big ole button to the Transaction page during the withdraw flow to hopefully help people notice the existence of that page.

<img width="604" alt="Screenshot 2024-02-09 at 10 51 18 AM" src="https://github.com/base-org/web/assets/1297679/7d02a993-64a1-477f-9816-e0bf67909727">


**Notes to reviewers**

**How has it been tested?**

Manually.

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
