### PR TITLE
Change docs link

### DIFF
--- a/apps/web/src/components/OnchainSummer/RewardsBlock.tsx
+++ b/apps/web/src/components/OnchainSummer/RewardsBlock.tsx
@@ -81,7 +81,7 @@ export default function RewardsBlock() {
             title="Gas Credits"
             description="Sponsor transactions and offer gasless experiences. Available through the Coinbase Developer Platform and other builders."
             linkText="Claim today"
-            link="https://docs.cloud.coinbase.com/base-node/docs/paymaster-bundler-qs"
+            link="https://docs.cdp.coinbase.com/node/docs/paymaster-bundler-qs/"
           />
           <RewardCard
             num="03"


### PR DESCRIPTION
**What changed? Why?**

Coinbase docs changed their domains and the redirects don't work properly.

**Notes to reviewers**

**How has it been tested?**
