### PR TITLE
Add utc to example message

### DIFF
--- a/apps/base-docs/tutorials/docs/5_farcaster-cast-actions-simple.md
+++ b/apps/base-docs/tutorials/docs/5_farcaster-cast-actions-simple.md
@@ -127,7 +127,7 @@ const date = now.toLocaleDateString();
 const time = now.toLocaleTimeString();
 
 // Format them as a string
-const dateTime = `${date} ${time}`;
+const dateTime = `${date} ${time} UTC`;
 
 return NextResponse.json({ message: dateTime }, { status: 200 });
 ```


### PR DESCRIPTION
**What changed? Why?**
Example for a frame action doesn't specify timezone.  Community member pointed out it was confusing.  Updated to specify UTC since I don't think we can see the user's timezone in the request.

**Notes to reviewers**

**How has it been tested?**

**Does this PR add a new token to the bridge?**

Are you adding an entry to [`assets.ts`](../apps/bridge/assets.ts)?

- [x] No, this PR does not add a new token to the bridge
- [x] Yes, and I've confirmed this token doesn't use a bridge override
- [ ] Yes, and I've confirmed this token is an OptimismMintableERC20

If you are adding a token to the bridge, please include evidence of both confirmations above for your reviewers.
