### PR TITLE
Fix incorrectly rendering open graph metadata

### DIFF
--- a/apps/base-docs/docusaurus.config.js
+++ b/apps/base-docs/docusaurus.config.js
@@ -29,6 +29,73 @@ const config = {
   title: APP_TITLE,
   tagline: '',
   url: 'https://docs.base.org',
+  headTags: [
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'og:type',
+        content: 'website',
+      },
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'og:title',
+        content: 'Base | Docs',
+      },
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'og:description',
+        content:
+          'Explore the documentation for Base, a secure, low-cost, builder-friendly Ethereum L2.',
+      },
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'og:image',
+        content: 'https://docs.base.org/img/base-open-graph.png',
+      },
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'twitter:card',
+        content: 'summary_large_image',
+      },
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'twitter:domain',
+        content: 'base.org',
+      },
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'twitter:title',
+        content: 'Base | Docs',
+      },
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'twitter:description',
+        content:
+          'Explore the documentation for Base, a secure, low-cost, builder-friendly Ethereum L2.',
+      },
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'twitter:image',
+        content: 'https://docs.base.org/img/base-open-graph.png',
+      },
+    },
+  ],
   customFields: {
     nodeEnv: process.env.NODE_ENV,
   },

--- a/apps/web/pages/_document.tsx
+++ b/apps/web/pages/_document.tsx
@@ -1,6 +1,15 @@
 import { Head, Html, Main, NextScript } from 'next/document';
 
