### PR TITLE
Add Bountycaster CTA, update SEO, & small fixes

### DIFF
--- a/apps/web/pages/_document.tsx
+++ b/apps/web/pages/_document.tsx
@@ -56,9 +56,9 @@ const ogDataForPath: Record<string, CustomDocumentProps['ogData']> = {
     url: 'https://base.org/third-party-cookies',
   },
   '/buildersummer': {
-    title: 'Base | Builder Summer',
+    title: 'Onchain Summer | Buildathon',
     description:
-      'We’re bringing back Onchain Summer to unleash onchain creativity, and invite everyone to build all summer long. Build, create, and get rewarded.',
+      'Onchain Summer is back to unleash onchain creativity and invite everyone to build all summer long. Build, create, and get rewarded. June – August 2024.',
     image: 'https://base.org/images/ocs/buildersummer_og.png',
     url: 'https://base.org/buildersummer',
   },

--- a/apps/web/pages/buildersummer.tsx
+++ b/apps/web/pages/buildersummer.tsx
@@ -12,9 +12,9 @@ export default function OnChainSummer() {
   return (
     <>
       <Head>
-        <title>Base | About</title>
+        <title>Onchain Summer | Buildathon</title>
         <meta
-          content="We’re bringing back Onchain Summer to unleash onchain creativity, and invite everyone to build all summer long. Build, create, and get rewarded."
+          content="Onchain Summer is back to unleash onchain creativity and invite everyone to build all summer long. Build, create, and get rewarded. June – August 2024."
           name="description"
         />
       </Head>

--- a/apps/web/pages/buildersummer.tsx
+++ b/apps/web/pages/buildersummer.tsx
@@ -10,14 +10,6 @@ import Head from 'next/head';
 
 export default function OnChainSummer() {
   return (
-    <>
-      <Head>
-        <title>Onchain Summer | Buildathon</title>
-        <meta
-          content="Onchain Summer is back to unleash onchain creativity and invite everyone to build all summer long. Build, create, and get rewarded. June – August 2024."
-          name="description"
-        />
-      </Head>
       <main className="flex w-full flex-col items-center bg-white">
         <div className="flex w-full flex-col items-center px-1 md:px-4">
           <Hero />
@@ -30,6 +22,5 @@ export default function OnChainSummer() {
           <ResourcesBlock />
         </div>
       </main>
-    </>
   );
 }

--- a/apps/web/pages/buildersummer.tsx
+++ b/apps/web/pages/buildersummer.tsx
@@ -6,21 +6,20 @@ import ResourcesBlock from 'apps/web/src/components/OnchainSummer/ResourcesBlock
 import RewardsBlock from 'apps/web/src/components/OnchainSummer/RewardsBlock';
 import SponsorsBlock from 'apps/web/src/components/OnchainSummer/SponsorsBlock';
 import ToolsBlock from 'apps/web/src/components/OnchainSummer/ToolsBlock';
-import Head from 'next/head';
 
 export default function OnChainSummer() {
   return (
-      <main className="flex w-full flex-col items-center bg-white">
-        <div className="flex w-full flex-col items-center px-1 md:px-4">
-          <Hero />
-          <AboutBlock />
-          <RewardsBlock />
-          <EventsBlock />
-          <SponsorsBlock />
-          <CommunityEventsBlock />
-          <ToolsBlock />
-          <ResourcesBlock />
-        </div>
-      </main>
+    <main className="flex w-full flex-col items-center bg-white">
+      <div className="flex w-full flex-col items-center px-1 md:px-4">
+        <Hero />
+        <AboutBlock />
+        <RewardsBlock />
+        <EventsBlock />
+        <SponsorsBlock />
+        <CommunityEventsBlock />
+        <ToolsBlock />
+        <ResourcesBlock />
+      </div>
+    </main>
   );
 }

--- a/apps/web/src/components/OnchainSummer/EventsBlock.tsx
+++ b/apps/web/src/components/OnchainSummer/EventsBlock.tsx
@@ -9,24 +9,34 @@ function EventCard({
   num,
   title,
   description,
+  link,
+  linkText = 'Learn more',
 }: {
   num: string;
   title: string;
   description: string;
+  link?: string;
+  linkText?: string;
 }) {
   return (
-    <div className="group flex flex-col justify-between gap-2 rounded-[5px] border-[1.5px] border-solid border-black p-4 duration-200 hover:bg-[#E9E8E8] md:min-h-[360px] lg:w-[400px] lg:min-w-[200px]">
-      <div className="flex flex-col md:gap-16">
-        <div className="flex flex-col">
-          <div className="flex flex-row items-center gap-2">
-            <EmptyBlackCircle />
-            <span className="text-l font-mono font-light">{num}</span>
-          </div>
-          <span className="mb-8 text-2xl font-light md:text-4xl">{title}</span>
+    <a
+      href={link}
+      target={link ? '_blank' : undefined}
+      rel="noreferrer noopener"
+      className="group flex min-w-[350px] flex-col justify-between gap-12 rounded-[5px] border-[1.5px] border-solid border-blue-600 p-4 duration-200 hover:bg-[#E9E8E8] hover:text-black md:w-[400px]"
+    >
+      <div className="flex flex-col">
+        <div className="flex flex-row items-center gap-2">
+          <EmptyBlackCircle />
+          <span className="text-l font-mono font-light">{num}</span>
         </div>
+        <span className="mb-8 text-2xl font-light uppercase md:text-4xl">{title}</span>
       </div>
-      <div className="text-lg">{description}</div>
-    </div>
+      <div className="flex flex-col">
+        <div className="text-lg">{description}</div>
+        {link && <div className="text my-4 font-mono uppercase">[→] {linkText}</div>}
+      </div>
+    </a>
   );
 }
 
@@ -67,12 +77,14 @@ function HackathonSlab() {
           <EventCard
             num="01"
             title="200 ETH IN REWARDS"
-            description="Split across tracks and teams; every winning team is eligible for 2-10 ETH"
+            description="Split across tracks and teams; every winning team is eligible for 2-10 ETH."
           />
           <EventCard
             num="02"
             title="COMMUNITY TRACK HOSTED BY BOUNTYCASTER"
-            description="Challenge the community with your ideas or pick up challenges that spark your interest"
+            description="Challenge the community with your ideas or pick up challenges that spark your interest."
+            link="https://www.bountycaster.xyz/onchainsummer"
+            linkText="Post a bounty"
           />
           <EventCard
             num="03"

--- a/apps/web/src/components/OnchainSummer/SponsorsBlock.tsx
+++ b/apps/web/src/components/OnchainSummer/SponsorsBlock.tsx
@@ -78,11 +78,11 @@ export default function SponsorsBlock() {
       <FadeInSection>
         <div className="my-6 flex flex-col gap-6 px-8">
           <span className="text-5xl font-extrabold leading-9 md:text-7xl">
-            BUILDATION TR<Brit>a</Brit>CK <Brit axis={68}>s</Brit>PONSORS
+            BUILDATHON TR<Brit>a</Brit>CK <Brit axis={68}>s</Brit>PONSORS
           </span>
           <p className="mt-4 text-2xl md:text-4xl">
             8 tracks across commerce, payments, gaming, creator, social, and more. Sponsored by
-            leading builders and innovators
+            leading builders and innovators.
           </p>
         </div>
       </FadeInSection>


### PR DESCRIPTION
**What changed? Why?**

- Changed SEO metatitle from `Base | About` to `Onchain Summer | Buildathon`
- Added dates to SEO metadescription: `Onchain Summer is inviting everyone to unleash onchain creativity & build all summer long. Build, create, & get rewarded. Jun – Aug 2024.`
- Made small fixes for consistency (“Buildation” typo, added .’s where needed, etc.)
- Added a link + CTA to Bountycaster (https://www.bountycaster.xyz/onchainsummer) to its section

**Notes to reviewers**

**How has it been tested?**

Manually