### PR TITLE
Experimentally fix ENV var setup for web

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -11,8 +11,8 @@ COPY . .
 # Install dependencies
 RUN yarn --immutable
 
-RUN yarn workspace @app/web next build
 RUN yarn workspaces focus --all --production
 
 EXPOSE 3000
-CMD ["yarn", "workspace", "@app/web", "start", "-p", "3000"]
+# Build at runtime so that we get ENV variables, this allows us to use [Automatic Static Optimization](https://nextjs.org/docs/pages/building-your-application/rendering/automatic-static-optimization)
+CMD ["/bin/bash", "-c", "yarn workspace @app/web next build ; yarn workspace @app/web start -p 3000"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -11,8 +11,6 @@ COPY . .
 # Install dependencies
 RUN yarn --immutable
 
-RUN yarn workspaces focus --all --production
-
 EXPOSE 3000
 # Build at runtime so that we get ENV variables, this allows us to use [Automatic Static Optimization](https://nextjs.org/docs/pages/building-your-application/rendering/automatic-static-optimization)
 CMD ["/bin/bash", "-c", "yarn workspace @app/web next build ; yarn workspace @app/web start -p 3000"]

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -111,15 +111,6 @@ const securityHeaders = [
 ];
 
 module.exports = extendBaseConfig({
-  publicRuntimeConfig: {
-    nodeEnv: process.env.NODE_ENV,
-    docsUrl: process.env.DOCS_URL ?? 'https://docs.base.org',
-    bridgeUrl: process.env.BRIDGE_URL ?? 'https://bridge.base.org',
-    greenhouseApiUrl: process.env.GREENHOUSE_HTTPS ?? 'https://boards-api.greenhouse.io/v1',
-    mainnetLaunchBlogPostURL:
-      process.env.MAINNET_LAUNCH_BLOG_POST_URL ?? 'https://base.mirror.xyz/',
-    mainnetLaunchFlag: process.env.MAINNET_LAUNCH_FLAG ?? 'false',
-  },
   i18n: {
     locales: ['en'],
     defaultLocale: 'en',

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -1,7 +1,7 @@
 import './global.css';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import App, { AppContext, AppProps } from 'next/app';
+import { AppProps } from 'next/app';
 import { MotionConfig } from 'framer-motion';
 import {
   Provider as CookieManagerProvider,
@@ -14,13 +14,6 @@ import { Layout } from '../src/components/Layout/Layout';
 import ClientAnalyticsScript from '../src/components/ClientAnalyticsScript/ClientAnalyticsScript';
 
 import { cookieManagerConfig } from '../src/utils/cookieManagerConfig';
-
-/* Adding this to force NextJS to render the app on the server at runtime instead of statically
-which allows us to use ENV vars in the way we expect (Codeflow does not insert ENV vars at Dockerfile build time, so statically rendered pages don't have access) */
-export async function getInitialProps(context: AppContext) {
-  const appProps = await App.getInitialProps(context);
-  return appProps;
-}
 
 export default function StaticApp({ Component, pageProps }: AppProps) {
   // Cookie Manager Provider Configuration
@@ -79,5 +72,3 @@ export default function StaticApp({ Component, pageProps }: AppProps) {
     </CookieManagerProvider>
   );
 }
-
-StaticApp.getInitialProps = getInitialProps;

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -9,9 +9,26 @@ import { Features } from '../src/components/Features/Features';
 import { Hero } from '../src/components/Home/Hero';
 import { JoinTheCommunity } from '../src/components/JoinTheCommunity/JoinTheCommunity';
 import { Partnerships } from '../src/components/Partnerships/Partnerships';
-import { FrameMetadata } from '@coinbase/onchainkit';
+import { FrameButtonMetadata, FrameMetadata } from '@coinbase/onchainkit';
+import { useMemo } from 'react';
 
 export default function Home() {
+  const buttons: [FrameButtonMetadata, ...FrameButtonMetadata[]] = useMemo(
+    () => [
+      {
+        action: 'link',
+        label: 'Read the docs',
+        target: 'https://docs.base.org/',
+      },
+      {
+        action: 'link',
+        label: 'Bridge assets',
+        target: 'https://bridge.base.org/deposit',
+      },
+    ],
+    [],
+  );
+
   return (
     <>
       <Head>
@@ -42,18 +59,7 @@ export default function Home() {
         <meta property="og:image:height" content="630" />
       </Head>
       <FrameMetadata
-        buttons={[
-          {
-            action: 'link',
-            label: 'Read the docs',
-            target: 'https://docs.base.org/',
-          },
-          {
-            action: 'link',
-            label: 'Bridge assets',
-            target: 'https://bridge.base.org/deposit',
-          },
-        ]}
+        buttons={buttons}
         image="https://base.org/images/base-open-graph.png"
         wrapper={Head}
       />

--- a/apps/web/pages/jobs.tsx
+++ b/apps/web/pages/jobs.tsx
@@ -1,13 +1,9 @@
 import { JobsList, JobType } from 'apps/web/src/components/Jobs/JobsList';
-import getConfig from 'next/config';
 import Head from 'next/head';
-
-const { publicRuntimeConfig } = getConfig();
+import { greenhouseApiUrl } from 'apps/web/src/constants';
 
 export async function getServerSideProps() {
-  const res = await fetch(
-    `${publicRuntimeConfig.greenhouseApiUrl}/boards/basejobs/jobs?content=true`,
-  );
+  const res = await fetch(`${greenhouseApiUrl}/boards/basejobs/jobs?content=true`);
   const { jobs } = (await res.json()) as { jobs: JobType[] };
   return {
     props: {
@@ -31,7 +27,7 @@ export default function Jobs({ jobs }: JobsProps) {
         />
       </Head>
       <main className="mt-[-96px] flex w-full grow flex-col items-center bg-black">
-        <section className="mt-[100px] mb-[140px] flex w-full max-w-[1440px] flex-col px-8 pb-10 sm:mt-[150px]">
+        <section className="mb-[140px] mt-[100px] flex w-full max-w-[1440px] flex-col px-8 pb-10 sm:mt-[150px]">
           <h1 className="font-display text-3xl text-white md:text-4xl lg:basis-1/2 lg:text-5xl">
             Join our team
           </h1>

--- a/apps/web/src/components/Home/Hero.tsx
+++ b/apps/web/src/components/Home/Hero.tsx
@@ -2,10 +2,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { Button } from 'apps/web/src/components/Button/Button';
 import { gradientBgMap, textGradientMap, Verb, verbs } from 'apps/web/src/styles/hero';
 import { motion, useReducedMotion } from 'framer-motion';
-import getConfig from 'next/config';
 import Link from 'next/link';
-
-const { publicRuntimeConfig } = getConfig();
+import { bridgeUrl, docsUrl } from 'apps/web/src/constants';
 
 const subtitleCopy =
   'Base is a secure, low-cost, builder-friendly Ethereum L2 built to bring the next billion users onchain.';
@@ -113,19 +111,10 @@ export function Hero() {
             </p>
             <div className="flex flex-col space-y-6">
               <div className="flex flex-col items-center gap-2 pt-7 md:flex-row">
-                <Link
-                  className="w-full"
-                  href={publicRuntimeConfig.docsUrl}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
+                <Link className="w-full" href={docsUrl} target="_blank" rel="noreferrer noopener">
                   <Button className="w-full">Read the docs</Button>
                 </Link>
-                <Link
-                  className="w-full"
-                  href={publicRuntimeConfig.bridgeUrl}
-                  rel="noreferrer noopener"
-                >
+                <Link className="w-full" href={bridgeUrl} rel="noreferrer noopener">
                   <Button className="w-full" variant="secondary">
                     Bridge assets
                   </Button>

--- a/apps/web/src/components/Layout/Footer/Footer.tsx
+++ b/apps/web/src/components/Layout/Footer/Footer.tsx
@@ -1,12 +1,10 @@
 import { useState, useCallback } from 'react';
-import getConfig from 'next/config';
 import Link from 'next/link';
 import { CookiePreferencesModal } from '@coinbase/cookie-banner';
 
 import { Icon } from '../../Icon/Icon';
 import { Logo } from '../../Logo/Logo';
-
-const { publicRuntimeConfig } = getConfig();
+import { bridgeUrl, docsUrl } from 'apps/web/src/constants';
 
 export function Footer() {
   const [isOpen, setIsOpen] = useState(false);
@@ -68,7 +66,7 @@ export function Footer() {
               <span className="font-mono text-xl text-white">About</span>
             </Link>
             <a
-              href={publicRuntimeConfig.docsUrl}
+              href={docsUrl}
               className="font-mono text-xl text-white"
               target="_blank"
               rel="noreferrer noopener"
@@ -76,7 +74,7 @@ export function Footer() {
               Docs
             </a>
             <a
-              href={publicRuntimeConfig.bridgeUrl}
+              href={bridgeUrl}
               className="font-mono text-xl text-white"
               target="_blank"
               rel="noreferrer noopener"

--- a/apps/web/src/components/Layout/Nav/DesktopNav.tsx
+++ b/apps/web/src/components/Layout/Nav/DesktopNav.tsx
@@ -1,13 +1,11 @@
 import React, { useState, useCallback } from 'react';
 import { AnimatePresence, motion, cubicBezier } from 'framer-motion';
-import getConfig from 'next/config';
 import Link from 'next/link';
 
 import useClickAway from '../../../utils/hooks/useClickAway';
 
 import { Icon } from '../../Icon/Icon';
-
-const { publicRuntimeConfig } = getConfig();
+import { bridgeUrl, docsUrl } from 'apps/web/src/constants';
 
 // Dropdown Link
 type DropdownLinkProps = {
@@ -111,7 +109,7 @@ function DesktopNav({ color }: DesktopNavProps) {
           />
         </Dropdown>
         <a
-          href={publicRuntimeConfig.bridgeUrl}
+          href={bridgeUrl}
           className={`inline-flex items-center font-mono text-xl ${
             color === 'black' ? 'text-black' : 'text-white'
           }`}
@@ -121,12 +119,7 @@ function DesktopNav({ color }: DesktopNavProps) {
           Bridge
         </a>
         <Dropdown label="Developers" color={color}>
-          <DropdownLink
-            href={publicRuntimeConfig.docsUrl}
-            label="Docs"
-            color={color}
-            externalLink
-          />
+          <DropdownLink href={docsUrl} label="Docs" color={color} externalLink />
           <DropdownLink
             href="https://basescan.org"
             label="Block Explorer"

--- a/apps/web/src/components/Layout/Nav/MobileMenu.tsx
+++ b/apps/web/src/components/Layout/Nav/MobileMenu.tsx
@@ -1,13 +1,11 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { AnimatePresence, motion, cubicBezier } from 'framer-motion';
-import getConfig from 'next/config';
 import Link from 'next/link';
 
 import { Icon } from '../../Icon/Icon';
 import { Logo } from '../../Logo/Logo';
 import { usePathname } from 'next/navigation';
-
-const { publicRuntimeConfig } = getConfig();
+import { bridgeUrl } from 'apps/web/src/constants';
 
 // Dropdown Link
 type DropdownLinkProps = {
@@ -183,7 +181,7 @@ function MobileMenu({ color }: MobileMenuProps) {
                   />
                 </Dropdown>
                 <a
-                  href={publicRuntimeConfig.bridgeUrl}
+                  href={bridgeUrl}
                   className="inline-flex items-center font-mono text-3xl text-white hover:underline"
                   target="_blank"
                   rel="noreferrer noopener"

--- a/apps/web/src/components/StartBuildingOnBase/StartBuildingOnBase.tsx
+++ b/apps/web/src/components/StartBuildingOnBase/StartBuildingOnBase.tsx
@@ -1,14 +1,12 @@
 import { Button } from 'apps/web/src/components/Button/Button';
-import getConfig from 'next/config';
+import { docsUrl } from 'apps/web/src/constants';
 import Image from 'next/image';
 import Link from 'next/link';
-
-const { publicRuntimeConfig } = getConfig();
 
 function ReadTheDocsButton() {
   return (
     <div className="w-[200px]">
-      <Link href={publicRuntimeConfig.docsUrl} target="_blank" rel="noreferrer noopener">
+      <Link href={docsUrl} target="_blank" rel="noreferrer noopener">
         <Button variant="primary">Read the docs</Button>
       </Link>
     </div>

--- a/apps/web/src/constants.ts
+++ b/apps/web/src/constants.ts
@@ -1,0 +1,9 @@
+export const nodeEnv = process.env.NODE_ENV;
+export const docsUrl = process.env.DOCS_URL ?? 'https://docs.base.org';
+export const bridgeUrl = process.env.BRIDGE_URL ?? 'https://bridge.base.org';
+export const greenhouseApiUrl =
+  process.env.GREENHOUSE_HTTPS ?? 'https://boards-api.greenhouse.io/v1';
+export const mainnetLaunchBlogPostURL =
+  process.env.MAINNET_LAUNCH_BLOG_POST_URL ?? 'https://base.mirror.xyz/';
+export const mainnetLaunchFlag = process.env.MAINNET_LAUNCH_FLAG ?? 'false';
+export const isDevelopment = nodeEnv === 'development';

--- a/apps/web/src/utils/initCCA.ts
+++ b/apps/web/src/utils/initCCA.ts
@@ -2,13 +2,10 @@
 // They recommended disabling linting and type-checking for now, since this version is not typed.
 /* eslint-disable */
 // @ts-nocheck
-import getConfig from 'next/config';
 import { NextRouter } from 'next/router';
 import { TrackingPreference } from '@coinbase/cookie-manager';
 import { uuid } from 'uuidv4';
-
-const { publicRuntimeConfig } = getConfig();
-const isDevelopment = publicRuntimeConfig.nodeEnv === 'development';
+import { isDevelopment } from 'apps/web/src/constants';
 
 // CCA library loads in ClientAnalyticsScript component
 const initCCA = (


### PR DESCRIPTION
**What changed? Why?**

This cleans up the way we get ENV vars, enabling us to use [Automatic Static Optimization](https://nextjs.org/docs/pages/building-your-application/rendering/automatic-static-optimization) to improve performance. It also looks cleaner because we don't have to import `getConfig` everywhere just to use an ENV var.

**Notes to reviewers**

**How has it been tested?**

Tested on a development deployment.

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
