### PR TITLE
change positioning of Imports NFT according to issue request

### DIFF
--- a/apps/base-docs/src/components/StudentProgress/index.jsx
+++ b/apps/base-docs/src/components/StudentProgress/index.jsx
@@ -43,10 +43,21 @@ export default function StudentProgress() {
     );
   };
 
+  // Function to render the NFT cards in the desired order (imports after 'inheritance' and before 'errors')
   const renderNFTs = () => {
-    const NFTs = Object.keys(nftData).map((nftNum) => {
+    // Get the sorted NFT keys, excluding key '19' imports
+    const sortedNFTKeys = Object.keys(nftData)
+      .filter((key) => key !== '19')
+      .sort((a, b) => a - b);
+  
+    // Find the index of key '8' and insert key '19' after it
+    const index = sortedNFTKeys.findIndex((key) => key === '8');
+    sortedNFTKeys.splice(index + 1, 0, '19');
+  
+    // Map over the sorted NFT keys and render the NFT cards
+    const NFTs = sortedNFTKeys.map((nftNum) => {
       const nft = nftData[nftNum];
-
+  
       return (
         <NFTCard
           key={nft.deployment.address}
@@ -56,7 +67,7 @@ export default function StudentProgress() {
         />
       );
     });
-
+  
     return NFTs;
   };
 


### PR DESCRIPTION
**What changed? Why?**
- Modified the renderNFTs function in the StudentProgress component to change the order in which the NFTs are displayed, according to issue https://github.com/base-org/web/issues/343#issue-2170026700
- The NFT with key '19' (Imports) is now rendered between the NFTs with keys '8' (Inheritance) and '10' (Errors).
- This change was made to improve the logical flow and grouping of the NFTs based on their topics.
- The rest of the NFTs are still rendered in ascending order based on their keys.

**Notes to reviewers**

Let me know if you have any suggestions or improvements to make the code more readable or efficient. I considered changing the key of Imports from 19 to 9 as there is none, but decided manually changing the order during rendering was safer.

**How has it been tested?**
- The changes have been tested locally by running the application, connecting wallet, and verifying the rendering order of the NFTs in the StudentProgress component.
- Confirmed that the Imports NFT is correctly displayed between the Inheritance and Errors NFTs and all functionality is working. 

**Does this PR add a new token to the bridge?**

- [ x] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
changes were made to docs app