### PR TITLE
Fix broken link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ This project and everyone participating in it are governed by our [Code of Condu
 
 ### Reporting Bugs
 
-1. **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/web/web/issues).
+1. **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/base-org/web/issues).
 
 2. If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/base-org/web/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
 


### PR DESCRIPTION
**What changed? Why?**

The link to the repo issues URL was pointing to a non-existent repo, so this change fixes the URL.

**Notes to reviewers**

None

**How has it been tested?**

Tested manually

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge
- [x] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20