### PR TITLE
fix(discord): Resolve double redirect to invite

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -25,14 +25,6 @@ export function middleware(req: NextRequest) {
     return NextResponse.redirect(url);
   }
 
-  if (url.pathname === '/discord') {
-    url.host = 'discord.gg';
-    url.pathname = '/buildonbase';
-    url.port = '443';
-
-    return NextResponse.redirect(url);
-  }
-
   if (url.pathname === '/blog') {
     url.host = 'base.mirror.xyz';
     url.pathname = '/';

--- a/apps/web/src/components/GetConnected/GetConnected.tsx
+++ b/apps/web/src/components/GetConnected/GetConnected.tsx
@@ -11,9 +11,9 @@ export function GetConnected() {
 
       <div className="flex flex-row gap-4 lg:h-full lg:items-center lg:gap-8">
         <div className="rounded-full border border-white p-5">
-          <Link href="/discord" title="Join us on Discord">
+          <a href="https://discord.com/invite/buildonbase" title="Join us on Discord">
             <Icon name="discord" width="48" height="48" />
-          </Link>
+          </a>
         </div>
         <div className="rounded-full border border-white p-5">
           <a href="https://github.com/base-org" title="Join us on Github">

--- a/apps/web/src/components/GetConnected/GetConnected.tsx
+++ b/apps/web/src/components/GetConnected/GetConnected.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-
 import { Icon } from '../Icon/Icon';
 
 export function GetConnected() {

--- a/apps/web/src/components/Layout/Footer/Footer.tsx
+++ b/apps/web/src/components/Layout/Footer/Footer.tsx
@@ -89,14 +89,14 @@ export function Footer() {
             </Link>
           </div>
           <div className="flex flex-row gap-4 pt-1 lg:h-full lg:gap-8">
-            <Link
-              href="/discord"
+            <a
+              href="https://discord.com/invite/buildonbase"
               target="_blank"
               rel="noreferrer noopener"
               title="Join us on Discord"
             >
               <Icon name="discord" width="24" height="20" />
-            </Link>
+            </a>
             <a
               href="https://twitter.com/base"
               target="_blank"

--- a/apps/web/src/components/Layout/Nav/DesktopNav.tsx
+++ b/apps/web/src/components/Layout/Nav/DesktopNav.tsx
@@ -147,9 +147,9 @@ function DesktopNav({ color }: DesktopNavProps) {
         </Dropdown>
       </div>
       <div className="flex h-full flex-row items-center space-x-8">
-        <Link href="/discord" title="Join us on Discord">
+        <a href="https://discord.com/invite/buildonbase" title="Join us on Discord">
           <Icon name="discord" width="24" height="20" color={color} />
-        </Link>
+        </a>
         <a href="https://twitter.com/base" title="Join us on Twitter">
           <Icon name="twitter" width="24" height="20" color={color} />
         </a>

--- a/apps/web/src/components/Layout/Nav/MobileMenu.tsx
+++ b/apps/web/src/components/Layout/Nav/MobileMenu.tsx
@@ -222,9 +222,9 @@ function MobileMenu({ color }: MobileMenuProps) {
                 </Dropdown>
               </div>
               <div className="flex flex-row gap-4 pb-8">
-                <Link href="/discord" title="Join us on Discord">
+                <a href="https://discord.com/invite/buildonbase" title="Join us on Discord">
                   <Icon name="discord" width="48" />
-                </Link>
+                </a>
                 <a href="https://twitter.com/base" title="Join us on Twitter">
                   <Icon name="twitter" width="48" />
                 </a>


### PR DESCRIPTION
**What changed? Why?**

In some cases CloudFlare isn't redirecting properly to our Discord invite page via base.org/discord; this updates the link so that all users go directly to the invite page

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost

**Does this PR add a new token to the bridge?**

- [X ] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
