### PR TITLE
Remove duplicate Security link in sidebar

### DIFF
--- a/apps/base-docs/sidebars.js
+++ b/apps/base-docs/sidebars.js
@@ -71,7 +71,6 @@ module.exports = {
       label: 'Brand Kit',
       href: 'https://github.com/base-org/brand-kit',
     },
-    ['security'],
     ['terms-of-service'],
     ['privacy-policy'],
     ['cookie-policy'],


### PR DESCRIPTION
**What changed? Why?**
Removed duplicate `Security` link in sidebar

**Notes to reviewers**
N/A

**How has it been tested?**
Manually

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
