### PR TITLE
Moved key property to list items

### DIFF
--- a/apps/base-docs/src/components/FooterCategory/index.tsx
+++ b/apps/base-docs/src/components/FooterCategory/index.tsx
@@ -18,8 +18,8 @@ function FooterCategory({ title, links }: FooterCategoryProps) {
       <h4 className={styles.footerCategoryTitle}>{title}</h4>
       <ul className={styles.footerCategoryList}>
         {links.map((link) => (
-          <li className={styles.footerCategoryListItem}>
-            <a key={link.title} href={link.href} className={styles.footerCategoryLink}>
+          <li key={link.title} className={styles.footerCategoryListItem}>
+            <a href={link.href} className={styles.footerCategoryLink}>
               {link.title}
             </a>
           </li>


### PR DESCRIPTION
**What changed? Why?**
Moved the react `key` property to the `<li>` tags instead of on the anchor tags, thereby resolving console errors.

**Notes to reviewers**

**How has it been tested?**
Manually locally.