### PR TITLE
docs(bridge): Update banner and FAQs

### DIFF
--- a/apps/bridge/pages/_app.tsx
+++ b/apps/bridge/pages/_app.tsx
@@ -136,7 +136,21 @@ function Root({ Component, pageProps }: AppProps) {
                       <div className="flex w-full flex-col">
                         <div className="flex w-full flex-row items-center gap-4 bg-notice-blue px-8 py-3 text-center font-sans text-sm font-bold text-white">
                           <Image alt="tooltip" src="/icons/alert.svg" width={16} height={16} />
-                          <p>This bridge is being replaced on May 10. See FAQs for details.</p>
+                          <p>
+                            As Base continues to decentralize, beginning May 10th bridge.base.org
+                            will redirect to{' '}
+                            <a
+                              href="https://superbridge.com/base"
+                              target="_blank"
+                              rel="noreferrer"
+                              className="underline"
+                            >
+                              Superbridge
+                            </a>{' '}
+                            and other bridges (collectively, "Superchain bridges"). Superchain
+                            bridges are available to initiate and complete deposits and withdrawals
+                            to and from Base. Please see our FAQs on this page for details.
+                          </p>
                         </div>
                       </div>
                       {allowedPaths.has(pathname) && (

--- a/apps/bridge/pages/_app.tsx
+++ b/apps/bridge/pages/_app.tsx
@@ -147,9 +147,10 @@ function Root({ Component, pageProps }: AppProps) {
                             >
                               Superbridge
                             </a>{' '}
-                            and other bridges (collectively, "Superchain bridges"). Superchain
-                            bridges are available to initiate and complete deposits and withdrawals
-                            to and from Base. Please see our FAQs on this page for details.
+                            and other bridges (collectively, &quot;Superchain bridges&quot;).
+                            Superchain bridges are available to initiate and complete deposits and
+                            withdrawals to and from Base. Please see our FAQs on this page for
+                            details.
                           </p>
                         </div>
                       </div>

--- a/apps/bridge/src/components/Faq/FaqSidebar.tsx
+++ b/apps/bridge/src/components/Faq/FaqSidebar.tsx
@@ -16,8 +16,8 @@ export function FaqSidebar() {
         question="How can I bridge to or withdraw from Base after the bridge has been deprecated?"
         answer={
           <>
-            Once deprecated, bridge.base.org will direct users to “Superchain Bridges” selected by
-            Base and the Optimism teams, one of which is{' '}
+            Once deprecated, bridge.base.org will direct users to &quot;Superchain Bridges&quot;
+            selected by Base and the Optimism teams, one of which is{' '}
             <a
               href="https://superbridge.com/base"
               target="_blank"

--- a/apps/bridge/src/components/Faq/FaqSidebar.tsx
+++ b/apps/bridge/src/components/Faq/FaqSidebar.tsx
@@ -5,19 +5,19 @@ export function FaqSidebar() {
     <div className="flex h-full w-full flex-col p-4 font-sans lg:w-[420px] lg:border-l lg:border-sidebar-border">
       <span className="mb-8 text-base font-medium text-stone-400">Frequently asked questions</span>
       <QuestionAccordion
-        question="Why is Base deprecating their bridge?"
+        question="Why is Base deprecating the bridge on bridge.base.org?"
         answer="Base is committed to decentralization and the Superchain vision. Leveraging the community to bootstrap the Superchain bridges is a step in that direction; increasing censorship resistance and decentralization."
       />
       <QuestionAccordion
-        question="Can I still use the Base bridge?"
-        answer="Yes, you can use the Base bridge until the frontend is deprecated (no sooner than 5/10)"
+        question="Can I still use the bridge on bridge.base.org?"
+        answer="You can use Base bridge until the frontend is deprecated on May 10th."
       />
       <QuestionAccordion
-        question="How can I bridge to Base after the bridge has been deprecated?"
+        question="How can I bridge to or withdraw from Base after the bridge has been deprecated?"
         answer={
           <>
-            Once deprecated, bridge.base.org will direct users to the two “Superchain Bridges”
-            selected by Base and the Optimism teams, one of which is{' '}
+            Once deprecated, bridge.base.org will direct users to “Superchain Bridges” selected by
+            Base and the Optimism teams, one of which is{' '}
             <a
               href="https://superbridge.com/base"
               target="_blank"
@@ -26,14 +26,32 @@ export function FaqSidebar() {
             >
               Superbridge
             </a>
-            . Both of these sites remain available to initiate and complete deposits and withdrawals
-            to and from Base
+            . Superchain Bridges remain available to initiate and complete deposits and withdrawals
+            to and from Base.
           </>
         }
       />
       <QuestionAccordion
         question="Can I initiate a withdrawal within 7 days of the Bridge being deprecated?"
-        answer="Yes. The Base bridge frontend will be fully functional until it is deprecated. If you initiate a withdrawal within 7 days of deprecation, you will receive your funds after the challenge period has closed."
+        answer={
+          <>
+            Yes, however, in the event you are unable to complete your withdraw within the 7 day
+            period, you will need to use a Superchain Bridge such as{' '}
+            <a
+              href="https://superbridge.com/base"
+              target="_blank"
+              rel="noreferrer"
+              className="underline"
+            >
+              Superbridge
+            </a>
+            &nbsp;to complete your withdrawal.
+          </>
+        }
+      />
+      <QuestionAccordion
+        question="Who operates Superchain Bridges like Superbridge.com?"
+        answer='Superbridge and Superchain Bridges are operated by third parties, not by Coinbase Technologies, Inc. ("Coinbase"). Coinbase does not control, operate, or assume any responsibility for the performance of these external platforms. Before using any Superchain Bridge, you may be required to agree to their terms and conditions. We strongly recommend you review these terms carefully, as well as any privacy policies, to understand your rights and obligations. The integration or inclusion of the Superchain Bridges does not imply an endorsement or recommendation of any bridge by Coinbase.'
       />
       <QuestionAccordion
         question="What is Base Bridge?"


### PR DESCRIPTION
**What changed? Why?**

Updates the banner with deprecation date, expands additional FAQs and adds link to Superbridge

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost

![2024-05-04 at 01 22 02@2x](https://github.com/base-org/web/assets/1130872/12ab4ede-b2c1-4635-9589-593f4199c295)
