### PR TITLE
Update HTTP Header for Coinbase Smart Wallet

### DIFF
--- a/apps/base-docs/server.js
+++ b/apps/base-docs/server.js
@@ -431,7 +431,7 @@ app.use(
     setHeaders: function (res) {
       res.setHeader('cache-control', 'no-store');
       res.setHeader('content-security-policy', cspObjectToString);
-      res.setHeader('cross-origin-opener-policy', 'same-origin');
+      res.setHeader('cross-origin-opener-policy', 'same-origin-allow-popups');
       res.setHeader('referrer-policy', 'strict-origin-when-cross-origin');
       res.setHeader('strict-transport-security', 'max-age=63072000; includeSubDomains; preload');
       res.setHeader('x-content-type-options', 'nosniff');

--- a/apps/bridge/next.config.js
+++ b/apps/bridge/next.config.js
@@ -103,7 +103,7 @@ const securityHeaders = [
   },
   {
     key: 'cross-origin-opener-policy',
-    value: 'same-origin',
+    value: 'same-origin-allow-popups',
   },
   {
     key: 'referrer-policy',

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -110,7 +110,7 @@ const securityHeaders = [
   },
   {
     key: 'cross-origin-opener-policy',
-    value: 'same-origin',
+    value: 'same-origin-allow-popups',
   },
   {
     key: 'referrer-policy',


### PR DESCRIPTION
**What changed? Why?**

- Currently, using Coinbase Smart Wallet on base.org results in an infinite spinner because the website fails to communicate with the popup. This is due to the `Cross-Origin-Opener-Policy` HTTP header being set to `same-origin` which prevents the popup from accessing the `window.opener` property
  - This PR updates the header to `same-origin-allow-popups` which allows the Smart Wallet popup to access `window.opener` and establish the connection

**Notes to reviewers**

**How has it been tested?**


| Before | After |
| ------------- | ------------- |
| <video src="https://github.com/base-org/web/assets/16995513/ba228ebd-d3ad-42db-adbc-655b60986a78">  | <video src="https://github.com/base-org/web/assets/16995513/21777265-44e3-484c-bf15-67d3a9cd4e97">|







