### PR TITLE
Add Chronicle to Oracles page

### DIFF
--- a/apps/base-docs/docs/tools/oracles.md
+++ b/apps/base-docs/docs/tools/oracles.md
@@ -12,6 +12,7 @@ keywords:
     Base network,
     Supra,
     Chainlink,
+    Chronicle,
     Pyth,
     VRF,
     Gelato VRF,
@@ -57,6 +58,19 @@ See [this guide](https://docs.chain.link/docs/get-the-latest-price/) to learn ho
 To use Chainlink datafeeds, you may need [LINK](https://docs.chain.link/resources/link-token-contracts?parent=dataFeeds) token.
 
 :::
+
+#### Supported Networks
+
+- Base Mainnet
+- Base Sepolia (Testnet)
+
+---
+
+## Chronicle
+
+[Chronicle](https://chroniclelabs.org/) provides a number of [Oracles](https://chroniclelabs.org/dashboard) for Base.
+
+See [this guide](https://docs.chroniclelabs.org/Developers/tutorials/Remix) to learn how to use the Chronicle Oracles.
 
 #### Supported Networks
 


### PR DESCRIPTION
**What changed? Why?**: Added [Chronicle](https://chroniclelabs.org/) to the Oracles page using the same template existing for the other Oracles

**Notes to reviewers**

**How has it been tested?**:  Yes, it was run locally
![Screenshot 2024-06-25 at 10 48 36](https://github.com/base-org/web/assets/34369307/42a9d200-6540-4c6f-b4a9-ab811d160ea0)
