### PR TITLE
Add warning message about v1 to v2 for wagmi

### DIFF
--- a/apps/base-docs/base-camp/docs/frontend-setup/building-an-onchain-app.md
+++ b/apps/base-docs/base-camp/docs/frontend-setup/building-an-onchain-app.md
@@ -8,6 +8,12 @@ While it's convenient and fast to start from a template, the template may not fi
 
 In this guide, we'll build the beginnings of an app similar to the one created by the [RainbowKit] quick start, but we'll do it piece by piece. You can follow along, and swap out any of our library choices with the ones you prefer.
 
+:::caution
+
+The frontend tutorials are currently based on version 1.X of Wagmi. Version 2 has recently been released and is a near complete rewrite of the library. We are working on updates. In the meantime, please use Version 1, or review the [migration guide](https://wagmi.sh/react/guides/migrate-from-v1-to-v2).
+
+:::
+
 ---
 
 ## Objectives

--- a/apps/base-docs/base-camp/docs/frontend-setup/overview.md
+++ b/apps/base-docs/base-camp/docs/frontend-setup/overview.md
@@ -6,6 +6,12 @@ hide_table_of_contents: false
 
 Welcome! The course you are about to begin will rapidly introduce you to frontend web development for onchain apps and enable you to write websites that can call your smart contract functions in a similar way to how traditional sites interact with APIs.
 
+:::caution
+
+The frontend tutorials are currently based on version 1.X of Wagmi. Version 2 has recently been released and is a near complete rewrite of the library. We are working on updates. In the meantime, please use Version 1, or review the [migration guide](https://wagmi.sh/react/guides/migrate-from-v1-to-v2).
+
+:::
+
 ## Prerequisites
 
 Before these lessons, you should:

--- a/apps/base-docs/base-camp/docs/frontend-setup/wallet-connectors.md
+++ b/apps/base-docs/base-camp/docs/frontend-setup/wallet-connectors.md
@@ -6,6 +6,12 @@ hide_table_of_contents: false
 
 One of the most intimidating tasks when building an onchain app is making that initial connection between your users' wallets, and your app. Initial research often surfaces a bewildering number of wallets, each with their own SDKs, and own methods to manage the connection. Luckily, you don't actually need to manage all of this on your own. There are a number of libraries specialized in creating a smooth and beautiful user experience to facilitate this connection.
 
+:::caution
+
+The frontend tutorials are currently based on version 1.X of Wagmi. Version 2 has recently been released and is a near complete rewrite of the library. We are working on updates. In the meantime, please use Version 1, or review the [migration guide](https://wagmi.sh/react/guides/migrate-from-v1-to-v2).
+
+:::
+
 ---
 
 ## Objectives

--- a/apps/base-docs/base-camp/docs/reading-and-displaying-data/configuring-useContractRead.md
+++ b/apps/base-docs/base-camp/docs/reading-and-displaying-data/configuring-useContractRead.md
@@ -6,6 +6,12 @@ hide_table_of_contents: false
 
 The [`useContractRead`] hook has a number of configurable properties that will allow you to adapt it to your needs. You can [`watch`], for updates, though not for free. Once those updates are retrieved you can use the hook to automatically run an update function to set state for React, or handle any other logic you want to trigger when the data on the blockchain changes.
 
+:::caution
+
+The frontend tutorials are currently based on version 1.X of Wagmi. Version 2 has recently been released and is a near complete rewrite of the library. We are working on updates. In the meantime, please use Version 1, or review the [migration guide](https://wagmi.sh/react/guides/migrate-from-v1-to-v2).
+
+:::
+
 ---
 
 ## Objectives

--- a/apps/base-docs/base-camp/docs/reading-and-displaying-data/useAccount.md
+++ b/apps/base-docs/base-camp/docs/reading-and-displaying-data/useAccount.md
@@ -8,6 +8,12 @@ hide_table_of_contents: false
 
 You can use this for connection-status-based rendering, to enable or disable controls or views based on address, and many other useful tasks.
 
+:::caution
+
+The frontend tutorials are currently based on version 1.X of Wagmi. Version 2 has recently been released and is a near complete rewrite of the library. We are working on updates. In the meantime, please use Version 1, or review the [migration guide](https://wagmi.sh/react/guides/migrate-from-v1-to-v2).
+
+:::
+
 ---
 
 ## Objectives

--- a/apps/base-docs/base-camp/docs/reading-and-displaying-data/useContractRead.md
+++ b/apps/base-docs/base-camp/docs/reading-and-displaying-data/useContractRead.md
@@ -6,6 +6,12 @@ hide_table_of_contents: false
 
 The `useContractRead` hook is [wagmi]'s method of calling `pure` and `view` functions from your smart contracts. As with `useAccount`, `useContractRead` contains a number of helpful properties to enable you to manage displaying information to your users.
 
+:::caution
+
+The frontend tutorials are currently based on version 1.X of Wagmi. Version 2 has recently been released and is a near complete rewrite of the library. We are working on updates. In the meantime, please use Version 1, or review the [migration guide](https://wagmi.sh/react/guides/migrate-from-v1-to-v2).
+
+:::
+
 ---
 
 ## Objectives

--- a/apps/base-docs/base-camp/docs/writing-to-contracts/useContractWrite.md
+++ b/apps/base-docs/base-camp/docs/writing-to-contracts/useContractWrite.md
@@ -6,6 +6,12 @@ hide_table_of_contents: false
 
 The [`useContractWrite`] hook allows you to call your `public` and `external` smart contract functions that write to state and create a permanent modification to the data on chain.
 
+:::caution
+
+The frontend tutorials are currently based on version 1.X of Wagmi. Version 2 has recently been released and is a near complete rewrite of the library. We are working on updates. In the meantime, please use Version 1, or review the [migration guide](https://wagmi.sh/react/guides/migrate-from-v1-to-v2).
+
+:::
+
 ---
 
 ## Objectives

--- a/apps/base-docs/base-camp/docs/writing-to-contracts/usePrepareContractWrite.md
+++ b/apps/base-docs/base-camp/docs/writing-to-contracts/usePrepareContractWrite.md
@@ -6,6 +6,12 @@ hide_table_of_contents: false
 
 The [`usePrepareContractWrite`] hook "Eagerly fetches the parameters required for sending a contract write transaction such as the gas estimate." What this means is that by using this hook, you can dramatically reduce the time it takes for the wallet confirmation to pop up for a transaction, and detect and respond to potential errors before the user tries to send a transaction.
 
+:::caution
+
+The frontend tutorials are currently based on version 1.X of Wagmi. Version 2 has recently been released and is a near complete rewrite of the library. We are working on updates. In the meantime, please use Version 1, or review the [migration guide](https://wagmi.sh/react/guides/migrate-from-v1-to-v2).
+
+:::
+
 ---
 
 ## Objectives

--- a/apps/base-docs/base-camp/sidebars.js
+++ b/apps/base-docs/base-camp/sidebars.js
@@ -817,7 +817,7 @@ const sidebars = {
         {
           type: 'link',
           label: 'Connecting to the Blockchain',
-          href: 'https://docs.base.org/connecting-to-the-blockchain/overview',
+          href: 'https://docs.base.org/tutorials/intro-to-providers',
           className: 'sidebar-coding',
         },
         {


### PR DESCRIPTION
**What changed? Why?**
Wagmi V2 is almost 100% breaking for our current frontend guides.  Adding a warning until I can update them.

**Notes to reviewers**
I didn't use reference-style links to make it easier to add and remove the warning.

**How has it been tested?**

**Does this PR add a new token to the bridge?**

- [ x] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
