### PR TITLE
chore(Explorer): Update to Blockscout

### DIFF
--- a/apps/base-docs/docs/using-base.md
+++ b/apps/base-docs/docs/using-base.md
@@ -54,14 +54,14 @@ To add Base as a custom network to MetaMask:
 4. Click **Add a network manually**.
 5. In the **Add a network manually** dialog that appears, enter the following information for Base mainnet:
 
-   | Name            | Value                                                |
-   | :-------------- | :--------------------------------------------------- |
-   | Network Name    | Base Mainnet                                         |
-   | Description     | The public mainnet for Base.                         |
-   | RPC Endpoint    | [https://mainnet.base.org](https://mainnet.base.org) |
-   | Chain ID        | 8453                                                 |
-   | Currency Symbol | ETH                                                  |
-   | Block Explorer  | [https://basescan.org](https://basescan.org)         |
+   | Name            | Value                                                        |
+   | :-------------- | :----------------------------------------------------------- |
+   | Network Name    | Base Mainnet                                                 |
+   | Description     | The public mainnet for Base.                                 |
+   | RPC Endpoint    | [https://mainnet.base.org](https://mainnet.base.org)         |
+   | Chain ID        | 8453                                                         |
+   | Currency Symbol | ETH                                                          |
+   | Block Explorer  | [https://base.blockscout.com/](https://base.blockscout.com/) |
 
 6. Tap the Save button to save Base as a network.
 
@@ -98,13 +98,13 @@ To add Base Sepolia as a custom network to MetaMask:
 4. Click **Add a network manually**.
 5. In the **Add a network manually** dialog that appears, enter the following information for the Base Sepolia testnet:
 
-   | Name            | Sepolia                                                                 |
-   | :-------------- | :---------------------------------------------------------------------- |
-   | Network Name    | Base Sepolia                                                            |
-   | RPC Endpoint    | [https://sepolia.base.org](https://sepolia.base.org)                    |
-   | Chain ID        | 84532                                                                   |
-   | Currency Symbol | ETH                                                                     |
-   | Block Explorer  | [https://sepolia-explorer.base.org/](https://sepolia-explorer.base.org) |
+   | Name            | Sepolia                                                                      |
+   | :-------------- | :--------------------------------------------------------------------------- |
+   | Network Name    | Base Sepolia                                                                 |
+   | RPC Endpoint    | [https://sepolia.base.org](https://sepolia.base.org)                         |
+   | Chain ID        | 84532                                                                        |
+   | Currency Symbol | ETH                                                                          |
+   | Block Explorer  | [https://base-sepolia.blockscout.com/](https://base-sepolia.blockscout.com/) |
 
 6. Tap the Save button to save Base Sepolia as a network.
 

--- a/apps/base-docs/docusaurus.config.js
+++ b/apps/base-docs/docusaurus.config.js
@@ -231,7 +231,7 @@ const config = {
           items: [
             {
               label: 'Block Explorer',
-              href: 'https://basescan.org/',
+              href: 'https://base.blockscout.com/',
             },
             {
               label: 'Status',

--- a/apps/web/src/components/Layout/Nav/DesktopNav.tsx
+++ b/apps/web/src/components/Layout/Nav/DesktopNav.tsx
@@ -121,7 +121,7 @@ function DesktopNav({ color }: DesktopNavProps) {
         <Dropdown label="Developers" color={color}>
           <DropdownLink href={docsUrl} label="Docs" color={color} externalLink />
           <DropdownLink
-            href="https://basescan.org"
+            href="https://base.blockscout.com/"
             label="Block Explorer"
             color={color}
             externalLink


### PR DESCRIPTION
**What changed? Why?**

Updates key explorer links to Blockscout while Basescan is down

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost

**Does this PR add a new token to the bridge?**

- [X] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
