### PR TITLE
chore: fix relative links in mdx files

### DIFF
--- a/apps/base-docs/docs/cookie-policy.mdx
+++ b/apps/base-docs/docs/cookie-policy.mdx
@@ -22,7 +22,7 @@ control our use of them.
 
 In some cases, we may use cookies and similar technologies to collect personal information,
 or information that becomes personal information if we combine it with other information.
-In such cases, the [Base Privacy Policy](/privacy-policy) will apply
+In such cases, the [Base Privacy Policy](./privacy-policy.md) will apply
 in addition to this Cookie Policy.
 
 ## 1. What Are Cookies?

--- a/apps/base-docs/tutorials/docs/0_deploy-with-foundry.md
+++ b/apps/base-docs/tutorials/docs/0_deploy-with-foundry.md
@@ -206,7 +206,7 @@ To deploy the contract to the Base Sepolia test network, run the following comma
 forge create ./src/NFT.sol:NFT --rpc-url $BASE_SEPOLIA_RPC --account deployer
 ```
 
-The contract will be deployed on the Base Sepolia test network. You can view the deployment status and contract by using a [block explorer](/tools/block-explorers) and searching for the address returned by your deploy script. If you've deployed an exact copy of the NFT contract above, it will already be verified and you'll be able to read and write to the contract using the web interface.
+The contract will be deployed on the Base Sepolia test network. You can view the deployment status and contract by using a [block explorer](/docs/tools/block-explorers) and searching for the address returned by your deploy script. If you've deployed an exact copy of the NFT contract above, it will already be verified and you'll be able to read and write to the contract using the web interface.
 
 :::info
 


### PR DESCRIPTION
**What changed? Why?**
There are 2 mdx files in the base docs set and each has 1 relative link -- both are broken as the syntax differs in an mdx vs md file.

**Notes to reviewers**


**How has it been tested?**
Was not tested against a locally run Docusaurus server