### PR TITLE
Add page with relevant information regarding fault proofs coming to Base Sepolia

### DIFF
--- a/apps/base-docs/docs/notices/preparing-for-fault-proofs-on-base-sepolia.md
+++ b/apps/base-docs/docs/notices/preparing-for-fault-proofs-on-base-sepolia.md
@@ -1,0 +1,72 @@
+---
+title: Preparing for fault proofs on Base Sepolia
+slug: /preparing-for-fault-proofs-on-base-sepolia
+description: Fault proofs are expected to go live for Base Sepolia testnet in mid-July.
+keywords:
+  [
+    Fault proofs,
+    Base,
+    L2 decentralization,
+    Permissionless output proposals,
+    Permissionless challenges,
+    Withdrawals,
+    Base Sepolia testnet,
+    DisputeGameFactory,
+    L2OutputOracle,
+    Seven-day finalization,
+    Dispute game,
+    Bridge operators,
+    UI updates,
+    Contract upgrades,
+    Node operators,
+    Superbridge,
+    Superchain bridges,
+    L1 to L2 deposits,
+    L2 to L1 withdrawals,
+    Mid-July upgrade,
+    Ethereum Sepolia,
+    Bridging logic,
+    Testnet funds,
+    Decentralized validation,
+    Community participation,
+  ]
+hide_table_of_contents: true
+---
+
+# Preparing for fault proofs on Base Sepolia (Testnet)
+
+Fault proofs are a critical implementation in an L2’s path towards decentralization. They enable a more decentralized approach to validating L2 state and pave the way towards more community participation.
+
+They improve decentralization with two important capabilities:
+
+- **Permissionless output proposals:** In an L2 without fault proofs, only the centralized proposer can create and submit output roots about the state of the L2. Now with fault proofs, anyone can make claims about Base's current state instead of relying on a central party.
+- **Permissionless challenges to output proposals:** If someone makes a faulty or fraudulent claim, anyone can challenge it.
+
+These changes allow anyone to withdraw funds from Base to L1 without having to rely on centralized actors.
+
+## Preparing for fault proofs
+
+Fault proofs are expected to go live for Base Sepolia (Testnet) in mid-July.
+
+**What’s changing for testnet withdrawals:**
+
+- Withdrawals will involve proving and finalizing based on the fault proof system.
+- Withdrawals will no longer be instantaneous: they will take at least seven days to finalize, but can take longer depending on the outcome of the corresponding dispute game used.
+- The `DisputeGameFactory` will replace the `L2OutputOracle` as the new contract where output root claims will be proposed.
+
+**If you are in the process of withdrawing your testnet funds from L2 to L1:**
+
+- **Withdrawals _before_ the upgrade in mid-July** will be processed instantaneously.
+- **Withdrawals _during_ or _after_ the fault proofs upgrade** for Base Sepolia will take at least seven days to complete.
+
+If your withdrawal of testnet funds from Base Sepolia to Ethereum Sepolia coincides with the upgrade proceeding in mid-July, you will be required to resubmit your withdrawal.
+
+**If your team is operating a bridge on Base Sepolia:**
+
+- Please provide your users with a notice on your UI to inform them that fault proofs will be enabled for Base Sepolia in mid-July.
+- Please ensure it’s clear to your users that testnet withdrawals will now take at least seven days.
+- Assess and update your bridging logic, and make sure the new L1 contracts are being used.
+
+Fault proof contract upgrades will be completed atomically, meaning all affected L1 contracts will be upgraded in a single transaction. No action will be required from node operators.
+
+Please note, bridge.base.org now redirects to [Superbridge](https://superbridge.app/base) and other bridges (collectively, "Superchain bridges"). Superchain bridges are available to initiate and complete deposits and withdrawals to and from Base. Please refer to our [docs](https://bridge.base.org/deposit) for more information on bridging.

--- a/apps/base-docs/sidebars.js
+++ b/apps/base-docs/sidebars.js
@@ -4,20 +4,10 @@ module.exports = {
     ['using-base'],
     {
       type: 'category',
-      label: 'Building on Base',
+      label: 'Notices',
       collapsible: false,
       collapsed: false,
-      items: [
-        'building-with-base/network-information',
-        'building-with-base/base-contracts',
-        'building-with-base/fees',
-        'building-with-base/differences',
-        {
-          type: 'link',
-          label: 'Decentralizing Base with Optimism',
-          href: 'https://base.mirror.xyz/H_KPwV31M7OJT-THUnU7wYjOF16Sy7aWvaEr5cgHi8I',
-        },
-      ],
+      items: ['notices/preparing-for-fault-proofs-on-base-sepolia'],
     },
     {
       type: 'category',

--- a/apps/base-docs/sidebars.js
+++ b/apps/base-docs/sidebars.js
@@ -11,6 +11,23 @@ module.exports = {
     },
     {
       type: 'category',
+      label: 'Building on Base',
+      collapsible: false,
+      collapsed: false,
+      items: [
+        'building-with-base/network-information',
+        'building-with-base/base-contracts',
+        'building-with-base/fees',
+        'building-with-base/differences',
+        {
+          type: 'link',
+          label: 'Decentralizing Base with Optimism',
+          href: 'https://base.mirror.xyz/H_KPwV31M7OJT-THUnU7wYjOF16Sy7aWvaEr5cgHi8I',
+        },
+      ],
+    },
+    {
+      type: 'category',
       label: 'Tools',
       collapsible: false,
       collapsed: false,


### PR DESCRIPTION
**What changed? Why?**

This adds a new section in the docs called 'Notices' and includes a notice (reviewed and approved) with important information that will be relevant for builders alongside fault proofs coming to Base Sepolia

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost
