### PR TITLE
Add testnet interfaces for interacting w/ Uniswap contracts

### DIFF
--- a/apps/base-docs/docs/contracts.md
+++ b/apps/base-docs/docs/contracts.md
@@ -83,6 +83,12 @@ This page lists contract addresses for onchain apps that we have deployed.
 | `quoterV2`                           | [0xC5290058841028F1614F3A6F0F5816cAd0df5E27](https://sepolia.basescan.org/address/0xC5290058841028F1614F3A6F0F5816cAd0df5E27) |
 | `swapRouter`                         | [0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4](https://sepolia.basescan.org/0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4)         |
 
+:::info
+
+Two community projects, [BaseX](https://basex-test.vercel.app/swap?currencyA=ETH&currencyB=0x036CbD53842c5426634e7929541eC2318f3dCF7e&focus=source) and [DapDap](https://testnet.base.dapdap.net/uniswap/swap), provide testnet interfacts for Uniswap contracts if you prefer to interact in the browser instead of with the contracts directly.
+
+:::
+
 ### Uniswap v2
 
 | Contract  | Address                                                                                                                       |

--- a/apps/base-docs/docs/contracts.md
+++ b/apps/base-docs/docs/contracts.md
@@ -83,9 +83,11 @@ This page lists contract addresses for onchain apps that we have deployed.
 | `quoterV2`                           | [0xC5290058841028F1614F3A6F0F5816cAd0df5E27](https://sepolia.basescan.org/address/0xC5290058841028F1614F3A6F0F5816cAd0df5E27) |
 | `swapRouter`                         | [0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4](https://sepolia.basescan.org/0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4)         |
 
+#### Testnet interfaces
+
 :::info
 
-Two community projects, [BaseX](https://basex-test.vercel.app/swap?currencyA=ETH&currencyB=0x036CbD53842c5426634e7929541eC2318f3dCF7e&focus=source) and [DapDap](https://testnet.base.dapdap.net/uniswap/swap), provide testnet interfacts for Uniswap contracts if you prefer to interact in the browser instead of with the contracts directly.
+Two community projects, [BaseX](https://basex-test.vercel.app/swap?currencyA=ETH&currencyB=0x036CbD53842c5426634e7929541eC2318f3dCF7e&focus=source) and [DapDap](https://testnet.base.dapdap.net/uniswap/swap), provide testnet interfaces for Uniswap contracts if you prefer to interact in the browser instead of with the contracts directly.
 
 :::
 


### PR DESCRIPTION
**What changed? Why?**

Updates the contracts page to add links to Base Sepolia testnet interfaces

**Notes to reviewers**

![2024-06-03 at 21 40 42@2x](https://github.com/base-org/web/assets/1130872/28f021a9-f38d-4610-ad75-98e5c9b316f3)

**How has it been tested?**

Localhost