### PR TITLE
Fix early termination of the filestream

### DIFF
--- a/apps/web/pages/onchainfont.tsx
+++ b/apps/web/pages/onchainfont.tsx
@@ -9,12 +9,24 @@ export async function getServerSideProps({ res }: { res: NextApiResponse }) {
   res.setHeader('Content-Disposition', 'attachment; filename=BritneyOnchain.zip');
   res.setHeader('Content-Type', 'application/octet-stream');
 
-  const fileStream = fs.createReadStream(filePath);
-  fileStream.pipe(res);
+  return new Promise((resolve, reject) => {
+    // Create a readable stream
+    const fileStream = fs.createReadStream(filePath);
 
-  return {
-    props: {},
-  };
+    // Pipe the file stream to the response
+    fileStream.pipe(res);
+
+    // Handle stream events
+    fileStream.on('end', () => {
+      res.end();
+      resolve({ props: {} });
+    });
+
+    fileStream.on('error', (err) => {
+      console.error(err);
+      reject(err);
+    });
+  });
 }
 
 function OnchainFont() {


### PR DESCRIPTION
**What changed? Why?**

Previously the downloaded zip file could fail to open because the response handler would resolve before the file finished streaming.

**Notes to reviewers**

**How has it been tested?**

Manually expanding the resulting zip file.
