### PR TITLE
chore: runs yarn dlx @next/codemod@latest built-in-next-font .

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,6 @@
     "@coinbase/cookie-manager": "^1.1.1",
     "@coinbase/onchainkit": "^0.6.0",
     "@heroicons/react": "^2.0.18",
-    "@next/font": "^13.1.5",
     "@rainbow-me/rainbowkit": "^2.0.5",
     "@sprig-technologies/sprig-browser": "^2.29.0",
     "@tanstack/react-query": "^5.29.2",

--- a/apps/web/src/components/Layout/Layout.tsx
+++ b/apps/web/src/components/Layout/Layout.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useMemo } from 'react';
-import localFont from '@next/font/local';
+import localFont from 'next/font/local';
 import { useRouter } from 'next/router';
 import { CookieBanner } from '@coinbase/cookie-banner';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -307,7 +307,6 @@ __metadata:
     "@coinbase/cookie-manager": ^1.1.1
     "@coinbase/onchainkit": ^0.6.0
     "@heroicons/react": ^2.0.18
-    "@next/font": ^13.1.5
     "@rainbow-me/rainbowkit": ^2.0.5
     "@sprig-technologies/sprig-browser": ^2.29.0
     "@tanstack/react-query": ^5.29.2
@@ -4967,7 +4966,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/font@npm:^13.1.5, @next/font@npm:^13.1.6":
+"@next/font@npm:^13.1.6":
   version: 13.5.6
   resolution: "@next/font@npm:13.5.6"
   checksum: 12aa997147094bb122e2e22b29a2f6c1872de37fca0b444f20aa5c48e20bd8176c7d8661c1c597a43d528c7dc75d3acc44bc08c47aa716a5ab450fca68e4c814


### PR DESCRIPTION
**What changed? Why?**

When running the local dev server we currently see:

```
⚠ Your project has `@next/font` installed as a dependency, please use the built-in `next/font` instead. The `@next/font` package will be removed in Next.js 14. You can migrate by running `yarn dlx @next/codemod@latest built-in-next-font .`. Read more: https://nextjs.org/docs/messages/built-in-next-font
```

This commit is the result of running the relevant codemod and using the built-in `next/font`

**How has it been tested?**

visually; locally

|before|after|
|-|-|
|<img width="828" alt="image" src="https://github.com/base-org/web/assets/5773490/8c3aa7ce-9933-49fd-bf41-0fc20585e55a">|<img width="843" alt="image" src="https://github.com/base-org/web/assets/5773490/528ca862-12f2-4bb8-8a97-c2c34613a5b2">|
