### PR TITLE
Improve loading experience on jobs page

### DIFF
--- a/apps/web/pages/jobs.tsx
+++ b/apps/web/pages/jobs.tsx
@@ -2,7 +2,7 @@ import { JobsList, JobType } from 'apps/web/src/components/Jobs/JobsList';
 import Head from 'next/head';
 import { greenhouseApiUrl } from 'apps/web/src/constants';
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   const res = await fetch(`${greenhouseApiUrl}/boards/basejobs/jobs?content=true`);
   const { jobs } = (await res.json()) as { jobs: JobType[] };
   return {


### PR DESCRIPTION
**What changed? Why?**

Use getStaticProps instead of getServerSideProps to statically render jobs page.

**Notes to reviewers**

**How has it been tested?**

Manually

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
