### PR TITLE
feat(bridge): Add planned withdrawal pause note to top of page

### DIFF
--- a/apps/bridge/pages/_app.tsx
+++ b/apps/bridge/pages/_app.tsx
@@ -133,14 +133,30 @@ function Root({ Component, pageProps }: AppProps) {
                         <Component {...props} />
                       )}
                       {allowedPaths.has(pathname) && (
-                        <Sidebar>
-                          <>
-                            <Header />
-                            <div className="m-0 w-full p-0 sm:h-[calc(100vh-72px)]">
-                              <Component {...props} />
-                            </div>
-                          </>
-                        </Sidebar>
+                        <div className="flex w-full flex-col">
+                          <div className="w-full bg-black px-8 py-3 text-center font-sans text-sm text-white">
+                            <span className="font-bold">Upcoming maintenance:</span> Base Bridge
+                            withdrawals will be temporarily paused starting at 11AM PST (6PM UTC) on
+                            Wednesday, March 20th, for approximately one hour. They will resume
+                            processing at the end of the maintenance period. To learn more please
+                            visit our{' '}
+                            <a
+                              href="https://base-l2.statuspage.io/incidents/zzz3tw0f92hp"
+                              className="text-cds-primary"
+                            >
+                              status page
+                            </a>
+                            .
+                          </div>
+                          <Sidebar>
+                            <>
+                              <Header />
+                              <div className="m-0 w-full p-0 sm:h-[calc(100vh-72px)]">
+                                <Component {...props} />
+                              </div>
+                            </>
+                          </Sidebar>
+                        </div>
                       )}
                     </div>
                   </Layout>


### PR DESCRIPTION
**What changed? Why?**

Add a note to the top of bridge.base.org so people are aware of the planned one-hour withdrawal pause on Wednesday.

**Notes to reviewers**

![2024-03-19 at 01 02 43@2x](https://github.com/base-org/web/assets/1130872/607a2967-d370-4950-a0ff-f2f6c384948d)

**How has it been tested?**

Localhost

**Does this PR add a new token to the bridge?**

- [X] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
