### PR TITLE
Add Sepolia RPC and Walletconnect verify to CSP

### DIFF
--- a/apps/base-docs/server.js
+++ b/apps/base-docs/server.js
@@ -69,11 +69,12 @@ const contentSecurityPolicy = {
     'wss://relay.walletconnect.com', // WalletConnect
     'wss://relay.walletconnect.org',
     'https://goerli.base.org', // Base Goerli RPC
+    'https://sepolia.base.org', // Base Sepolia RPC
     'https://cca-lite.coinbase.com', // CCA Lite
     'https://*.algolia.net', // Algolia Search
     'https://*.algolianet.com', // Algolia Search
   ],
-  'frame-src': ["'self'", 'https://player.vimeo.com'],
+  'frame-src': ["'self'", 'https://player.vimeo.com', 'https://verify.walletconnect.org'],
 };
 
 const cspObjectToString = Object.entries(contentSecurityPolicy).reduce((acc, [key, value]) => {


### PR DESCRIPTION
**What changed? Why?**
Add Sepolia RPC and Walletconnect verify to Content Security Policy to fix Base Camp App:

![image](https://github.com/base-org/web/assets/123022781/26a46bfd-d02a-4034-bae1-a3df1e16f71e)

**Notes to reviewers**

**How has it been tested?**

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
