### PR TITLE
(fixes): fix tutorial broken link

### DIFF
--- a/apps/base-docs/tutorials/docs/2_coinbase-smart-wallet.md
+++ b/apps/base-docs/tutorials/docs/2_coinbase-smart-wallet.md
@@ -685,7 +685,7 @@ In this tutorial, you've learned how to connect users to your onchain app with t
 [viem]: https://viem.sh/
 [signMessage]: https://viem.sh/docs/actions/wallet/signMessage.html
 [OpenZeppelin]: https://www.openzeppelin.com/
-[Coinbase Smart Wallet]: www.smartwallet.dev
+[Coinbase Smart Wallet]: https://www.smartwallet.dev
 [passkeys]: https://fidoalliance.org/passkeys/
 [Building Onchain NFTs]: https://docs.base.org/tutorials/complex-onchain-nfts
 [rect]: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/rect


### PR DESCRIPTION
**What changed? Why?**

Broken link on https://docs.base.org/tutorials/coinbase-smart-wallet/

Coinbase Smart Wallet linked to `https://docs.base.org/tutorials/coinbase-smart-wallet/www.smartwallet.dev`

**Notes to reviewers**

N/A

**How has it been tested?**

`yarn workspace @app/base-docs dev` and tested locally
