### PR TITLE
Update nft-minting-frame.md

### DIFF
--- a/apps/base-docs/docs/building-with-base/guides/nft-minting-frame.md
+++ b/apps/base-docs/docs/building-with-base/guides/nft-minting-frame.md
@@ -569,7 +569,7 @@ In this tutorial, you learned how to create [Farcaster] frames. You then updated
 [Vercel]: https://vercel.com
 [Frame Validator]: https://warpcast.com/~/developers/frames
 [Base channel]: https://warpcast.com/~/channel/base
-[Complex Onchain NFTs]: https://https://docs.base.org/building-with-base/guides/complex-onchain-nfts
+[Complex Onchain NFTs]: https://docs.base.org/building-with-base/guides/complex-onchain-nfts
 [Frames]: https://warpcast.notion.site/Farcaster-Frames-4bd47fe97dc74a42a48d3a234636d8c5
 [viem]: https://viem.sh/
 [Basescan]: https://basescan.org/


### PR DESCRIPTION
Corrected the malformed URL for the Complex Onchain NFTs guide in the documentation. Removed the extra "https://" prefix to ensure the link is functional and users can successfully navigate to the guide.

Before: https://https://docs.base.org/building-with-base/guides/complex-onchain-nfts

After: https://docs.base.org/building-with-base/guides/complex-onchain-nfts

This minor documentation fix enhances navigability and user experience.

**What changed? Why?**
Corrected the malformed URL for the Complex Onchain NFTs guide in the documentation. Removed the extra "https://" prefix to ensure the link is functional and users can successfully navigate to the guide.

Before: https://https://docs.base.org/building-with-base/guides/complex-onchain-nfts

After: https://docs.base.org/building-with-base/guides/complex-onchain-nfts

This minor documentation fix enhances navigability and user experience.

**Notes to reviewers**
https://github.com/base-org/web/issues/318

**How has it been tested?**
Verify the new link works. 

**Does this PR add a new token to the bridge?**
No. 

- [ X] No, this PR does not add a new token to the bridge
- [X ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
