### PR TITLE
docs(token-list): Drop bridge.base.org language

### DIFF
--- a/apps/base-docs/docs/tokens/token-list.md
+++ b/apps/base-docs/docs/tokens/token-list.md
@@ -40,4 +40,4 @@ Follow the instructions in the [GitHub repository](https://github.com/ethereum-o
 
 ### Step 3: Await final approval
 
-Reviews are regularly conducted by the Base team and you should receive a reply within 24-72 hours (depending on if the PR was opened on a week day, weekend or holiday).
+Reviews are regularly conducted by the Base team and you should receive a reply within 24-72 hours (depending on if the PR is opened on a week day, weekend or holiday).

--- a/apps/base-docs/docs/tokens/token-list.md
+++ b/apps/base-docs/docs/tokens/token-list.md
@@ -20,9 +20,7 @@ hide_table_of_contents: true
 
 # The Base Token List
 
-This page is intended for token issuers who already have an ERC-20 contract deployed on Ethereum and would like to submit their token for bridging between Ethereum and Base and Base Mainnet to Base Bridge and other bridges. Base uses the [Optimism Superchain token list](https://github.com/ethereum-optimism/ethereum-optimism.github.io) as a reference for tokens that have been deployed on Base.
-
-**_Note - Tokens approved in the Github repository are not necessarily listed on the Base Bridge._**
+This page is intended for token issuers who already have an ERC-20 contract deployed on Ethereum and would like to submit their token for bridging between Ethereum and Base. Base uses the [Optimism Superchain token list](https://github.com/ethereum-optimism/ethereum-optimism.github.io) as a reference for tokens that have been deployed on Base.
 
 **_Disclaimer: Base does not endorse any of the tokens that are listed in the Github repository and has conducted only preliminary checks, which include automated checks listed_** [**_here_**](https://github.com/ethereum-optimism/ethereum-optimism.github.io)**_._**
 
@@ -42,4 +40,4 @@ Follow the instructions in the [GitHub repository](https://github.com/ethereum-o
 
 ### Step 3: Await final approval
 
-Tokens approved in the Github repository are not necessarily listed on the Base Bridge and are not guaranteed or automatic. Base Bridge reviews are conducted manually by the Base team. For more information, please visit our [Discord](https://base.org/discord).
+Reviews are regularly conducted by the Base team and you should receive a reply within 24-72 hours (depending on if the PR was opened on a week day, weekend or holiday).


### PR DESCRIPTION
**What changed? Why?**

This drops a docs reference to the official Base Bridge which has now been deprecated

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost