### PR TITLE
docs(pr-template): Drop token questionnaire from pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,13 +3,3 @@
 **Notes to reviewers**
 
 **How has it been tested?**
-
-**Does this PR add a new token to the bridge?**
-
-Are you adding an entry to [`assets.ts`](../apps/bridge/assets.ts)?
-
-- [ ] No, this PR does not add a new token to the bridge
-- [ ] Yes, and I've confirmed this token doesn't use a bridge override
-- [ ] Yes, and I've confirmed this token is an OptimismMintableERC20
-
-If you are adding a token to the bridge, please include evidence of both confirmations above for your reviewers.


### PR DESCRIPTION
**What changed? Why?**

We haven't seen any pull requests adding tokens directly to the bridge for many weeks so I was thinking we can drop this since it is not relevant for most contributors

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost

**Does this PR add a new token to the bridge?**

Are you adding an entry to [`assets.ts`](../apps/bridge/assets.ts)?

- [X] No, this PR does not add a new token to the bridge
- [ ] Yes, and I've confirmed this token doesn't use a bridge override
- [ ] Yes, and I've confirmed this token is an OptimismMintableERC20

If you are adding a token to the bridge, please include evidence of both confirmations above for your reviewers.
