### PR TITLE
Update Algolia Indexer Action

### DIFF
--- a/.github/workflows/update-algolia.yml
+++ b/.github/workflows/update-algolia.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get the content of algolia.json as config
         id: algolia_config
         run: echo "::set-output name=config::$(cat apps/base-docs/algolia.json | jq -r tostring)"


### PR DESCRIPTION
**What changed? Why?**

Updated the GitHub Action that indexes docs content for Algolia search. Followed the example [here](https://github.com/bisontrails/cloud-docs/blob/main/.github/workflows/update-algolia.yml) from Coinbase Cloud Docs repo.

**Notes to reviewers**

The Algolia search index currently contains links to /guides content, which has been migrated to /tutorials. Once this GitHub Action is fixed, we can index the new /tutorials content and search results should no longer link to /guides pages with a 404.

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge