### PR TITLE
Add a basic Frame to base.org

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@coinbase/cookie-banner": "^1.0.3",
     "@coinbase/cookie-manager": "^1.1.1",
+    "@coinbase/onchainkit": "^0.6.0",
     "@heroicons/react": "^2.0.18",
     "@next/font": "^13.1.5",
     "ethers": "5.7.2",

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -9,6 +9,7 @@ import { Features } from '../src/components/Features/Features';
 import { Hero } from '../src/components/Home/Hero';
 import { JoinTheCommunity } from '../src/components/JoinTheCommunity/JoinTheCommunity';
 import { Partnerships } from '../src/components/Partnerships/Partnerships';
+import { FrameMetadata } from '@coinbase/onchainkit';
 
 export default function Home() {
   return (
@@ -40,6 +41,22 @@ export default function Home() {
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
       </Head>
+      <FrameMetadata
+        buttons={[
+          {
+            action: 'link',
+            label: 'Read the docs',
+            target: 'https://docs.base.org/',
+          },
+          {
+            action: 'link',
+            label: 'Bridge assets',
+            target: 'https://bridge.base.org/deposit',
+          },
+        ]}
+        image="https://base.org/images/base-open-graph.png"
+        wrapper={Head}
+      />
       <Hero />
       <main className="flex w-full flex-col items-center bg-black">
         <Divider />

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,6 +286,7 @@ __metadata:
   dependencies:
     "@coinbase/cookie-banner": ^1.0.3
     "@coinbase/cookie-manager": ^1.1.1
+    "@coinbase/onchainkit": ^0.6.0
     "@heroicons/react": ^2.0.18
     "@next/font": ^13.1.5
     "@types/node": 18.11.18
@@ -2128,6 +2129,17 @@ __metadata:
     "@coinbase/cookie-manager": 1.1.0
     js-cookie: ^3.0.5
   checksum: 20a67646cf1f37a1db0eb0b2e2e6989f6f34b1a4881d81dead1829b44fe7400f2acf2ebdf2da049ce9804fca4b6f07e6b71b9fe44ffe01c231c1c95f01ea466a
+  languageName: node
+  linkType: hard
+
+"@coinbase/onchainkit@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@coinbase/onchainkit@npm:0.6.0"
+  peerDependencies:
+    react: ^18
+    react-dom: ^18
+    viem: ^2.7.0
+  checksum: 26d2d26b19c609a87176008a8062b4f9ba7144bf0e844deadda800b4fcd1ca3aeb4e6cb1b359b8a7ee2e1b5a830e903ccb896f2b82757e56c1c3124e93215dff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What changed? Why?**
Add basic Farcaster Frame for base.org.

Displays same image as OpenGraph / Twitter (for now)
Displays two buttons (same ones as homepage):
- Read the docs - link to docs
- Bridge assets - link to bridge

**Notes to reviewers**
N/A

**How has it been tested?**
Manually

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
