### PR TITLE
Update block explorer links & add query parameters to tutorial filtering

### DIFF
--- a/apps/base-docs/docs/using-base.md
+++ b/apps/base-docs/docs/using-base.md
@@ -54,14 +54,14 @@ To add Base as a custom network to MetaMask:
 4. Click **Add a network manually**.
 5. In the **Add a network manually** dialog that appears, enter the following information for Base mainnet:
 
-   | Name            | Value                                                        |
-   | :-------------- | :----------------------------------------------------------- |
-   | Network Name    | Base Mainnet                                                 |
-   | Description     | The public mainnet for Base.                                 |
-   | RPC Endpoint    | [https://mainnet.base.org](https://mainnet.base.org)         |
-   | Chain ID        | 8453                                                         |
-   | Currency Symbol | ETH                                                          |
-   | Block Explorer  | [https://base.blockscout.com/](https://base.blockscout.com/) |
+   | Name            | Value                                                  |
+   | :-------------- | :----------------------------------------------------- |
+   | Network Name    | Base Mainnet                                           |
+   | Description     | The public mainnet for Base.                           |
+   | RPC Endpoint    | [https://mainnet.base.org](https://mainnet.base.org)   |
+   | Chain ID        | 8453                                                   |
+   | Currency Symbol | ETH                                                    |
+   | Block Explorer  | [https://explorer.base.org](https://explorer.base.org) |
 
 6. Tap the Save button to save Base as a network.
 
@@ -98,13 +98,13 @@ To add Base Sepolia as a custom network to MetaMask:
 4. Click **Add a network manually**.
 5. In the **Add a network manually** dialog that appears, enter the following information for the Base Sepolia testnet:
 
-   | Name            | Sepolia                                                                      |
-   | :-------------- | :--------------------------------------------------------------------------- |
-   | Network Name    | Base Sepolia                                                                 |
-   | RPC Endpoint    | [https://sepolia.base.org](https://sepolia.base.org)                         |
-   | Chain ID        | 84532                                                                        |
-   | Currency Symbol | ETH                                                                          |
-   | Block Explorer  | [https://base-sepolia.blockscout.com/](https://base-sepolia.blockscout.com/) |
+   | Name            | Sepolia                                                                |
+   | :-------------- | :--------------------------------------------------------------------- |
+   | Network Name    | Base Sepolia                                                           |
+   | RPC Endpoint    | [https://sepolia.base.org](https://sepolia.base.org)                   |
+   | Chain ID        | 84532                                                                  |
+   | Currency Symbol | ETH                                                                    |
+   | Block Explorer  | [https://sepolia-explorer.base.org](https://sepolia-explorer.base.org) |
 
 6. Tap the Save button to save Base Sepolia as a network.
 

--- a/apps/base-docs/docusaurus.config.js
+++ b/apps/base-docs/docusaurus.config.js
@@ -231,7 +231,7 @@ const config = {
           items: [
             {
               label: 'Block Explorer',
-              href: 'https://base.blockscout.com/',
+              href: 'https://explorer.base.org/',
             },
             {
               label: 'Status',

--- a/apps/base-docs/src/pages/tutorials/index.jsx
+++ b/apps/base-docs/src/pages/tutorials/index.jsx
@@ -1,14 +1,13 @@
-// eslint-disable-next-line import/no-unresolved
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Layout from '@theme/Layout';
 import { Link } from 'react-router-dom';
 import { ThemeClassNames } from '@docusaurus/theme-common';
 import Heading from '@theme/Heading';
-import MDXContent from '@theme/MDXContent';
 import clsx from 'clsx';
 import styles from './styles.module.css';
 import tutorialData from '../../../tutorials/data.json';
 import authors from '@app/base-docs/static/json/authors.json';
+import { useHistory, useLocation } from 'react-router-dom';
 
 const TagList = [
   'all',
@@ -21,6 +20,10 @@ const TagList = [
   'vrf',
   'frames',
 ];
+
+function useQuery() {
+  return new URLSearchParams(useLocation().search);
+}
 
 function TagChip({ tag, isSelected, setSelectedTag }) {
   const select = useCallback(() => {
@@ -81,10 +84,22 @@ const TITLE = 'Base Builder Tutorials';
 
 export default function Tutorials() {
   const [selectedTag, setSelectedTag] = useState('all');
+  const history = useHistory();
+  const query = useQuery();
 
-  const selectTag = (tag) => {
-    setSelectedTag(tag);
-  };
+  useEffect(() => {
+    const tag = query.get('tag');
+    if (tag) {
+      setSelectedTag(tag);
+    }
+  }, [query]);
+
+  const selectTag = useCallback(
+    (tag) => {
+      history.push(`?tag=${tag}`);
+    },
+    [history],
+  );
 
   return (
     <Layout title="Base Tutorials" description="Base tutorials">

--- a/apps/base-docs/tutorials/data.json
+++ b/apps/base-docs/tutorials/data.json
@@ -24,7 +24,7 @@
         ],
         "difficulty": "beginner",
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "17 mins"
     },
     "deploy-with-hardhat": {
@@ -52,7 +52,7 @@
         ],
         "difficulty": "beginner",
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "15 mins"
     },
     "deploy-with-remix": {
@@ -81,7 +81,7 @@
         ],
         "difficulty": "beginner",
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "18 mins"
     },
     "deploy-with-tenderly": {
@@ -111,7 +111,7 @@
         ],
         "difficulty": "beginner",
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "19 mins"
     },
     "deploy-with-thirdweb": {
@@ -144,7 +144,7 @@
         ],
         "difficulty": "beginner",
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "10 mins"
     },
     "run-a-base-node": {
@@ -171,7 +171,7 @@
         ],
         "difficulty": "beginner",
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "5 mins"
     },
     "build-with-thirdweb": {
@@ -203,7 +203,7 @@
         ],
         "difficulty": "beginner",
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "8 mins"
     },
     "account-abstraction-with-biconomy": {
@@ -229,7 +229,7 @@
         ],
         "difficulty": "intermediate",
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "29 mins"
     },
     "account-abstraction-with-privy-and-base-paymaster": {
@@ -256,7 +256,7 @@
         "difficulty": "intermediate",
         "hide_table_of_contents": false,
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "46 mins"
     },
     "cross-chain-with-ccip": {
@@ -280,7 +280,7 @@
         ],
         "difficulty": "intermediate",
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "32 mins"
     },
     "cross-chain-with-layerzero": {
@@ -304,7 +304,7 @@
         ],
         "difficulty": "intermediate",
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "34 mins"
     },
     "complex-onchain-nfts": {
@@ -332,7 +332,7 @@
         "difficulty": "intermediate",
         "hide_table_of_contents": false,
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "39 mins"
     },
     "oracles-chainlink-price-feeds": {
@@ -360,7 +360,7 @@
         ],
         "difficulty": "intermediate",
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "11 mins"
     },
     "oracles-pyth-price-feeds": {
@@ -389,7 +389,7 @@
         ],
         "difficulty": "intermediate",
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "13 mins"
     },
     "oracles-supra-vrf": {
@@ -426,7 +426,7 @@
         ],
         "difficulty": "intermediate",
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "19 mins"
     },
     "farcaster-frames-deploy-to-vercel": {
@@ -448,7 +448,7 @@
         "difficulty": "beginner",
         "hide_table_of_contents": false,
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "9 mins"
     },
     "farcaster-frames-gating-and-redirects": {
@@ -467,7 +467,7 @@
         "difficulty": "intermediate",
         "hide_table_of_contents": false,
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "12 mins"
     },
     "farcaster-frames-hyperframes": {
@@ -491,7 +491,7 @@
         "tags": [
             "frames"
         ],
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "16 mins"
     },
     "farcaster-frames-nft-minting": {
@@ -515,7 +515,7 @@
         "difficulty": "beginner",
         "hide_table_of_contents": false,
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "22 mins"
     },
     "farcaster-frames-nocode-minting": {
@@ -540,7 +540,7 @@
         "difficulty": "beginner",
         "hide_table_of_contents": false,
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "7 mins"
     },
     "farcaster-frames-transactions": {
@@ -562,7 +562,7 @@
         "difficulty": "intermediate",
         "hide_table_of_contents": false,
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "17 mins"
     },
     "hardhat-debugging": {
@@ -584,7 +584,7 @@
         "difficulty": "beginner",
         "hide_table_of_contents": false,
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "15 mins"
     },
     "hardhat-profiling-gas": {
@@ -609,7 +609,7 @@
         "difficulty": "beginner",
         "hide_table_of_contents": false,
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "16 mins"
     },
     "hardhat-profiling-size": {
@@ -635,7 +635,7 @@
         "difficulty": "beginner",
         "hide_table_of_contents": false,
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "22 mins"
     },
     "hardhat-test-coverage": {
@@ -661,7 +661,7 @@
         "difficulty": "beginner",
         "hide_table_of_contents": false,
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "9 mins"
     },
     "intro-to-foundry-setup": {
@@ -682,7 +682,7 @@
         "difficulty": "beginner",
         "hide_table_of_contents": false,
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "6 mins"
     },
     "intro-to-foundry-testing": {
@@ -705,7 +705,7 @@
         "difficulty": "beginner",
         "hide_table_of_contents": false,
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "9 mins"
     },
     "intro-to-providers": {
@@ -754,7 +754,7 @@
         "difficulty": "beginner",
         "hide_table_of_contents": false,
         "displayed_sidebar": null,
-        "last_updated": "Apr 4",
+        "last_updated": "Apr 5",
         "duration": "20 mins"
     }
 }

--- a/apps/web/src/components/Layout/Nav/DesktopNav.tsx
+++ b/apps/web/src/components/Layout/Nav/DesktopNav.tsx
@@ -121,7 +121,7 @@ function DesktopNav({ color }: DesktopNavProps) {
         <Dropdown label="Developers" color={color}>
           <DropdownLink href={docsUrl} label="Docs" color={color} externalLink />
           <DropdownLink
-            href="https://base.blockscout.com/"
+            href="https://explorer.base.org/"
             label="Block Explorer"
             color={color}
             externalLink

--- a/apps/web/src/components/Layout/Nav/MobileMenu.tsx
+++ b/apps/web/src/components/Layout/Nav/MobileMenu.tsx
@@ -197,7 +197,7 @@ function MobileMenu({ color }: MobileMenuProps) {
                 >
                   <DropdownLink href="https://docs.base.org" label="Docs" externalLink />
                   <DropdownLink
-                    href="https://basescan.org"
+                    href="https://explorer.base.org/"
                     label={`Block\nExplorer`}
                     externalLink
                   />


### PR DESCRIPTION
**What changed? Why?**
- Update primary block explorer links to `https://explorer.base.org/`
- Add query parameters to tutorial filtering, enabling the sharing of pre-filtered pages (i.e. `http://docs.base.org/tutorials?tag=frames`)

**Notes to reviewers**
N/A

**How has it been tested?**
Manually

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
