### PR TITLE
Use getServerSideProps instead of getStaticProps to fetch jobs

### DIFF
--- a/apps/web/pages/jobs.tsx
+++ b/apps/web/pages/jobs.tsx
@@ -2,7 +2,7 @@ import { JobsList, JobType } from 'apps/web/src/components/Jobs/JobsList';
 import Head from 'next/head';
 import { greenhouseApiUrl } from 'apps/web/src/constants';
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   const res = await fetch(`${greenhouseApiUrl}/boards/basejobs/jobs?content=true`);
   const { jobs } = (await res.json()) as { jobs: JobType[] };
   return {


### PR DESCRIPTION
**What changed? Why?**
Fixes https://github.com/base-org/web/issues/451.

Instead of using [getStaticProps](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-static-props) to fetch jobs, this PR uses [getServerSideProps](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props). `getServerSideProps` will fetch data at request time, rather than build time. This will be slight performance hit but will fix the issue where the jobs page returns no jobs even though jobs exist.

**Notes to reviewers**

**How has it been tested?**
Locally

**Does this PR add a new token to the bridge?**
No

Are you adding an entry to [`assets.ts`](../apps/bridge/assets.ts)?

- [x] No, this PR does not add a new token to the bridge
- [ ] Yes, and I've confirmed this token doesn't use a bridge override
- [ ] Yes, and I've confirmed this token is an OptimismMintableERC20

If you are adding a token to the bridge, please include evidence of both confirmations above for your reviewers.
