### PR TITLE
Updated Dockerfile in Base-Docs to build at runtime

### DIFF
--- a/apps/base-docs/Dockerfile
+++ b/apps/base-docs/Dockerfile
@@ -2,6 +2,8 @@ FROM 652969937640.dkr.ecr.us-east-1.amazonaws.com/containers/node:v16
 
 RUN apt-get update && apt-get install -y zip
 
+ENV NODE_ENV=production
+
 WORKDIR /repo
 
 COPY . .
@@ -9,9 +11,6 @@ COPY . .
 # Install dependencies
 RUN yarn --immutable
 
-ENV NODE_ENV=production
-RUN yarn workspace @app/base-docs build
-RUN yarn workspaces focus --all --production
-
 EXPOSE 3000
-CMD ["yarn", "workspace", "@app/base-docs", "start"]
+# Build at runtime so that we get ENV variables, this allows us to use [Automatic Static Optimization](https://nextjs.org/docs/pages/building-your-application/rendering/automatic-static-optimization)
+CMD ["/bin/bash", "-c", "yarn workspace @app/base-docs build ; yarn workspace @app/base-docs start -p 3000"]


### PR DESCRIPTION
**What changed? Why?**
Updated the Dockerfile in the Base-Docs app to build at runtime. This enables the inclusion of env variables that otherwise are not included in the build.

**Notes to reviewers**

**How has it been tested?**
* Deployed internal test environment through CodeFlow. 
* Confirmed that SPRIG_ENVIRONMENT_ID is present and that the Sprig integration loads successfully. 
