### PR TITLE
chore(README): Force redeploy on sepolia-bridge.base.org

### DIFF
--- a/apps/bridge/README.md
+++ b/apps/bridge/README.md
@@ -1,6 +1,6 @@
 # Base Bridge App
 
-The Base bridge app is a Next.js app.
+The Base Bridge App is a Next.js app.
 
 ## Getting started
 


### PR DESCRIPTION
**What changed? Why?**

Trivial change to README to enable a deployment on sepolia-bridge.base.org on top of a stale commit.

Stale commit that wasn't deployed:
fb4b13cd0da90eda9216593635d1419167bf63b3

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost

**Does this PR add a new token to the bridge?**

- [X] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
