### PR TITLE
Update data-indexers.md to include GhostGraph

### DIFF
--- a/apps/base-docs/docs/tools/data-indexers.md
+++ b/apps/base-docs/docs/tools/data-indexers.md
@@ -87,6 +87,20 @@ To get started, visit the [documentation](https://docs.envio.dev/docs/overview) 
 
 ---
 
+## GhostGraph
+
+[GhostGraph](https://GhostGraph.xyz/) makes it easy to build blazingly fast indexers (subgraphs) for smart contracts.
+
+GhostGraph is the first indexing solution that lets you write your index transformations in **Solidity**. Base dApps can query data with GraphQL using our hosted endpoints.
+
+To get started, you can [sign up for an account](https://app.ghostlogs.xyz/ghostgraph/sign-up) and follow [this quickstart](https://docs.ghostlogs.xyz/category/-getting-started-1) guide on how to create, deploy, and query a GhostGraph.
+
+#### Supported Networks
+
+- Base Mainnet
+
+---
+
 ## Moralis
 
 [Moralis](https://moralis.io/?utm_source=base-docs&utm_medium=partner-docs) offers comprehensive data APIs for crypto, offering both indexed and real-time data across 15+ chains. Moralis' APIs include portfolio and wallet balances, NFT data, token data, price data, candlestick data, net worth data, and a lot more. All of the data is enriched with things like metadata, parsed events and address labels.


### PR DESCRIPTION
This PR added GhostGraph to `data-indexers.md` file

## **What changed? Why?**

Added GhostGraph as a data indexer for Base data in data-indexers.md

## **How has it been tested?**
* Run `yarn workspace @app/base-docs dev`
* Navigate to `http://localhost:3000/docs/tools/data-indexers`
* Validate that the changes worked as expected: ![GhostGraph_Base_Docs](https://github.com/base-org/web/assets/13743841/9bf9c7a1-0a65-4db7-b684-5c8f9a6ba598)

## **Does this PR add a new token to the bridge?**
* No, this PR does not add a new token to the bridge
* [NA] I've confirmed this token doesn't use a bridge override
* [NA] I've confirmed this token is an OptimismMintableERC20

## **More Info**
* https://twitter.com/0xGhostLogs/status/1790415744833843659