### PR TITLE
Fixing URLs throughout Building with Base Guides (#353)

### DIFF
--- a/apps/base-docs/docs/building-with-base/guides/advanced-frame-behavior.md
+++ b/apps/base-docs/docs/building-with-base/guides/advanced-frame-behavior.md
@@ -285,8 +285,8 @@ In this tutorial, you learned how to use the newest features of Frames - text in
 [Vercel]: https://vercel.com
 [Frame Validator]: https://warpcast.com/~/developers/frames
 [Base channel]: https://warpcast.com/~/channel/base
-[deploying with Vercel]: ./deploy-frame-on-vercel
-[NFT Minting Frame]: ./nft-minting-frame
+[deploying with Vercel]: /building-with-base/guides/deploy-frame-on-vercel
+[NFT Minting Frame]: /building-with-base/guides/nft-minting-frame
 [Frames]: https://warpcast.notion.site/Farcaster-Frames-4bd47fe97dc74a42a48d3a234636d8c5
 [viem]: https://viem.sh/
 [Basescan]: https://basescan.org/

--- a/apps/base-docs/docs/building-with-base/guides/deploy-frame-on-vercel.md
+++ b/apps/base-docs/docs/building-with-base/guides/deploy-frame-on-vercel.md
@@ -148,7 +148,7 @@ In this tutorial, you learned how to set up [Vercel]
 [Vercel]: https://vercel.com
 [Frame Validator]: https://warpcast.com/~/developers/frames
 [Base channel]: https://warpcast.com/~/channel/base
-[Complex Onchain NFTs]: https://https://docs.base.org/building-with-base/guides/complex-onchain-nfts
+[Complex Onchain NFTs]: /building-with-base/guides/complex-onchain-nfts
 [Frames]: https://warpcast.notion.site/Farcaster-Frames-4bd47fe97dc74a42a48d3a234636d8c5
 [viem]: https://viem.sh/
 [Basescan]: https://basescan.org/

--- a/apps/base-docs/docs/building-with-base/guides/hyperframes.md
+++ b/apps/base-docs/docs/building-with-base/guides/hyperframes.md
@@ -367,10 +367,10 @@ In this tutorial, you learned how to implement a system of hyperframes - frames 
 [OnchainKit]: https://github.com/coinbase/onchainkit
 [Vercel]: https://vercel.com
 [Frame Validator]: https://warpcast.com/~/developers/frames
-[deploying with Vercel]: ./deploy-frame-on-vercel
+[deploying with Vercel]: /building-with-base/guides/deploy-frame-on-vercel
 [Frames]: https://docs.farcaster.xyz/learn/what-is-farcaster/frames
 [viem]: https://viem.sh/
-[NFT Minting Frame]: ./nft-minting-frame
+[NFT Minting Frame]: /building-with-base/guides/nft-minting-frame
 [old-school adventure game]: https://warpcast.com/briandoyle81/0x108f1cdb
 [query string]: https://en.wikipedia.org/wiki/Query_string
 [changelog]: https://github.com/coinbase/onchainkit/blob/main/CHANGELOG.md

--- a/apps/base-docs/docs/building-with-base/guides/linked-minting-frame.md
+++ b/apps/base-docs/docs/building-with-base/guides/linked-minting-frame.md
@@ -119,7 +119,7 @@ Your simple mint is ready to use on [Farcaster]! Be sure to check out our other 
 In this tutorial, you learned how to make a simple [Frame] on [Farcaster] that is tied to a [mint.fun] NFT mint!
 
 ---
-
+[mint.fun]: https://mint.fun/
 [Farcaster]: https://www.farcaster.xyz/
 [a-frame-in-100-lines]: https://github.com/Zizzamia/a-frame-in-100-lines
 [OnchainKit]: https://github.com/coinbase/onchainkit
@@ -127,6 +127,7 @@ In this tutorial, you learned how to make a simple [Frame] on [Farcaster] that i
 [Frame Validator]: https://warpcast.com/~/developers/frames
 [Base channel]: https://warpcast.com/~/channel/base
 [deploying with Vercel]: /building-with-base/guides/deploy-frame-on-vercel
+[Frame]: https://docs.farcaster.xyz/learn/what-is-farcaster/frames
 [Frames]: https://docs.farcaster.xyz/learn/what-is-farcaster/frames
 [advanced behavior]: /building-with-base/guides/advanced-frame-behavior
 [mint with your own contract]: /building-with-base/guides/nft-minting-frame

--- a/apps/base-docs/docs/building-with-base/guides/linked-minting-frame.md
+++ b/apps/base-docs/docs/building-with-base/guides/linked-minting-frame.md
@@ -126,7 +126,7 @@ In this tutorial, you learned how to make a simple [Frame] on [Farcaster] that i
 [Vercel]: https://vercel.com
 [Frame Validator]: https://warpcast.com/~/developers/frames
 [Base channel]: https://warpcast.com/~/channel/base
-[deploying with Vercel]: ./deploy-frame-on-vercel
+[deploying with Vercel]: /building-with-base/guides/deploy-frame-on-vercel
 [Frames]: https://docs.farcaster.xyz/learn/what-is-farcaster/frames
-[advanced behavior]: ./advanced-frame-behavior
-[mint with your own contract]: ./nft-minting-frame
+[advanced behavior]: /building-with-base/guides/advanced-frame-behavior
+[mint with your own contract]: /building-with-base/guides/nft-minting-frame

--- a/apps/base-docs/docs/building-with-base/guides/linked-minting-frame.md
+++ b/apps/base-docs/docs/building-with-base/guides/linked-minting-frame.md
@@ -119,6 +119,7 @@ Your simple mint is ready to use on [Farcaster]! Be sure to check out our other 
 In this tutorial, you learned how to make a simple [Frame] on [Farcaster] that is tied to a [mint.fun] NFT mint!
 
 ---
+
 [mint.fun]: https://mint.fun/
 [Farcaster]: https://www.farcaster.xyz/
 [a-frame-in-100-lines]: https://github.com/Zizzamia/a-frame-in-100-lines

--- a/apps/base-docs/docs/building-with-base/guides/nft-minting-frame.md
+++ b/apps/base-docs/docs/building-with-base/guides/nft-minting-frame.md
@@ -561,7 +561,7 @@ In this tutorial, you learned how to create [Farcaster] frames. You then updated
 [Vercel]: https://vercel.com
 [Frame Validator]: https://warpcast.com/~/developers/frames
 [Base channel]: https://warpcast.com/~/channel/base
-[Complex Onchain NFTs]: https://docs.base.org/building-with-base/guides/complex-onchain-nfts
+[Complex Onchain NFTs]: /building-with-base/guides/complex-onchain-nfts
 [Frames]: https://warpcast.notion.site/Farcaster-Frames-4bd47fe97dc74a42a48d3a234636d8c5
 [viem]: https://viem.sh/
 [Basescan]: https://basescan.org/


### PR DESCRIPTION
**What changed? Why?**
Opened Issue (#353)
I have updated the relative paths in the markdown files for the Base Guides to ensure they lead to the correct locations when hosted on the production site. The original relative paths, which worked as expected in a local development environment, resulted in incorrect, nested URLs in the production environment, leading to 404 errors. This update changes the relative paths to root-relative paths, ensuring they function correctly in all environments.

**Notes to reviewers**
Please review the changes to ensure that the updated URLs correspond to the actual paths where the documents are located. This update is critical for maintaining the integrity of the documentation and ensuring that users can navigate it without encountering dead links.

I've made corrections to the following files under the `apps/base-docs/docs/building-with-base/guides/` path:

1. `advanced-frame-behavior.md`
2. `deploy-frame-on-vercel.md`
3. `hyperframes.md`
4. `linked-minting-frame.md`
5. `nft-minting-frame.md`

Changes involved updating relative links such as `./deploy-frame-on-vercel` to root-relative links like `/building-with-base/guides/deploy-frame-on-vercel`. This was done to ensure consistent and correct path resolution across both local and production environments.

**How has it been tested?**
The updated paths have been tested in a local development environment to ensure they correctly resolve to the intended documents. Additional testing in a staging or production-like environment is recommended to confirm that the changes resolve the navigation issues observed in production.

**Does this PR add a new token to the bridge?**

- [X] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
