### PR TITLE
Add warning about reverts to erc-20 exercise

### DIFF
--- a/apps/base-docs/base-camp/docs/erc-20-token/erc-20-exercise.md
+++ b/apps/base-docs/base-camp/docs/erc-20-token/erc-20-exercise.md
@@ -60,6 +60,12 @@ Only token holders are allowed to create issues, and issues cannot be created th
 
 This function must return the index of the newly-created issue.
 
+:::caution
+
+One of the unit tests will break if you place your check for `quorum` before the check that the user holds a token. The test compares encoded error names, which are **not** human-readable. If you are getting `-> AssertionError: �s is not equal to �9�` or similar, this is likely the issue.
+
+:::
+
 ### Get Issue
 
 Add an `external` function called `getIssue` that can return all of the data for the issue of the provided `_id`.


### PR DESCRIPTION
**What changed? Why?**
The ERC-20 exercise tests for an expected revert for `NoTokensHeld` in a way that also triggers `QuorumTooHigh`.  If the submitted contract has the latter before the former, they will incorrectly fail the test.

Added a warning describing this.

**Notes to reviewers**

**How has it been tested?**

**Does this PR add a new token to the bridge?**

- [ ] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
