### PR TITLE
docs(node): Bump HDD requirements

### DIFF
--- a/apps/base-docs/tutorials/docs/0_run-a-base-node.md
+++ b/apps/base-docs/tutorials/docs/0_run-a-base-node.md
@@ -60,7 +60,7 @@ We recommend you have this configuration to run a node:
 
 - 8-Core CPU
 - at least 16 GB RAM
-- an SSD drive with at least 700GB (full node) or 4TB (archive node) free
+- an SSD drive with at least 750GB (full node) or 4.5TB (archive node) free
 
 :::info
 


### PR DESCRIPTION
**What changed? Why?**

Bumps hardware requirements from 700 to 750 for a full node, and 4TB to 4.5TB for an archive node

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost