### PR TITLE
Add Scopescan.ai to the explorer doc section (follow PR 226)

### DIFF
--- a/apps/base-docs/docs/tools/block-explorers.md
+++ b/apps/base-docs/docs/tools/block-explorers.md
@@ -76,6 +76,11 @@ A testnet explorer for [Base Goerli](https://base-goerli.dex.guru/) is also avai
 
 [Routescan](https://superscan.network/) superchain explorer allows you to search for transactions, addresses, tokens, prices and other activities taking place across all Superchain blockchains, including Base.
 
+
+## Scopescan
+
+[Scopescan](https://scan.0xscope.com/home?network=base) supports Base on their platform. Base voyagers can check Base transaction records, addresses, tokens, and other traits on their platform. Scopescan also supports visualizing capital flows and checking token holder graphs on Base.
+
 ---
 
 ## Tenderly Explorer


### PR DESCRIPTION
**What changed? Why?**

I add Scopescan, a data analytic platform to the block explorer documentation page.

This is because Scopescan also support to check Base transactions & tokens & addresses, they also have other nice features like:

- moneyflow tool to visualize token flows
- Token holder graph to visualize token holder distributions
- Smartmoney dashboard to check who made the most money on Base

**Notes to reviewers**

_This is a new PR followed by the previously closed PR 226_

Scopescan is power by 0xscope, they received legit fundings from OKX and Hashkey.

I believe Scopescan can help a lot with Base users with their data and tooling ability. That's why i propose this change. Hope it get approved, thanks!

scan.0xscope.com is their platform link, you can try and decide.
