### PR TITLE
fix(block explorer): Point to Blockscout alongside outage

### DIFF
--- a/apps/base-docs/docs/building-with-base/network-information.md
+++ b/apps/base-docs/docs/building-with-base/network-information.md
@@ -35,7 +35,7 @@ hide_table_of_contents: true
 | RPC Endpoint    | [https://mainnet.base.org](https://mainnet.base.org)<br/>_Rate limited and not for production systems._ |
 | Chain ID        | 8453                                                                                                    |
 | Currency Symbol | ETH                                                                                                     |
-| Block Explorer  | [https://basescan.org](https://basescan.org)                                                            |
+| Block Explorer  | [https://base.blockscout.com/](https://base.blockscout.com/)                                            |
 
 ---
 

--- a/apps/base-docs/docs/using-base.md
+++ b/apps/base-docs/docs/using-base.md
@@ -54,14 +54,14 @@ To add Base as a custom network to MetaMask:
 4. Click **Add a network manually**.
 5. In the **Add a network manually** dialog that appears, enter the following information for Base mainnet:
 
-   | Name            | Value                                                  |
-   | :-------------- | :----------------------------------------------------- |
-   | Network Name    | Base Mainnet                                           |
-   | Description     | The public mainnet for Base.                           |
-   | RPC Endpoint    | [https://mainnet.base.org](https://mainnet.base.org)   |
-   | Chain ID        | 8453                                                   |
-   | Currency Symbol | ETH                                                    |
-   | Block Explorer  | [https://explorer.base.org](https://explorer.base.org) |
+   | Name            | Value                                                        |
+   | :-------------- | :----------------------------------------------------------- |
+   | Network Name    | Base Mainnet                                                 |
+   | Description     | The public mainnet for Base.                                 |
+   | RPC Endpoint    | [https://mainnet.base.org](https://mainnet.base.org)         |
+   | Chain ID        | 8453                                                         |
+   | Currency Symbol | ETH                                                          |
+   | Block Explorer  | [https://base.blockscout.com/](https://base.blockscout.com/) |
 
 6. Tap the Save button to save Base as a network.
 

--- a/apps/base-docs/docusaurus.config.js
+++ b/apps/base-docs/docusaurus.config.js
@@ -231,7 +231,7 @@ const config = {
           items: [
             {
               label: 'Block Explorer',
-              href: 'https://explorer.base.org/',
+              href: 'https://base.blockscout.com/',
             },
             {
               label: 'Status',

--- a/apps/bridge/src/components/Nav/DesktopNav.tsx
+++ b/apps/bridge/src/components/Nav/DesktopNav.tsx
@@ -136,7 +136,7 @@ function DesktopNav({ color }: DesktopNavProps) {
         <DropdownLink href="https://docs.base.org" label="Docs" color={color} externalLink />
         <DropdownLink href="https://base.org/camp" label="Learn" color={color} externalLink />
         <DropdownLink
-          href="https://explorer.base.org/"
+          href="https://base.blockscout.com/"
           label="Block Explorer"
           color={color}
           externalLink

--- a/apps/bridge/src/components/Nav/MobileMenu.tsx
+++ b/apps/bridge/src/components/Nav/MobileMenu.tsx
@@ -188,7 +188,7 @@ function MobileMenu({ color }: MobileMenuProps) {
                 >
                   <DropdownLink href="https://docs.base.org" label="Docs" externalLink />
                   <DropdownLink
-                    href="https://explorer.base.org/"
+                    href="https://base.blockscout.com/"
                     label={`Block\nExplorer`}
                     externalLink
                   />

--- a/apps/web/src/components/Layout/Nav/DesktopNav.tsx
+++ b/apps/web/src/components/Layout/Nav/DesktopNav.tsx
@@ -148,7 +148,7 @@ function DesktopNav({ color }: DesktopNavProps) {
         <DropdownLink href={docsUrl} label="Docs" color={color} externalLink />
         <DropdownLink href="https://base.org/camp" label="Learn" color={color} externalLink />
         <DropdownLink
-          href="https://explorer.base.org/"
+          href="https://base.blockscout.com/"
           label="Block Explorer"
           color={color}
           externalLink

--- a/apps/web/src/components/Layout/Nav/MobileMenu.tsx
+++ b/apps/web/src/components/Layout/Nav/MobileMenu.tsx
@@ -199,7 +199,7 @@ function MobileMenu({ color }: MobileMenuProps) {
                 >
                   <DropdownLink href="https://docs.base.org" label="Docs" externalLink />
                   <DropdownLink
-                    href="https://explorer.base.org/"
+                    href="https://base.blockscout.com/"
                     label={`Block\nExplorer`}
                     externalLink
                   />


### PR DESCRIPTION
**What changed? Why?**

[Basescan is currently experiencing an outage](https://basescan.statuspage.io/incidents/vhp0m2pr0vdn). This updates relevant block explorer links to point to Blockscout in the interim.

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost