### PR TITLE
fix: update foundry tutorial link

### DIFF
--- a/apps/base-docs/base-camp/sidebars.js
+++ b/apps/base-docs/base-camp/sidebars.js
@@ -196,7 +196,7 @@ const sidebars = {
         {
           type: 'link',
           label: 'Introduction to Foundry',
-          href: 'https://docs.base.org/building-with-base/guides/building-with-base-and-foundry/introduction',
+          href: 'https://docs.base.org/tutorials/intro-to-foundry-setup',
           className: 'sidebar-coding',
         },
       ],


### PR DESCRIPTION
**What changed? Why?**
Outdated link that 404s replaced with the correct tutorial link

**Notes to reviewers**
Confirmed with @briandoyle81CB in base discord that this is the correct link to use

**How has it been tested?**
yes

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
