### PR TITLE
Fix nav align on mobile

### DIFF
--- a/apps/web/src/components/Layout/Nav/DesktopNav.tsx
+++ b/apps/web/src/components/Layout/Nav/DesktopNav.tsx
@@ -124,87 +124,85 @@ function IconLink({
 
 function DesktopNav({ color }: DesktopNavProps) {
   return (
-    <div className="hidden w-full flex-row items-center lg:flex">
-      <div className="flex h-full w-full flex-row items-center justify-between">
-        <Dropdown label="Ecosystem" color={color}>
-          <DropdownLink href="/ecosystem" label="Apps" color={color} />
-          <DropdownLink
-            href="https://paragraph.xyz/@grants.base.eth/calling-based-builders"
-            label="Grants"
-            color={color}
-            externalLink
-          />
-        </Dropdown>
-        <a
-          href={bridgeUrl}
-          className={`inline-flex items-center font-mono text-xl ${
-            color === 'black' ? 'text-black' : 'text-white'
-          }`}
-          target="_blank"
-          rel="noreferrer noopener"
-        >
-          Bridge
-        </a>
-        <Dropdown label="Developers" color={color}>
-          <DropdownLink href={docsUrl} label="Docs" color={color} externalLink />
-          <DropdownLink
-            href="https://explorer.base.org/"
-            label="Block Explorer"
-            color={color}
-            externalLink
-          />
-          <DropdownLink href="https://status.base.org" label="Status" color={color} externalLink />
-          <DropdownLink
-            href="https://hackerone.com/coinbase"
-            label="Bug Bounty"
-            color={color}
-            externalLink
-          />
-          <DropdownLink
-            href="https://github.com/base-org"
-            label="GitHub"
-            color={color}
-            externalLink
-          />
-        </Dropdown>
-        <Dropdown label="About" color={color}>
-          <DropdownLink href="/about" label="Mission" color={color} />
-          <DropdownLink href="https://base.mirror.xyz" label="Blog" color={color} externalLink />
-          <DropdownLink href="/jobs" label="Jobs" color={color} />
-        </Dropdown>
-        <Dropdown label="Socials" className="align-text-bottom" color={color}>
-          <IconLink
-            href="https://warpcast.com/~/channel/base"
-            icon="farcaster"
-            label="Farcaster"
-            color={color}
-            title="Join us on Warpcast"
-          />
-          <IconLink
-            href="https://discord.com/invite/buildonbase"
-            icon="discord"
-            label="Discord"
-            color={color}
-            title="Join us on Discord"
-          />
-          <IconLink
-            href="https://twitter.com/base"
-            icon="twitter"
-            label="Twitter"
-            color={color}
-            title="Join us on Twitter"
-          />
-          <IconLink
-            href="https://github.com/base-org"
-            icon="github"
-            label="Github"
-            color={color}
-            title="Join us on Github"
-          />
-        </Dropdown>
+    <div className="hidden h-full w-fit flex-grow flex-row items-center items-center justify-between lg:flex">
+      <Dropdown label="Ecosystem" color={color}>
+        <DropdownLink href="/ecosystem" label="Apps" color={color} />
+        <DropdownLink
+          href="https://paragraph.xyz/@grants.base.eth/calling-based-builders"
+          label="Grants"
+          color={color}
+          externalLink
+        />
+      </Dropdown>
+      <a
+        href={bridgeUrl}
+        className={`inline-flex items-center font-mono text-xl ${
+          color === 'black' ? 'text-black' : 'text-white'
+        }`}
+        target="_blank"
+        rel="noreferrer noopener"
+      >
+        Bridge
+      </a>
+      <Dropdown label="Developers" color={color}>
+        <DropdownLink href={docsUrl} label="Docs" color={color} externalLink />
+        <DropdownLink
+          href="https://explorer.base.org/"
+          label="Block Explorer"
+          color={color}
+          externalLink
+        />
+        <DropdownLink href="https://status.base.org" label="Status" color={color} externalLink />
+        <DropdownLink
+          href="https://hackerone.com/coinbase"
+          label="Bug Bounty"
+          color={color}
+          externalLink
+        />
+        <DropdownLink
+          href="https://github.com/base-org"
+          label="GitHub"
+          color={color}
+          externalLink
+        />
+      </Dropdown>
+      <Dropdown label="About" color={color}>
+        <DropdownLink href="/about" label="Mission" color={color} />
+        <DropdownLink href="https://base.mirror.xyz" label="Blog" color={color} externalLink />
+        <DropdownLink href="/jobs" label="Jobs" color={color} />
+      </Dropdown>
+      <Dropdown label="Socials" className="align-text-bottom" color={color}>
+        <IconLink
+          href="https://warpcast.com/~/channel/base"
+          icon="farcaster"
+          label="Farcaster"
+          color={color}
+          title="Join us on Warpcast"
+        />
+        <IconLink
+          href="https://discord.com/invite/buildonbase"
+          icon="discord"
+          label="Discord"
+          color={color}
+          title="Join us on Discord"
+        />
+        <IconLink
+          href="https://twitter.com/base"
+          icon="twitter"
+          label="Twitter"
+          color={color}
+          title="Join us on Twitter"
+        />
+        <IconLink
+          href="https://github.com/base-org"
+          icon="github"
+          label="Github"
+          color={color}
+          title="Join us on Github"
+        />
+      </Dropdown>
 
-        <ConnectWalletButton color={color} className="relative inline-block" />
-      </div>
+      <ConnectWalletButton color={color} className="relative inline-block" />
     </div>
   );
 }

--- a/apps/web/src/components/Layout/Nav/MobileMenu.tsx
+++ b/apps/web/src/components/Layout/Nav/MobileMenu.tsx
@@ -155,7 +155,7 @@ function MobileMenu({ color }: MobileMenuProps) {
           >
             <div className="flex justify-between">
               <Link href="/" onClick={handleMenuClose}>
-                <Logo color="white" />
+                <Logo color="white" width="106px" />
               </Link>
               <button
                 className="appearance-none"

--- a/apps/web/src/components/Layout/Nav/Nav.tsx
+++ b/apps/web/src/components/Layout/Nav/Nav.tsx
@@ -18,7 +18,7 @@ export function Nav({ color }: NavProps) {
       <NftBanner />
       <nav className="bg-transparent z-10 flex h-24 w-full max-w-[1440px] flex-row items-center justify-between gap-16 self-center p-8">
         <Link href="/" aria-label="Base Homepage">
-          <Logo color={color} path={pathname} />
+          <Logo color={color} path={pathname} width="106px" />
         </Link>
         <DesktopNav color={color} />
         <MobileMenu color={color} />


### PR DESCRIPTION
**What changed? Why?**

Previously:

<img width="686" alt="Screenshot 2024-04-26 at 12 32 26 PM" src="https://github.com/base-org/web/assets/1297679/ee8a2b1f-5469-4e14-9c74-0be3f00cbee2">

![IMG_5163](https://github.com/base-org/web/assets/1297679/91dfbf18-a878-400d-82bc-e45d4e7f149a)

Now:

![IMG_5164](https://github.com/base-org/web/assets/1297679/fb4898c2-b5ed-4481-8fbc-b6600c1dc811)
![IMG_5165](https://github.com/base-org/web/assets/1297679/8414529f-2285-4559-86a1-27edde0f6bcc)


**Notes to reviewers**


**How has it been tested?**

Manually using remote debugging on local iOS device.

**Does this PR add a new token to the bridge?**

Are you adding an entry to [`assets.ts`](../apps/bridge/assets.ts)?

- [ ] No, this PR does not add a new token to the bridge
- [ ] Yes, and I've confirmed this token doesn't use a bridge override
- [ ] Yes, and I've confirmed this token is an OptimismMintableERC20

If you are adding a token to the bridge, please include evidence of both confirmations above for your reviewers.
