### PR TITLE
fix(ecosystem): Typo in partner image name

### DIFF
--- a/apps/web/src/data/ecosystem.json
+++ b/apps/web/src/data/ecosystem.json
@@ -96,7 +96,7 @@
     ],
     "description": "Ochain ranking protocol. Track your progress in your favorite projects and rise to the top.\n",
     "url": "https://rubyscore.io/",
-    "imageUrl": "/images/partners/rubsyscore.png"
+    "imageUrl": "/images/partners/rubyscore.png"
   },
   {
     "name": "BotFi.app",


### PR DESCRIPTION
**What changed? Why?**

There was a typo in Rubyscore's image name in ecosystem.json

**Notes to reviewers**

**How has it been tested?**

**Does this PR add a new token to the bridge?**

- [ ] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