-export default function Document() {
+interface CustomDocumentProps {
+  metadata: {
+    title: string;
+    description: string;
+    image: string;
+    url: string;
+  };
+}
+
+export default function Document({ metadata }: CustomDocumentProps) {
   return (
     <Html>
       <Head>
@@ -15,6 +24,17 @@ export default function Document() {
           name="google-site-verification"
           content="lqwNRCxYlFLIcX9EiKAvE4k4ZT8JGpdWgehEIPA7y1Y"
         />
+        <meta property="og:url" content={metadata.url} />
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content={metadata.title} />
+        <meta property="og:description" content={metadata.description} />
+        <meta property="og:image" content={metadata.image} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta property="twitter:domain" content="base.org" />
+        <meta property="twitter:url" content={metadata.url} />
+        <meta name="twitter:title" content={metadata.title} />
+        <meta name="twitter:description" content={metadata.description} />
+        <meta name="twitter:image" content={metadata.image} />
       </Head>
       <body className="flex min-h-screen flex-col">
         <Main />
@@ -23,3 +43,70 @@ export default function Document() {
     </Html>
   );
 }
+
+Document.getInitialProps = async (ctx) => {
+  const initialProps = await ctx.defaultGetInitialProps(ctx);
+  const { pathname } = ctx;
+
+  // Define default metadata
+  let title = 'Base';
+  let description =
+    'Base is a secure, low-cost, builder-friendly Ethereum L2 built to bring the next billion users onchain.';
+  let image = 'https://base.org/images/base-open-graph.png';
+  let url = 'https://base.org';
+
+  // Customize metadata based on the current page
+  switch (pathname) {
+    case '/about':
+      title = 'Base | About';
+      description =
+        'From the beginning, our secret master plan has been clear and consistent: create an open financial system that increases economic freedom globally by moving deliberately through four phases.';
+      image = 'https://base.org/images/base-open-graph.png';
+      url = 'https://base.org/about';
+      break;
+    case '/bootcamp':
+      title = 'Base | Bootcamp';
+      description =
+        'Base Bootcamp is an async, cohort-based training program designed to turn web developers into Smart Contract developers.';
+      image = 'https://base.org/images/base-open-graph.png';
+      url = 'https://base.org/bootcamp';
+      break;
+    case '/cookie-policy':
+      title = 'Base | Cookie Policy';
+      description = 'This Cookie Policy explains how Base uses cookies and similar technologies';
+      image = 'https://base.org/images/base-open-graph.png';
+      url = 'https://base.org/cookie-policy';
+      break;
+    case '/ecosystem':
+      title = 'Base | Ecosystem';
+      description = 'An overview of apps and integrations in the Base ecosystem.';
+      image = 'https://base.org/images/base-open-graph.png';
+      url = 'https://base.org/base-ecosystem';
+      break;
+    case '/jobs':
+      title = 'Base | Jobs';
+      description = 'Learn about new opportunities to apply to join the Base team.';
+      image = 'https://base.org/images/base-open-graph.png';
+      url = 'https://base.org/jobs';
+      break;
+    case '/third-party-cookies':
+      title = 'Base | Third Party Cookies';
+      description = 'This page lists the companies that use cookies and other technologies.';
+      image = 'https://base.org/images/base-open-graph.png';
+      url = 'https://base.org/third-party-cookies';
+      break;
+    // Add more cases for other pages
+    default:
+      break;
+  }
+
+  return {
+    ...initialProps,
+    metadata: {
+      title,
+      description,
+      image,
+      url,
+    },
+  };
+};

--- a/apps/web/pages/bootcamp.tsx
+++ b/apps/web/pages/bootcamp.tsx
@@ -16,26 +16,6 @@ export default function Home() {
           content="Base Bootcamp is a cohort-based training program hosted by Coinbase engineers, designed to turn senior-level developers into Smart Contract developers."
           name="description"
         />
-        <meta property="og:site_name" content="Base" />
-        <meta property="og:type" content="website" />
-        <meta property="og:title" content="Base" />
-        <meta
-          property="og:description"
-          content="Base Bootcamp is a cohort-based training program hosted by Coinbase engineers, designed to turn senior-level developers into Smart Contract developers."
-        />
-        <meta property="og:url" content="https://base.org" />
-        <meta property="og:image" content="https://base.org/images/base-open-graph.png" />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="Base" />
-        <meta
-          name="twitter:description"
-          content="Base Bootcamp is a cohort-based training program hosted by Coinbase engineers, designed to turn senior-level developers into Smart Contract developers."
-        />
-        <meta name="twitter:url" content="https://base.org" />
-        <meta name="twitter:image" content="https://base.org/images/base-open-graph.png" />
-        <meta name="twitter:site" content="Base" />
-        <meta property="og:image:width" content="1200" />
-        <meta property="og:image:height" content="630" />
       </Head>
       <Hero />
       <main className="flex w-full flex-col items-center bg-black">

--- a/apps/web/pages/ecosystem.tsx
+++ b/apps/web/pages/ecosystem.tsx
@@ -43,26 +43,6 @@ export default function Ecosystem() {
           content="Base is a secure, low-cost, developer-friendly Ethereum L2 built to bring the next billion users to web3."
           name="description"
         />
-        <meta property="og:site_name" content="Base" />
-        <meta property="og:type" content="website" />
-        <meta property="og:title" content="Base | Ecosystem" />
-        <meta
-          property="og:description"
-          content="Base is a secure, low-cost, builder-friendly Ethereum L2 built to bring the next billion users onchain."
-        />
-        <meta property="og:url" content="https://base.org/ecosystem" />
-        <meta property="og:image" content="https://base.org/images/base-open-graph.png" />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="Base | Ecosystem" />
-        <meta
-          name="twitter:description"
-          content="Base is a secure, low-cost, builder-friendly Ethereum L2 built to bring the next billion users onchain."
-        />
-        <meta name="twitter:url" content="https://base.org/ecosystem" />
-        <meta name="twitter:image" content="https://base.org/images/base-open-graph.png" />
-        <meta name="twitter:site" content="Base | Ecosystem" />
-        <meta property="og:image:width" content="1200" />
-        <meta property="og:image:height" content="630" />
       </Head>
       <main className="flex w-full flex-col items-center bg-black">
         <EcosystemHero />

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -37,26 +37,6 @@ export default function Home() {
           content="Base is a secure, low-cost, builder-friendly Ethereum L2 built to bring the next billion users onchain."
           name="description"
         />
-        <meta property="og:site_name" content="Base" />
-        <meta property="og:type" content="website" />
-        <meta property="og:title" content="Base" />
-        <meta
-          property="og:description"
-          content="Base is a secure, low-cost, builder-friendly Ethereum L2 built to bring the next billion users onchain."
-        />
-        <meta property="og:url" content="https://base.org" />
-        <meta property="og:image" content="https://base.org/images/base-open-graph.png" />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="Base" />
-        <meta
-          name="twitter:description"
-          content="Base is a secure, low-cost, builder-friendly Ethereum L2 built to bring the next billion users onchain."
-        />
-        <meta name="twitter:url" content="https://base.org" />
-        <meta name="twitter:image" content="https://base.org/images/base-open-graph.png" />
-        <meta name="twitter:site" content="Base" />
-        <meta property="og:image:width" content="1200" />
-        <meta property="og:image:height" content="630" />
       </Head>
       <FrameMetadata
         buttons={buttons}


### PR DESCRIPTION
**What changed? Why?**

There's currently an issue where our open graph metadata isn't displaying due to the nature of server side rendering and makes our links look ugly when they get shared on social media and in messengers; this PR makes a first pass at attempting to resolve the issue

I'm trying to do this first without including the og:url field, as we don't currently populate it dynamically; if needed will follow-on with a subsequent PR to develop that feature which is a bit heavier of a lift

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost

**Does this PR add a new token to the bridge?**

- [X] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
