### PR TITLE
refactor(middleware): Preserve Discord redirect

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -25,6 +25,14 @@ export function middleware(req: NextRequest) {
     return NextResponse.redirect(url);
   }
 
+  if (url.pathname === '/discord') {
+    url.host = 'discord.gg';
+    url.pathname = '/buildonbase';
+    url.port = '443';
+
+    return NextResponse.redirect(url);
+  }
+
   if (url.pathname === '/blog') {
     url.host = 'base.mirror.xyz';
     url.pathname = '/';


### PR DESCRIPTION
**What changed? Why?**

This adds back the route to our middleware to ensure that base.org/discord always works since that link will have propagated throughout the web and we don't want it to 404

Context: #361 

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost

**Does this PR add a new token to the bridge?**

- [X ] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
