### PR TITLE
fix tag error

### DIFF
--- a/apps/base-docs/src/pages/tutorials/index.jsx
+++ b/apps/base-docs/src/pages/tutorials/index.jsx
@@ -126,9 +126,13 @@ export default function Tutorials() {
             <div className={clsx(styles.tutorialList)}>
               {tutorialData &&
                 Object.values(tutorialData)
-                  .filter((tutorial) =>
-                    selectedTag == 'all' ? tutorial : tutorial.tags.includes(selectedTag),
-                  )
+                  .filter((tutorial) => {
+                    if (tutorial.tags) {
+                      return selectedTag == 'all' ? tutorial : tutorial.tags.includes(selectedTag)
+                    } else {
+                      return false
+                    }
+                  })
                   .map((tutorial) => <TutorialListCell tutorial={tutorial} />)}
             </div>
           </div>

--- a/apps/base-docs/tutorials/docs/2_account-abstraction-with-particle-network.md
+++ b/apps/base-docs/tutorials/docs/2_account-abstraction-with-particle-network.md
@@ -3,6 +3,9 @@ title: Account Abstraction on Base using Particle Network
 slug: /account-abstraction-with-particle-network
 description: A walkthrough on Particle Network's Modular Smart Wallet-as-a-Service, leveraging account abstraction and social logins across various providers.
 author: TABASCOatw
+tags: [
+    'account abstraction'
+  ]
 keywords:
   [
     Account Abstraction,


### PR DESCRIPTION
**What changed? Why?**
The check for tags in tutorials doesn't have a check to ensure the tags field exists. This change returns false if no tags field exists on the docs metadata

**Notes to reviewers**

**How has it been tested?**
Built site locally, confirmed fix works

**Does this PR add a new token to the bridge?**
no

Are you adding an entry to [`assets.ts`](../apps/bridge/assets.ts)?

- [X] No, this PR does not add a new token to the bridge
- [ ] Yes, and I've confirmed this token doesn't use a bridge override
- [ ] Yes, and I've confirmed this token is an OptimismMintableERC20

If you are adding a token to the bridge, please include evidence of both confirmations above for your reviewers.
