### PR TITLE
docs(frame-transactions): Drop warning regarding no support for testnet

### DIFF
--- a/apps/base-docs/tutorials/docs/3_farcaster-frames-transactions.md
+++ b/apps/base-docs/tutorials/docs/3_farcaster-frames-transactions.md
@@ -185,12 +185,6 @@ import { base } from 'viem/chains';
 import type { FrameTransactionResponse } from '@coinbase/onchainkit/frame';
 ```
 
-:::caution
-
-At the time of writing, Base Sepolia is not yet on the list of approved chains, but is in the process of being added.
-
-:::
-
 Finally, you'll need to import the ABI and address for your contract. If you're using a tool that exports the ABI as an object, you can add it as below after adding the folder and file for the ABI. Make sure you have `const abi =` before the array containing the ABI, and `export default abi;`.
 
 You also need to add the contract address to `config.ts`.


### PR DESCRIPTION
**What changed? Why?**

Drops the warning that there is no support for testnet

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost

**Does this PR add a new token to the bridge?**

Are you adding an entry to [`assets.ts`](../apps/bridge/assets.ts)?

- [X] No, this PR does not add a new token to the bridge
- [ ] Yes, and I've confirmed this token doesn't use a bridge override
- [ ] Yes, and I've confirmed this token is an OptimismMintableERC20

If you are adding a token to the bridge, please include evidence of both confirmations above for your reviewers.
