### PR TITLE
Improve Base Camp Invalid chain ID error (#349)

### DIFF
--- a/apps/base-docs/src/utils/nft-exercise-data.js
+++ b/apps/base-docs/src/utils/nft-exercise-data.js
@@ -156,7 +156,7 @@ function useNFTData() {
       deployments = baseSepoliaDeployments;
       break;
     default:
-      throw new Error(`Invalid chain ID: ${chain?.id}`);
+      throw new Error(`Unsupported network (Chain ID: ${chain?.id}). Please connect to Base Sepolia.`);
       break;
   }
 


### PR DESCRIPTION
**What changed? Why?**
- The error message displayed when connecting to the wrong network while tracking progress with Base Camp has been updated.
- The previous error message was not clear and informative enough, lacking guidance for users on how to resolve the issue.
- The updated error message now clearly communicates that the user is connected to an unsupported network, provides the specific chain ID, and instructs them to connect to the Base Sepolia network.

**Notes to reviewers**
- Please review the updated error message in the useNFTData function in the nft-exercise-data.js file.
- Ensure that the error message is clear, concise, and actionable, guiding users to switch to the Base Sepolia network.
- Consider any additional feedback or suggestions to further improve the user experience.

**How has it been tested?**
- The changes have been tested locally by intentionally connecting to an unsupported network and verifying that the new error message is displayed correctly.
- The specific chain ID of the unsupported network is included in the error message.
- The error message instructs the user to connect to the Base Sepolia network.

**Does this PR add a new token to the bridge?**

- [X] No, this PR does not add a new token to the bridge
- [X] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
