### PR TITLE
fix: Logo svg width error

### DIFF
--- a/apps/bridge/src/components/Logo/Logo.tsx
+++ b/apps/bridge/src/components/Logo/Logo.tsx
@@ -4,7 +4,7 @@ type LogoProps = {
   height?: string;
 };
 
-export function Logo({ color = 'white', width = 'auto', height = '32' }: LogoProps) {
+export function Logo({ color = 'white', width = '100%', height = '32' }: LogoProps) {
   return (
     <svg
       width={width}

--- a/apps/web/src/components/Logo/Logo.tsx
+++ b/apps/web/src/components/Logo/Logo.tsx
@@ -8,15 +8,9 @@ type LogoProps = {
   path?: string;
 };
 
-export function Logo({ color = 'white', width = 'auto', height = '32', path }: LogoProps) {
+export function Logo({ color = 'white', width = '100%', height = '32', path }: LogoProps) {
   if (path === '/bootcamp') {
-    return (
-      <Image
-        width={300}
-        src={BaseBootcampLogo}
-        alt="Base Bootcamp"
-      />
-    );
+    return <Image width={300} src={BaseBootcampLogo} alt="Base Bootcamp" />;
   }
 
   return (


### PR DESCRIPTION
**What changed? Why?**

Fix invalid logo svg `width` attr

![image](https://github.com/base-org/web/assets/36932151/04325990-ebe8-4a33-b24e-ed726af35ecc)
![image](https://github.com/base-org/web/assets/36932151/5432cf42-e186-4866-8270-5c2bb98b8c62)


**Notes to reviewers**

**How has it been tested?**

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge
- [x] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
