### PR TITLE
mention setting `OP_NODE_L1_BEACON`

### DIFF
--- a/apps/base-docs/docs/building-with-base/guides/run-a-base-node.md
+++ b/apps/base-docs/docs/building-with-base/guides/run-a-base-node.md
@@ -77,7 +77,7 @@ You'll need your own L1 RPC URL. This can be one that you run yourself, or via a
 ## Running a Node
 
 1. Clone the [repo].
-2. Ensure you have an Ethereum L1 full node RPC available (not Base), and set `OP_NODE_L1_ETH_RPC` (in the `.env.*` file if using `docker-compose`). If running your own L1 node, it needs to be synced before Base will be able to fully sync.
+2. Ensure you have an Ethereum L1 full node RPC available (not Base), and set `OP_NODE_L1_ETH_RPC` & `OP_NODE_L1_BEACON` (in the `.env.*` file if using `docker-compose`). If running your own L1 node, it needs to be synced before Base will be able to fully sync.
 3. Uncomment the line relevant to your network (`.env.sepolia`, or `.env.mainnet`) under the 2 `env_file` keys in `docker-compose.yml`.
 4. Run `docker compose up`. Confirm you get a response from:
 


### PR DESCRIPTION
**What changed? Why?**
mentioned setting `OP_NODE_L1_BEACON` var when starting a base node
**Notes to reviewers**

**How has it been tested?**

**Does this PR add a new token to the bridge?**

- [ ] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
