### PR TITLE
Update Coinbase Onramp page

### DIFF
--- a/apps/base-docs/docs/tools/onramps.md
+++ b/apps/base-docs/docs/tools/onramps.md
@@ -15,7 +15,7 @@ keywords:
     payments,
     fiat to crypto,
     fiat,
-    Coinbase Pay,
+    Coinbase Onramp,
     MoonPay,
     Onramp,
   ]
@@ -26,9 +26,9 @@ hide_table_of_contents: true
 
 ---
 
-## Coinbase Pay
+## Coinbase Onramp
 
-[Coinbase Pay](https://www.coinbase.com/cloud/products/pay-sdk) is a fiat-to-crypto onramp that allows users to buy or transfer crypto directly from self-custody wallets and apps. Coinbase Pay supports 60+ fiat currencies with regulatory compliance and licensing, as well as 100+ cryptocurrencies, including ETH on Base. [Join the waitlist](https://www.coinbase.com/cloud/products/pay-sdk) to use the Pay SDK.
+[Coinbase Onramp](https://www.coinbase.com/developer-platform/products/onramp) is a fiat-to-crypto onramp that allows users to buy or transfer crypto directly from self-custody wallets and apps. Coinbase Onramp supports 60+ fiat currencies with regulatory compliance and licensing, as well as 100+ cryptocurrencies, including ETH on Base. [Get started here](https://www.coinbase.com/developer-platform/products/onramp) to use the Coinbase Developer Platform.
 
 ---
 

--- a/apps/web/src/data/ecosystem.json
+++ b/apps/web/src/data/ecosystem.json
@@ -1521,9 +1521,9 @@
     "imageUrl": "/images/partners/commerce.webp"
   },
   {
-    "name": "Coinbase Pay",
-    "url": "https://www.coinbase.com/cloud/products/pay-sdk",
-    "description": "Let your users buy or transfer digital assets with the most trusted name in crypto. Join the waitlist for access to the SDK.",
+    "name": "Coinbase Onramp",
+    "url": "https://www.coinbase.com/developer-platform/products/onramp",
+    "description": "Let your users buy or transfer digital assets with the most trusted name in crypto.",
     "tags": [
       "onramp"
     ],


### PR DESCRIPTION
**What changed? Why?**

- Update naming from Coinbase Pay to Coinbase Onramp
- Update language to say they can get started by going to Coinbase Developer Platform [here](https://docs.cdp.coinbase.com/onramp/docs/getting-started/) instead of joining the waitlist
- Update URL for marketing link to https://www.coinbase.com/developer-platform/products/onramp instead of https://www.coinbase.com/cloud/products/pay-sdk

**Notes to reviewers**

**How has it been tested?**

Ran locally
