### PR TITLE
Algolia Crawler Config Update

### DIFF
--- a/apps/base-docs/algolia.json
+++ b/apps/base-docs/algolia.json
@@ -23,6 +23,8 @@
       "text": "article p, article li"
     }
   },
+  "js_render": true,
+  "js_wait": 2,
   "strip_chars": " .,;:#",
   "custom_settings": {
     "separatorsToIndex": "_",


### PR DESCRIPTION
### What changed? Why?

[Previous attempt](https://github.com/base-org/web/pull/399) to fix Algolia crawler resolved some errors/warnings related to outdated dependencies, but the crawler is still finding 0 records to index.

This PR adds the `js_render` and `js_wait` fields to the Algolia crawler config, which addresses the possibility that the crawler is running before page load completes. Docs on these fields [here](https://docsearch.algolia.com/docs/legacy/config-file#js_render-optional).