### PR TITLE
chore: updated node versioning to be latest of 18 (hydrogen)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,30 +5,29 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ['master']
   pull_request:
-    branches: [ "master" ]
+    branches: ['master']
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - name: Install dependencies
-      run: yarn
-    - name: Lint
-      run: yarn lint
-    - name: Build
-      run: yarn build
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - name: Install dependencies
+        run: yarn
+      - name: Lint
+        run: yarn lint
+      - name: Build
+        run: yarn build

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-18.14
+lts/hydrogen

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "next-transpile-modules": "Next compatibility"
   },
   "engines": {
-    "node": "18.14"
+    "node": ">18.20.3"
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {


### PR DESCRIPTION
just housekeeping and allowing .nvmrc to be permissive w/ hydrogen LTS tag

https://nodejs.org/en/blog/release/v18.12.0

note: I've added 18.x to the gh build action matrix. I don't have privileges currently to modify the required build steps and move from 16->18 there. 