### PR TITLE
Fix Docs Link CSS

### DIFF
--- a/apps/base-docs/src/css/doc-page.css
+++ b/apps/base-docs/src/css/doc-page.css
@@ -15,7 +15,7 @@ main .container .row .col {
 
 .table-of-contents {
   font-size: 1rem;
-  padding: 30px;
+  padding: 0 30px;
 }
 
 .table-of-contents > li > a {

--- a/apps/base-docs/src/pages/tutorials/styles.module.css
+++ b/apps/base-docs/src/pages/tutorials/styles.module.css
@@ -1,5 +1,5 @@
-a,
-a:hover {
+.tutorialsMainContainer a,
+.tutorialsMainContainer a:hover {
   text-decoration: none;
   color: var(--base-docs-color-fg);
 }


### PR DESCRIPTION
**What changed? Why?**

The Tutorials page CSS included an overly broad selector that affected all anchor tags on the site, coloring them white. I made that selector more specific so it only affects anchor tags on the Tutorials page cards. I also adjusted the padding on the Tutorials table of contents to even out the edges of the page layout.

<img width="1784" alt="Screenshot 2024-04-01 at 10 51 32 AM" src="https://github.com/base-org/web/assets/144269024/e910d233-00d8-46c1-b398-b17c4a211071">

<img width="1784" alt="Screenshot 2024-04-01 at 10 51 55 AM" src="https://github.com/base-org/web/assets/144269024/8381bfae-6ed7-4b19-88e4-1d988a1a5682">

**How has it been tested?**

Ran the app locally and confirmed links are rendering blue.

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge