### PR TITLE
Swap typescript Code Blocks to tsx

### DIFF
--- a/apps/base-docs/base-camp/docs/frontend-setup/building-an-onchain-app.md
+++ b/apps/base-docs/base-camp/docs/frontend-setup/building-an-onchain-app.md
@@ -81,7 +81,7 @@ As discussed above, add `"use client":` to the top of the file.
 
 Continue with the imports:
 
-```typescript
+```tsx
 import '@rainbow-me/rainbowkit/styles.css';
 import { useState, type ReactNode } from 'react';
 import { getDefaultConfig, RainbowKitProvider } from '@rainbow-me/rainbowkit';
@@ -108,7 +108,7 @@ Remember, everything on the frontend is public! Be sure to configure the allowli
 
 :::
 
-```typescript
+```tsx
 const config = getDefaultConfig({
   appName: 'Cool Onchain App',
   projectId: 'YOUR_PROJECT_ID',
@@ -123,7 +123,7 @@ const config = getDefaultConfig({
 
 Add an exported function for the providers. This sets up the `QueryClient` and returns `props.children` wrapped in all of your providers.
 
-```typescript
+```tsx
 export function Providers(props: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
 
@@ -141,7 +141,7 @@ export function Providers(props: { children: ReactNode }) {
 
 Open `layout.tsx`. Import your `Providers`, being careful if you use auto-import as there are many other things with similar names in the list. Wrap the `children` in your `return` with the new `Providers`.
 
-```typescript
+```tsx
 return (
   <html lang="en">
     <body className={inter.className}>
@@ -157,13 +157,13 @@ You're now ready to add your connect button. You can do this anywhere in your ap
 
 Open up `page.tsx`, and import the `ConnectButton`:
 
-```typescript
+```tsx
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 ```
 
 Then, simply add the `ConnectButton` component at the top of the first `<div>`:
 
-```typescript
+```tsx
 // This function has been simplified to save space.
 export default function Home() {
   return (
@@ -183,7 +183,7 @@ Run your app with `yarn dev`, and you should be able to use the RainbowKit conne
 
 You use the [Connect Button] props to modify its properties, or you can [customize the connect button] extensively. Some users dislike having the connect button display their token balance. Try disabling it with:
 
-```typescript
+```tsx
 <ConnectButton showBalance={false} />
 ```
 

--- a/apps/base-docs/base-camp/docs/hardhat-deploy/hardhat-deploy-sbs.md
+++ b/apps/base-docs/base-camp/docs/hardhat-deploy/hardhat-deploy-sbs.md
@@ -30,7 +30,7 @@ To install:
 
 1. Run `npm install -D hardhat-deploy`. Then, import hardhat-deploy in `hardhat.config.ts`:
 
-```typescript
+```tsx
 import 'hardhat-deploy';
 ```
 
@@ -38,7 +38,7 @@ import 'hardhat-deploy';
 
 3. Include the following:
 
-```typescript
+```tsx
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { DeployFunction } from 'hardhat-deploy/types';
 
@@ -69,7 +69,7 @@ export default func;
 
 6. Run the following, which adds an alias to the account 0 of your environment:
 
-```typescript
+```tsx
 const config: HardhatUserConfig = {
   solidity: '0.8.23',
   namedAccounts: {
@@ -80,7 +80,7 @@ const config: HardhatUserConfig = {
 
 7. Implement the deploy function by including the following in the `001_deploy_lock.ts` file:
 
-```typescript
+```tsx
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { DeployFunction } from 'hardhat-deploy/types';
 import { ethers } from 'hardhat';
@@ -121,7 +121,7 @@ The easiest way to test your deployment is by modifying the test.
 
 Go to `Lock.ts` and include in the imports the following:
 
-```typescript
+```tsx
 import { ethers, deployments } from 'hardhat';
 ```
 
@@ -129,7 +129,7 @@ import { ethers, deployments } from 'hardhat';
 
 Change the `before` function to look like the following:
 
-```typescript
+```tsx
 before(async () => {
   lastBlockTimeStamp = await time.latest();
 
@@ -148,7 +148,7 @@ Notice how you execute `deployments.fixture` and pass a tag that matches the one
 
 The deployment file is then executed and you can then reuse that functionality and simply consume the address of the newly-deployed contract by using:
 
-```typescript
+```tsx
 const lockDeployment = await deployments.get('Lock');
 ```
 
@@ -176,7 +176,7 @@ Deploying to a real test network involves configuring the network parameters in 
 
 Include the following in the `hardhat.config.ts` file:
 
-```typescript
+```tsx
 const config: HardhatUserConfig = {
   solidity: '0.8.18',
   namedAccounts: {
@@ -219,7 +219,7 @@ npm install -D dotenv
 
 Then, include the following in the `hardhat.config.ts` file:
 
-```typescript
+```tsx
 import dotenv from 'dotenv';
 
 dotenv.config();

--- a/apps/base-docs/base-camp/docs/hardhat-forking/hardhat-forking.md
+++ b/apps/base-docs/base-camp/docs/hardhat-forking/hardhat-forking.md
@@ -46,7 +46,7 @@ Those won't be covered in this guide, however it's recommended to explore them a
 
 The BalanceReader contract is created as follows:
 
-```typescript
+```tsx
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -106,7 +106,7 @@ Also notice that forking is enabled by specifying `enabled: true`, however this 
 
 Create a test file in the test folder called `BalanceReader.ts` and include the following:
 
-```typescript
+```tsx
 import { Signer } from 'ethers';
 import { ethers } from 'hardhat';
 

--- a/apps/base-docs/base-camp/docs/hardhat-setup-overview/hardhat-setup-overview-sbs.md
+++ b/apps/base-docs/base-camp/docs/hardhat-setup-overview/hardhat-setup-overview-sbs.md
@@ -85,7 +85,7 @@ Since the project uses Typescript, you have the benefit of using static typing.
 
 The following is the default configuration:
 
-```typescript
+```tsx
 import { HardhatUserConfig } from 'hardhat/config';
 import '@nomicfoundation/hardhat-toolbox';
 
@@ -106,7 +106,7 @@ You can configure aspects such as:
 
 For example:
 
-```typescript
+```tsx
 import { HardhatUserConfig } from 'hardhat/config';
 import '@nomicfoundation/hardhat-toolbox';
 

--- a/apps/base-docs/base-camp/docs/hardhat-testing/hardhat-testing-sbs.md
+++ b/apps/base-docs/base-camp/docs/hardhat-testing/hardhat-testing-sbs.md
@@ -39,7 +39,7 @@ In the following, you reuse this smart contract but rewrite the test using Typec
 
 To remove the body of the `Lock.ts` file:
 
-```typescript
+```tsx
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 
@@ -54,7 +54,7 @@ The `Lock.sol` contract allows the creator to lock Ether until an unlock time ha
 
 Notice the constructor has a payable keyword:
 
-```typescript
+```tsx
 constructor(uint _unlockTime) payable {
         require(
             block.timestamp < _unlockTime,
@@ -83,7 +83,7 @@ Start with the value locked, however you must set up a `before` function, which 
 
 Then, include some new imports and variables:
 
-```typescript
+```tsx
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 
@@ -138,6 +138,7 @@ describe('Lock', function () {
   });
 });
 ```
+
 </details>
 
 ### Testing `unlockTime`
@@ -150,7 +151,7 @@ The first test case should verify that the `unlockTime` variable is correct.
 
 <summary>Reveal code</summary>
 
-```typescript
+```tsx
 it('should get the unlockTime value', async () => {
   // we get the value from the contract
   const unlockTime = await lockInstance.unlockTime();
@@ -177,8 +178,6 @@ You can simply run `npx hardhat test` and then get:
 
 ### Testing Ether balance
 
-
-
 In order to get the balance of your `Lock` contract, you simply call `ethers.provider.getBalance`.
 
 Create a new test case:
@@ -187,7 +186,7 @@ Create a new test case:
 
 <summary>Reveal code</summary>
 
-```typescript
+```tsx
 it('should have the right ether balance', async () => {
   // Get the Lock contract address
   const lockInstanceAddress = await lockInstance.getAddress();
@@ -221,7 +220,7 @@ Similar to the previous test cases, you can verify that the owner is correct.
 
 <summary>Reveal code</summary>
 
-```typescript
+```tsx
 it('should have the right owner', async () => {
   // Notice ownerSigned has an address property
   expect(await lockInstance.owner()).to.equal(ownerSigner.address);
@@ -242,7 +241,6 @@ Then, run `npx hardhat test` and you should get:
   3 passing (1s)
 ```
 
-
 ### Testing withdraw
 
 Testing withdrawal is more complex because you need to assert certain conditions, such as:
@@ -255,7 +253,7 @@ Hardhat allow you to test reverts with a set of custom matchers.
 
 For example, the following code checks that an attempt to call the function `withdraw` reverts with a particular message:
 
-```typescript
+```tsx
 it('shouldn"t allow to withdraw before unlock time', async () => {
   await expect(lockInstance.withdraw()).to.be.revertedWith("You can't withdraw yet");
 });
@@ -265,7 +263,7 @@ In addition, Hardhat also allows you to manipulate the time of the environment w
 
 You can modify `the block.timestamp` by using the time helper:
 
-```typescript
+```tsx
 it('shouldn"t allow to withdraw a non owner', async () => {
   const newLastBlockTimeStamp = await time.latest();
 
@@ -288,7 +286,7 @@ Finally, test that the owner can withdraw. You can manipulate the time similarly
 
 <summary>Reveal code</summary>
 
-```typescript
+```tsx
 it('should allow to withdraw a owner', async () => {
   const balanceBefore = await ethers.provider.getBalance(await lockInstance.getAddress());
 

--- a/apps/base-docs/base-camp/docs/hardhat-verify/hardhat-verify-sbs.md
+++ b/apps/base-docs/base-camp/docs/hardhat-verify/hardhat-verify-sbs.md
@@ -55,7 +55,7 @@ You'll need to go to that particular explorer and get the API Key following a si
 
 You can configure the Etherscan API Key for each different network. For example, include the following to the `hardhat.config.ts` file for Base Sepolia:
 
-```typescript
+```tsx
 base_sepolia: {
   url: "https://sepolia.base.org",
   accounts: {

--- a/apps/base-docs/base-camp/docs/interfaces/contract-to-contract-interaction.md
+++ b/apps/base-docs/base-camp/docs/interfaces/contract-to-contract-interaction.md
@@ -129,7 +129,7 @@ interface IUniswapV3Factory {
 
 Then, create a test file called `PoolCreator.test.ts` with the following content:
 
-```typescript
+```tsx
 import { ethers } from 'hardhat';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
 

--- a/apps/base-docs/base-camp/docs/reading-and-displaying-data/configuring-useReadContract.md
+++ b/apps/base-docs/base-camp/docs/reading-and-displaying-data/configuring-useReadContract.md
@@ -30,7 +30,7 @@ Once the excitement of your accomplishment of finally reading from your own cont
 
 The easiest is to use `useBlockNumber` with the `watch` feature to automatically keep track of the block number, then use the `queryClient` to update when that changes. **Make sure** you decompose the `queryKey` from the return of `useReadContract`.
 
-```typescript
+```tsx
 import { useEffect, useState } from 'react';
 import { useReadContract, useBlockNumber } from 'wagmi';
 import { useQueryClient } from '@tanstack/react-query';
@@ -82,7 +82,7 @@ Luckily, you have options to control these calls a little better.
 
 Once quick improvement is to simply stop watching the blockchain if the website doesn't have focus. To see this in action, add a state variable to count how many times the function has settled, and one for if the page is focused. You'll also need to set up event listeners to set the state of the latter when the page is focused or blurred.
 
-```typescript
+```tsx
 const [timesCalled, setTimesCalled] = useState(0);
 const [pageIsFocused, setPageIsFocused] = useState(true);
 
@@ -102,13 +102,13 @@ useEffect(() => {
 
 Then, update the `watch` for `useBlockNumber` so that it only does so if `pageIsFocused`.
 
-```typescript
+```tsx
 const { data: blockNumber } = useBlockNumber({ watch: pageIsFocused });
 ```
 
 Add a line to the `useEffect` for `blockNumber` increment your counter as well.
 
-```typescript
+```tsx
 useEffect(() => {
   setTimesCalled((prev) => prev + 1);
   queryClient.invalidateQueries({ queryKey: issuesQueryKey });
@@ -117,7 +117,7 @@ useEffect(() => {
 
 Finally, surface your counter in the component.
 
-```typescript
+```tsx
 return (
   <div>
     <h2>Number of times called</h2>
@@ -139,7 +139,7 @@ A more robust DAO is going to have a voting period of at least a day or two, so 
 
 Adjust your [`pollingInterval`] by setting it in `getDefaultConfig` in `_app.tsx`:
 
-```typescript
+```tsx
 const config = getDefaultConfig({
   appName: 'RainbowKit App',
   projectId: 'YOUR_PROJECT_ID',
@@ -157,7 +157,7 @@ You can also set `pollingInterval` if you're using `createConfig` instead of the
 
 You can use a similar system to call your update function on demand. First, add a button, a handler for that button, and a state variable for it to set:
 
-```typescript
+```tsx
 const [triggerRead, setTriggerRead] = useState(false);
 
 const handleTriggerRead = () => {
@@ -165,7 +165,7 @@ const handleTriggerRead = () => {
 };
 ```
 
-```typescript
+```tsx
 return (
   <div>
     <button onClick={handleTriggerRead}>Read Now</button>
@@ -180,7 +180,7 @@ return (
 
 Finally, set `watch` to equal `triggerRead`, instead of `pageIsFocused`, and reset `triggerRead` in the `useEffect`.
 
-```typescript
+```tsx
 const { data: blockNumber } = useBlockNumber({ watch: triggerRead });
 
 // Other code...
@@ -201,7 +201,7 @@ You can use the "is" return values to set UI elements depending on the status of
 
 Try to modify your button to provide feedback to the user that the function has been called.
 
-```typescript
+```tsx
 // Bad code example, do not use
 <button disabled={issuesIsLoading} onClick={handleTriggerRead}>
   {issuesIsLoading ? 'Loading' : 'Read Now'}
@@ -212,7 +212,7 @@ The above code won't break anything, but nothing will appear to happen. This hap
 
 Instead, try decomposing `isFetching` in your `useReadContract`. This property is true while data is being fetched, even if data has already been loaded once.
 
-```typescript
+```tsx
 // Imperfect code example, do not use
 <button disabled={issuesIsFetching} onClick={handleTriggerRead}>
   {issuesIsFetching ? 'Loading' : 'Read Now'}
@@ -227,7 +227,7 @@ You'll probably see the button flicker very quickly since the call doesn't take 
 
 Arguments are passed into a `useReadContract` hook by adding an array of arguments, in order, to the `args` property. Common practice is to use React state variables set by UI elements to enable the arguments to be set and modified. For example, you might create a drop-down to set `issueNumber`, then fetch that issue with:
 
-```typescript
+```tsx
 // Incomplete code stub
 const [issueNumber, setIssueNumber] = useState(0);
 

--- a/apps/base-docs/base-camp/docs/reading-and-displaying-data/useAccount.md
+++ b/apps/base-docs/base-camp/docs/reading-and-displaying-data/useAccount.md
@@ -27,7 +27,7 @@ Either way, change the list of chains to only include `baseSepolia` as the netwo
 
 You can set up your providers as described in [Introduction to Providers], or use the default from RainbowKit:
 
-```typescript
+```tsx
 const config = getDefaultConfig({
   appName: 'RainbowKit App',
   projectId: 'YOUR APP ID',
@@ -44,7 +44,7 @@ The [`useAccount`] hook allows you to access account and connection data from wi
 
 Add a folder for `components` and a file called `ConnectionWindow.tsx` in that folder. Add the below component to the file, and replace the boilerplate text in `index.tsx` with an instance of it.
 
-```typescript
+```tsx
 // ConnectionWindow.tsx
 export function ConnectionWindow() {
   return (
@@ -55,7 +55,7 @@ export function ConnectionWindow() {
 }
 ```
 
-```typescript
+```tsx
 // index.tsx
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import type { NextPage } from 'next';
@@ -81,7 +81,7 @@ For the purposes of this exercise, open `styles/Home.module.css` and **delete or
 
 Return to `ConnectionWindow.tsx` and add the `useAccount` hook to the top, where you'd add any state variables. The general pattern for wagmi hooks is you decompose the properties you want to use from a function call of the name of the hook. For some, you'll add a config object to that call, but it's not needed for this one.
 
-```typescript
+```tsx
 import { useAccount } from 'wagmi';
 
 export function ConnectionWindow() {
@@ -99,11 +99,11 @@ You can see all the deconstructable return options in the [UseAccountReturnType]
 
 Update your `<div>` to show the address of the connected wallet:
 
-```Typescript
+```tsx
 <div>
   <h2>Connection Status</h2>
   <div>
-    <p>{"Address: " + address}</p>
+    <p>{'Address: ' + address}</p>
   </div>
 </div>
 ```

--- a/apps/base-docs/base-camp/docs/reading-and-displaying-data/useReadContract.md
+++ b/apps/base-docs/base-camp/docs/reading-and-displaying-data/useReadContract.md
@@ -91,7 +91,7 @@ Either way, add a folder called `deployments` and place a copy of the artifact f
 
 Add a file for a new component called `IssueList.tsx`. You can start with:
 
-```typescript
+```tsx
 import { useReadContract } from 'wagmi';
 
 export function IssueList() {
@@ -106,7 +106,7 @@ export function IssueList() {
 
 You'll need to do some prepwork to enable Typescript to more easily interpret the data returned from your contract. Add an `interface` called `Issue` that matches with the `ReturnableIssue` type:
 
-```typescript
+```tsx
 interface Issue {
   voters: string[];
   issueDesc: string;
@@ -128,19 +128,19 @@ Be very careful here! `bigint` is the name of the type, `BigInt` is the name of 
 
 Now, import `useState` and add a state variable to hold your list of `Issue`s.
 
-```typescript
+```tsx
 const [issues, setIssues] = useState<Issue[]>([]);
 ```
 
 You'll also need to import your contract artifact:
 
-```typescript
+```tsx
 import contractData from '../deployments/FEWeightedVoting.json';
 ```
 
 Finally, the moment you've been waiting for: Time to read from your contract! Add an instance of the [`useReadContract`] hook. It works similarly to the [`useAccount`] hook. Configure it with:
 
-```typescript
+```tsx
 const {
   data: issuesData,
   isError: issuesIsError,
@@ -154,7 +154,7 @@ const {
 
 You can use `useEffect` to do something when the call completes and the data. For now, just log it to the console:
 
-```typescript
+```tsx
 useEffect(() => {
   if (issuesData) {
     const issuesList = issuesData as Issue[];
@@ -166,7 +166,7 @@ useEffect(() => {
 
 Add in instance of your new component to `index.tsx`:
 
-```typescript
+```tsx
 <main className={styles.main}>
   <ConnectButton />
   <ConnectionWindow />
@@ -188,7 +188,7 @@ Breaking down the hook, you've:
 
 Now that you've got the data in state, you can display it via your component. One strategy to display a list of items is to compile a `ReactNode` array in a render function.
 
-```typescript
+```tsx
 function renderIssues() {
   return issues.map((issue) => (
     <div key={issue.issueDesc}>
@@ -207,7 +207,7 @@ function renderIssues() {
 
 Then, call the render function in the return for your component:
 
-```typescript
+```tsx
 return (
   <div>
     <h2>All Issues</h2>
@@ -239,7 +239,7 @@ Remember how the Solidity compiler creates automatic getters for all of your pub
 
 Redeploy with the above change, and add a second `useReadContract` to fetch an individual issue using the getter:
 
-```typescript
+```tsx
 // Bad code for example, do not use
 const {
   data: getOneData,

--- a/apps/base-docs/base-camp/docs/writing-to-contracts/useSimulateContract.md
+++ b/apps/base-docs/base-camp/docs/writing-to-contracts/useSimulateContract.md
@@ -26,7 +26,7 @@ In the previous step-by-step, you used [`useWriteContract`] to set up a hook you
 
 The `useSimulateContract` can be used in partnership with `useWriteContract`. To do so, you set up the transaction parameters in `useSimulateContract`, then use the `data?.request` returned by it as an argument in the call to write to the contract. Modify your `TokenInfo` component to test it:
 
-```typescript
+```tsx
 // Bad code for example.  See below for fix.
 const {
   data: claimData,
@@ -57,7 +57,7 @@ const handleClaimClick = () => {
 
 You'll also need to update your handler to use the TypeScript pre-check feature, because the claim function will be briefly `undefined`.
 
-```typescript
+```tsx
 const handleClaimClick = () => {
   claim(claimData!.request);
 };
@@ -75,7 +75,7 @@ You'll need to make some modifications for it to work. The `claimIsError` variab
 
 You can solve this a number of ways, including simply not rendering the button if the user has already claimed. You could also modify the code, and combine it with `isError`, to share this information to the user.
 
-```typescript
+```tsx
 const {
   data: claimData,
   isFetching: claimIsFetching,

--- a/apps/base-docs/base-camp/docs/writing-to-contracts/useWriteContract.md
+++ b/apps/base-docs/base-camp/docs/writing-to-contracts/useWriteContract.md
@@ -40,7 +40,7 @@ You've built an app that can read from your Simple DAO smart contract, but so fa
 
 Add a new component called `TokenInfo` to the project, and a state variable for `tokenBalance`.
 
-```typescript
+```tsx
 import { useState } from 'react';
 
 export function TokenInfo() {
@@ -54,7 +54,7 @@ You'll need to know how many tokens the user has to be able to make decisions on
 
 You'll need the user's address to use in `args`, which you can conveniently get from the [`useAccount`] hook using the pattern below.
 
-```typescript:
+```tsx:
 const { data: balanceData, queryKey: balanceQueryKey } =
   useReadContract({
     address: contractData.address as `0x${string}`,
@@ -82,7 +82,7 @@ Remember, this is an expensive method to watch for data to change on the blockch
 
 Set the `return` for your component to display this balance to the user:
 
-```typescript
+```tsx
 return (
   <div>
     <p>{'Token Balance: ' + tokenBalance}</p>
@@ -92,7 +92,7 @@ return (
 
 Then, add the component to your app in `index.tsx`.
 
-```typescript
+```tsx
 return (
   <div className={styles.container}>
     <main className={styles.main}>
@@ -110,7 +110,7 @@ Run the app and make sure you see the expected balance displayed on the page.
 
 The [`useWriteContract`] hook is configured similarly to the [`useReadContract`] hook, with one important difference. You'll need to decompose the `write` property from the function call. This is a function that you can use to call your smart contract function whenever you'd like!
 
-```typescript
+```tsx
 const { writeContract: claim, isPending: claimIsPending } = useWriteContract();
 ```
 
@@ -118,7 +118,7 @@ Add an event handler function and a button. As with the `useReadContract` hook, 
 
 You can use this to nudge them to look to their wallet to complete the transaction. Additionally, add a `useEffect` to watch for an error state.
 
-```typescript
+```tsx
 const handleClaimClick = () => {
   claim({
     abi: contractData.abi,

--- a/apps/base-docs/docs/tools/hardhat.md
+++ b/apps/base-docs/docs/tools/hardhat.md
@@ -33,7 +33,7 @@ You can use Hardhat to edit, compile, debug, and deploy your smart contracts to 
 
 To configure [Hardhat](https://hardhat.org/) to deploy smart contracts to Base, update your project’s `hardhat.config.ts` file by adding Base as a network:
 
-```typescript
+```tsx
 networks: {
    // for mainnet
    "base-mainnet": {

--- a/apps/base-docs/tutorials/docs/0_deploy-with-hardhat.mdx
+++ b/apps/base-docs/tutorials/docs/0_deploy-with-hardhat.mdx
@@ -92,7 +92,7 @@ In order to deploy smart contracts to the Base network, you will need to configu
 
 To configure Hardhat to use Base, add Base as a network to your project's `hardhat.config.ts` file:
 
-```typescript
+```tsx
 import { HardhatUserConfig } from 'hardhat/config';
 import '@nomicfoundation/hardhat-toolbox';
 
@@ -219,7 +219,7 @@ Once your contract has been successfully compiled, you can deploy the contract t
 
 To deploy the contract to the Base Sepolia test network, you'll need to modify the `scripts/deploy.ts` in your project:
 
-```typescript
+```tsx
 import { ethers } from 'hardhat';
 
 async function main() {
@@ -271,7 +271,7 @@ In `hardhat.config.ts`, configure Base Sepolia as a custom network. Add the foll
 <Tabs>
 <TabItem value="basescan" label="Basescan">
 
-```typescript
+```tsx
 etherscan: {
    apiKey: {
     "base-sepolia": "PLACEHOLDER_STRING"
@@ -298,7 +298,7 @@ When verifying a contract with Basescan on testnet (Sepolia), an API key is not 
 </TabItem>
 <TabItem value="blockscout" label="Blockscout">
 
-```typescript
+```tsx
 // Hardhat expects etherscan here, even if you're using Blockscout.
 etherscan: {
    apiKey: {

--- a/apps/base-docs/tutorials/docs/1_event-poap-nouns.md
+++ b/apps/base-docs/tutorials/docs/1_event-poap-nouns.md
@@ -1,0 +1,68 @@
+---
+title: 'Event POAPs with Nouns'
+slug: /event-poaps-with-nouns
+description: Learn how to give attendees of an in-person event a Nouns-based POAP/PFT, even if they're not onchain yet.
+author: briandoyle81
+keywords: [Solidity, ERC-721, token, NFT, POAP, Nouns, PFP]
+tags: ['nft', 'smart contracts']
+difficulty: hard
+hide_table_of_contents: false
+displayed_sidebar: null
+---
+
+You've probably seen people in onchain communities use ⌐◨-◨ in their profile names. These are called _Nouns Goggles_, or _Noggles_. They're an ASCII representation of the glasses found on every procedurally generated [Nouns] NFT avatar. The [Nouns Auction] makes one new Noun available for auction every single day - forever!
+
+Ownership of a Noun gives a wallet address membership in the [Nouns DAO]. The [Nouns Protocol] is open-source and the art is public domain, so any builder can leverage the protocol to create their own community. For example, the [Purple DAO] supports [Farcaster].
+
+In this tutorial, you'll learn how to use Nouns and the Coinbase [Smart Wallet] to create an app in which non-crypto-native participants at an IRL event can be onboarded and receive Nounish avatars.
+
+---
+
+## Objectives
+
+By the end of this tutorial you should be able to:
+
+- Deploy a copy of the [Nouns Protocol]
+- Construct a web app that can onboard new users with the Coinbase [Smart Wallet] and grand them a Nounish avatar NFT
+
+## Prerequisites
+
+### ERC-721 Tokens
+
+This tutorial assumes that you are able to write, test, and deploy your own ERC-721 tokens using the Solidity programming language. If you need to learn that first, check out our content in [Base Camp] or the sections specific to [ERC-721 Tokens]!
+
+### Vercel
+
+You'll need to be comfortable deploying your app to [Vercel], or using another solution on your own. Check out our tutorial on [deploying with Vercel] if you need a refresher!
+
+### Onchain Apps
+
+The tutorial assumes you're comfortable with the basics of deploying an app and connecting it to a smart contract. If you're still learning this part, check out our tutorials in [Base Camp] for [Building an Onchain App].
+
+---
+
+## The Nouns Protocol
+
+Start by cloning the [Nouns Monorepo]. Open `packages/nouns-contracts` and review the readme, and install dependencies.
+
+```bash
+cd packages/nouns-contracts
+yarn install
+```
+
+## Conclusion
+
+---
+
+[Base Camp]: https://base.org.camp
+[ERC-721 Tokens]: https://docs.base.org/base-camp/docs/erc-721-token/erc-721-standard-video
+[OpenZeppelin ERC-721]: https://docs.openzeppelin.com/contracts/2.x/api/token/erc721
+[OpenZeppelin]: https://www.openzeppelin.com/
+[Nouns]: https://nouns.center/intro
+[Nouns Auction]: https://nouns.wtf/
+[Nouns DAO]: https://nouns.wtf/vote
+[Nouns Protocol]: https://nouns.center/dev/nouns-protocol
+[Nouns Monorepo]: https://github.com/nounsDAO/nouns-monorepo/
+[Purple DAO]: https://nouns.build/dao/base/0x8de71d80eE2C4700bC9D4F8031a2504Ca93f7088/563
+[Farcaster]: https://www.farcaster.xyz/
+[Smart Wallet]: https://www.smartwallet.dev/why

--- a/apps/base-docs/tutorials/docs/1_thirdweb-unreal-nft-items.md
+++ b/apps/base-docs/tutorials/docs/1_thirdweb-unreal-nft-items.md
@@ -148,7 +148,7 @@ In the server `.env`:
 
 Open `client/components/ThirdwebProvider.tsx`. Update the `activeChain` to Base Sepolia.
 
-```typescript
+```tsx
 import { BaseSepoliaTestnet } from '@thirdweb-dev/chains';
 
 // This is the chainId your dApp will work on.
@@ -159,7 +159,7 @@ const activeChain = BaseSepoliaTestnet;
 
 Open `server/src/controllers/engineController.ts`. Update the `const`s at the beginning to load from environment variables:
 
-```typescript
+```tsx
 const ENGINE_URL = process.env.THIRDWEB_ENGINE_URL;
 const BACKEND_WALLET = process.env.THIRDWEB_ENGINE_BACKEND_WALLET;
 const ERC20_CONTRACT = process.env.ERC20_CONTRACT;
@@ -270,13 +270,13 @@ RANDOM_COLOR_NFT_CONTRACT=<your contract address>
 
 Open `server/src/controllers/engineController.ts` and add it there as well:
 
-```typescript
+```tsx
 const RANDOM_COLOR_NFT_CONTRACT = process.env.RANDOM_COLOR_NFT_CONTRACT;
 ```
 
 Now, using `claimERC20` as a template, add a function to `claimRandomColorNFT`. It's identical, except the `url`, `body`, and error message are:
 
-```typescript
+```tsx
 // Other code...
 const url = `${ENGINE_URL}/contract/${CHAIN}/${RANDOM_COLOR_NFT_CONTRACT}/write`;
 // Other code
@@ -296,7 +296,7 @@ A better practice for production would be to make a more generalized function th
 
 Next, you need to add a route for this function. Open `server/src/routes/engineRoutes.ts`. Import `claimRandomColorNFT` and add a route for it:
 
-```typescript
+```tsx
 router.post('/claim-random-color-nft', claimRandomColorNFT);
 ```
 
@@ -366,7 +366,7 @@ On the right side, change the `Element 2` material to `MI_NFT_Color`. The car is
 
 Return to `engine-express` and open `engineController.ts`. Add a function to `getNFTColors` that uses the `read` endpoint to call the `getNFTsOwned` function.
 
-```typescript
+```tsx
 export const getNFTColors = async (req: Request, res: Response) => {
   const { authToken } = req.body;
   if (!authToken || !userTokens[authToken]) {
@@ -395,7 +395,7 @@ export const getNFTColors = async (req: Request, res: Response) => {
 
 You'll also need to add this function to `engineRoutes.ts`:
 
-```typescript
+```tsx
 router.post('/get-nft-colors', getNFTColors);
 ```
 
@@ -403,7 +403,7 @@ Return to `engineController.ts`.
 
 Because Unreal doesn't support SVGs, you'll need to extract the color from your NFT metadata, and pass that to use in the material you created. Start by adding a type for the response, and for the JSON metadata:
 
-```typescript
+```tsx
 type NFTData = {
   tokenId: bigint;
   metadata: string;
@@ -418,7 +418,7 @@ type JSONMetadata = {
 
 You'll also need helper functions to decode the base64 encoded metadata and SVG, then get the color from the SVG.
 
-```typescript
+```tsx
 function getJsonMetadata(nft: NFTData) {
   const base64String = nft.metadata.split(',')[1];
   const jsonString = atob(base64String);
@@ -435,7 +435,7 @@ function getColorFromBase64StringSVG(base64String: string) {
 
 Use these to extract an array of colors and return it:
 
-```typescript
+```tsx
 const nfts = response.data.result.map((item: any) => {
   return {
     tokenId: item[0],

--- a/apps/base-docs/tutorials/docs/2_account-abstraction-with-particle-network.md
+++ b/apps/base-docs/tutorials/docs/2_account-abstraction-with-particle-network.md
@@ -214,7 +214,7 @@ To achieve this, `AuthCoreContextProvider` will take the following parameters:
 
 With this in mind, an example of what your `index.jsx/tsx` file may look like given the usage of `AuthCoreContextProvider` has been included below.
 
-```typescript
+```tsx
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 
@@ -278,7 +278,7 @@ These hooks include `useEthereum` for the retrieval of the standard EOA-based pr
 
 To begin building `App.jsx/tsx`, you'll need to define the relevant functions from these hooks through a process similar to the example below:
 
-```typescript
+```tsx
 import React, { useState, useEffect } from 'react';
 import { useEthereum, useConnect, useAuthCore } from '@particle-network/auth-core-modal';
 import { BaseSepolia } from '@particle-network/chains';
@@ -320,7 +320,7 @@ To configure `SmartAccount`, you'll be using the following parameters:
 
 See the snippet below for an example of a constructed `SmartAccount` object:
 
-```typescript
+```tsx
 import React, { useState, useEffect } from 'react';
 import { useEthereum, useConnect, useAuthCore } from '@particle-network/auth-core-modal';
 import { BaseSepolia } from '@particle-network/chains';
@@ -362,7 +362,7 @@ Essentially, we'll construct an instance of `AAWrapProvider`, passing in the pre
 
 You can achieve this in one line of code, e.g.:
 
-```typescript
+```tsx
 // For Ethers V6, use ethers.BrowserProvider instead; the syntax below won't work.
 const customProvider = new ethers.providers.Web3Provider(
   new AAWrapProvider(smartAccount, SendTransactionMode.Gasless),
@@ -399,7 +399,7 @@ Ideally, some logic should be set in place to ensure `connect` isn't called if a
 
 Below is an example of calling `connect` (within the conditional described above).
 
-```typescript
+```tsx
 const handleLogin = async (authType) => {
   if (!userInfo) {
     await connect({
@@ -429,7 +429,7 @@ If you intend on interacting with a contract, `data` can also be filled out (or 
 
 Therefore, your `tx` object should look like this:
 
-```typescript
+```tsx
 const executeUserOp = async () => {
     ...
 
@@ -454,7 +454,7 @@ To reflect the transaction hash after its confirmation on-chain, you can call th
 
 See the example below for a visualization of this process:
 
-```typescript
+```tsx
 const executeUserOp = async () => {
   const signer = customProvider.getSigner();
 
@@ -480,7 +480,7 @@ Essentially, this displays either "Sign in with Google" or "Sign in with Twitter
 
 Below is an example of what your `App.jsx/tsx` file may look at this point. At the bottom of this snippet you'll find the JSX:
 
-```typescript
+```tsx
 import React, { useState, useEffect } from 'react';
 
 import { useEthereum, useConnect, useAuthCore } from '@particle-network/auth-core-modal';

--- a/apps/base-docs/tutorials/docs/2_account-abstraction-with-privy-and-base-paymaster.md
+++ b/apps/base-docs/tutorials/docs/2_account-abstraction-with-privy-and-base-paymaster.md
@@ -292,7 +292,7 @@ If you navigate to [console.privy.io](https://console.privy.io/), you'll see tha
 
 Diving into the code, first look at the `PrivyProvider` inside of `_app.jsx`:
 
-```typescript
+```tsx
 <PrivyProvider
   appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID || ''}
   onSuccess={() => router.push('/dashboard')}
@@ -307,7 +307,7 @@ Additionally, it's here that you can pass an optional `config` property to enabl
 
 Add a `config` property to the `<PrivyProvider />` in `_app.jsx` with `'github'` and `'sms'` as the login options:
 
-```typescript
+```tsx
 <PrivyProvider
   appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID || ''}
   onSuccess={() => router.push('/dashboard')}
@@ -339,7 +339,7 @@ A full list of the fields and methods returned from `usePrivy` are [documented h
 
 To access wallet data for currently authenticated user, use the `useWallets` hook:
 
-```typescript
+```tsx
 import { ConnectedWallet, useWallets } from '@privy-io/react-auth';
 
 const { wallets } = useWallets();
@@ -387,7 +387,7 @@ When configuring your app to create embedded wallets on login, you have 2 option
 
 Inside of `_app.tsx`, update your `PrivyProvider`:
 
-```typescript
+```tsx
 <PrivyProvider
   appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID || ''}
   onSuccess={() => router.push('/dashboard')}
@@ -401,7 +401,7 @@ Inside of `_app.tsx`, update your `PrivyProvider`:
 
 Log out of your application, then log in again and see that your user has an additional `linkedAccount` which is the Privy Embedded Wallet:
 
-```typescript
+```tsx
 {
   "address": "0xD5063967BA703D485e3Ca40Ecd61882dfa5F49b2",
   "type": "wallet",
@@ -504,7 +504,7 @@ If you're used to working with wagmi, you'll find the process of sending and awa
 
 When a user clicks, the app first creates a viem `RpcTransactionRequest` for the `mint` function on the smart contract. The `smartContractAddress` is supplied by the `SmartAccountProvider`, and the `ABI` and contract `NFT_ADDRESS` are loaded from `lib/constants.ts`:
 
-```typescript
+```tsx
 {
   from: smartAccountAddress,
   to: NFT_ADDRESS,
@@ -542,7 +542,7 @@ Open `SmartAccountContext.tsx` in your project. You'll see an error for `getDefa
 
 The app is currently configured to find and use the user's embedded Privy wallet as the signer. To change this, modify the instantiation of the `SmartAccountProvider`. Instead of `find`ing the user's Privy wallet:
 
-```typescript
+```tsx
 // Old code to change
 
 // Get a list of all of the wallets (EOAs) the user has connected to your site
@@ -553,7 +553,7 @@ const embeddedWallet = wallets.find((wallet) => wallet.walletClientType === 'pri
 
 Simply grab the first wallet in the list (you'll want to do something more elegant for a production app):
 
-```typescript
+```tsx
 // Updated Code
 
 // Get a list of all of the wallets (EOAs) the user has connected to your site
@@ -566,7 +566,7 @@ const wallet = wallets[0];
 
 Then, update the call at the bottom of `useEffect` to `createSmartWallet` if there is an `embeddedWallet` to instead create it if there is a `wallet`, using that `wallet`. You'll also need to update the dependency in the dependency array.
 
-```typescript
+```tsx
 useEffect(() => {
   // Other code
 
@@ -591,7 +591,7 @@ Its instance type 'SmartAccountProvider<Transport>' is not a valid JSX element.
 
 :::
 
-```typescript
+```tsx
 <PrivyProvider
   appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID || ''}
   onSuccess={() => router.push('/dashboard')}
@@ -610,7 +610,7 @@ Its instance type 'SmartAccountProvider<Transport>' is not a valid JSX element.
 
 Grab the snippet from the original demo that displays the user's addresses, and add it to `dashboard.tsx` in the new project:
 
-```typescript
+```tsx
 <p className="mt-6 font-bold uppercase text-sm text-gray-600">
   Your Smart Wallet Address
 </p>
@@ -635,7 +635,7 @@ Paste it above the `<p>` for the `User Object` window.
 
 You'll need to import `BASE_GOERLI_SCAN_URL` from `constants.ts`. The `useSmartAccount` hook returns `smartAccountProvider` and `eoa`. Import it and add it under the `usePrivy` hook. You don't need them just yet, but go ahead and decompose `smartAccountProvider` and `sendSponsoredUserOperation` as well:
 
-```typescript
+```tsx
 const router = useRouter();
 const {
   ready,
@@ -673,7 +673,7 @@ You've adjusted the foundation of the app to allow you to use the Base Goerli Pa
 
 Start by using the `mint` function in the original example. In the `DashboardPage` component, add a state variable holding an empty element:
 
-```typescript
+```tsx
 const [transactionLink, setTransactionLink] = useState(<></>);
 ```
 
@@ -681,7 +681,7 @@ Then, add a variant of the original `onMint` function that sets this variable an
 
 **Note:** make sure you change your wallet address in `args` to make sure the NFT is sent to your EOA wallet address!
 
-```typescript
+```tsx
 const onMint = async () => {
   // The mint button is disabled if either of these are undefined
   if (!smartAccountProvider || !smartAccountAddress) return;
@@ -716,7 +716,7 @@ const onMint = async () => {
 
 Finally, above where you added the addresses, add a button to call the function, and display the link to the transaction:
 
-```typescript
+```tsx
 <button
   onClick={onMint}
   className="rounded-md bg-violet-600 px-4 py-2 text-sm text-white hover:bg-violet-700 disabled:bg-violet-400"
@@ -743,7 +743,7 @@ The [Base Paymaster] on Goerli is very permissive. To call another function, all
 
 For example, to call the `claim` function in the Weighted Voting contract we've used in other tutorials, you'd simply need to import the Hardhat-style [artifact] for the contract and use it to call the function:
 
-```typescript
+```tsx
 const userOpHash = await sendSponsoredUserOperation({
   from: smartAccountAddress,
   to: weightedVoting.address as `0x${string}`,

--- a/apps/base-docs/tutorials/docs/2_coinbase-smart-wallet.md
+++ b/apps/base-docs/tutorials/docs/2_coinbase-smart-wallet.md
@@ -347,7 +347,7 @@ By using the Smart Wallet, you've made it easy for both new and experienced user
 
 Open `page.tsx` and find the `<div>` with the Connect section:
 
-```typescript
+```tsx
 <div>
   <h2>Connect</h2>
   {connectors.map((connector) => (
@@ -362,7 +362,7 @@ Open `page.tsx` and find the `<div>` with the Connect section:
 
 Add a `<header>` element to the top (or as appropriate for the UI/UX library you are using). Move the Connect `<div>` inside, and replace the `connectors.map` function with one that finds the Smart Wallet and uses it to connect. First, create the function:
 
-```typescript
+```tsx
 const createWallet = useCallback(() => {
   const coinbaseWalletConnector = connectors.find(
     (connector) => connector.id === 'coinbaseWalletSDK',
@@ -375,7 +375,7 @@ const createWallet = useCallback(() => {
 
 Then update the `<header>` to use it. You can also move the `Disconnect` button into the header. Only show the appropriate button, depending on the connection state.
 
-```typescript
+```tsx
 <header>
   <div>
     <h2>Connect</h2>
@@ -399,7 +399,7 @@ Then update the `<header>` to use it. You can also move the `Disconnect` button 
 
 Experienced users will know that they need funds for gas and payments to interact with your app, but new users may not. Both benefit from seeing their balance shown on the app. Import `useBalance` and initialize it below `useAccount`:
 
-```typescript
+```tsx
 const account = useAccount();
 const balance = useBalance({ address: account.address });
 ```
@@ -408,7 +408,7 @@ Then add it to the display when the user is logged in. You'll need to extract it
 
 Create a helper function to show the balance with four decimals:
 
-```typescript
+```tsx
 function weiToEtherString(wei: bigint) {
   const ether = formatEther(wei);
   return parseFloat(ether).toFixed(4).toString();
@@ -417,7 +417,7 @@ function weiToEtherString(wei: bigint) {
 
 Then use it to display the user's balance:
 
-```typescript
+```tsx
 <div>
   {account.status === 'connected' &&
     'Balance: (' + account.chain?.name + ') ' + weiToEtherString(balance?.data?.value || BigInt(0))}
@@ -446,7 +446,7 @@ Once you have that, you can use the _One Click_ pay feature to set up a transact
 
 To add this, first add a helper function to build the link:
 
-```typescript
+```tsx
 const APP_ID = 1234; // Replace with your Project Id
 
 function buildOneClickURL() {
@@ -456,7 +456,7 @@ function buildOneClickURL() {
 
 Then add a new button that opens the URL in a new window:
 
-```typescript
+```tsx
 <div>
   {account.status === 'connected' && (
     <button onClick={() => window.open(buildOneClickURL())}>Fund Wallet (Uses Real Money!)</button>
@@ -480,7 +480,7 @@ Use a blockchain explorer to mint a few NFTs on your contract if you haven't yet
 
 Add a new folder in `app` for `components` then add a component called `nftList` in a file of the same name. Import the address and ABI for your deployed Random Color NFT contract. Also import `useAccount` and `useReadContract` from `wagmi`:
 
-```typescript
+```tsx
 import { useAccount, useReadContract } from 'wagmi';
 import contractData from '../contracts/RandomColorNFT.json';
 ```
@@ -528,7 +528,7 @@ export function NFTList() {
 
 Add a type and helper function to convert the base64 encoded metadata to JSON:
 
-```typescript
+```tsx
 type JSONMetadata = {
   name: string;
   description: string;
@@ -548,7 +548,7 @@ The image is already in a format usable by `<img>` tags!
 
 Now that you can extract your metadata and image from your data, use it to build a render function for your NFTs:
 
-```typescript
+```tsx
 function renderNft(nft: NFTData) {
   const metadata = getJsonMetadata(nft);
   return (
@@ -563,7 +563,7 @@ function renderNft(nft: NFTData) {
 
 And use it to display them:
 
-```typescript
+```tsx
 return (
   <div>
     <h2>NFTs</h2>
@@ -587,7 +587,7 @@ Everything should work as expected for both.
 
 Import and set up functions to write to your contract and wait for the receipt:
 
-```typescript
+```tsx
 const { data: writeData, writeContract } = useWriteContract();
 const { data: receipt } = useWaitForTransactionReceipt({
   hash: writeData,
@@ -596,7 +596,7 @@ const { data: receipt } = useWaitForTransactionReceipt({
 
 Wait for the receipt, and use it to trigger a refetch of the NFT data. Doing so will update the user's list of NFTs after they buy a new one:
 
-```typescript
+```tsx
 useEffect(() => {
   if (receipt) {
     refetchNftData();
@@ -606,7 +606,7 @@ useEffect(() => {
 
 Finally, add a button allowing the user to purchase a new NFT:
 
-```typescript
+```tsx
 <button
   onClick={() =>
     writeContract({

--- a/apps/base-docs/tutorials/docs/2_onchain-nfts.md
+++ b/apps/base-docs/tutorials/docs/2_onchain-nfts.md
@@ -396,7 +396,7 @@ string memory json = Base64.encode(
 
 Now is a good time to deploy to testnet and see if this first pass is working as expected. If you're using [Hardhat and Hardhat Deploy], you can use this script:
 
-```typescript
+```tsx
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { DeployFunction } from 'hardhat-deploy/types';
 
@@ -664,7 +664,7 @@ contract SVGRenderer {
 
 Update your deploy script, then deploy and test as before.
 
-```typescript
+```tsx
 const SkyRenderer = await deploy('SkyRenderer', {
   from: deployer,
 });
@@ -776,7 +776,7 @@ function render(uint _tokenId) public view returns (string memory) {
 
 And the deploy script:
 
-```typescript
+```tsx
 const LandRenderer = await deploy('LandRenderer', {
   from: deployer,
 });

--- a/apps/base-docs/tutorials/docs/2_signature-mint.md
+++ b/apps/base-docs/tutorials/docs/2_signature-mint.md
@@ -249,7 +249,7 @@ If you're using a different library, you'll need to do research to figure out ho
 
 Add a new test file and fill out a skeleton to deploy your contract and run a test:
 
-```typescript
+```tsx
 import { loadFixture } from '@nomicfoundation/hardhat-toolbox-viem/network-helpers';
 import { expect } from 'chai';
 import hre from 'hardhat';
@@ -299,7 +299,7 @@ describe('Test', function () {
 
 You can use the example in the documentation for [signMessage] in the [viem] wallet client to get started, but it will **not** work as expected.
 
-```typescript
+```tsx
 // BAD CODE EXAMPLE DO NOT USE!
 const signature = await owner.signMessage({
   message: signer1Address,
@@ -312,20 +312,20 @@ The reason for this is that while `signMessage` does follow the previously menti
 
 To fix this, first import some helper functions from [viem]:
 
-```typescript
+```tsx
 import { keccak256, encodePacked, toBytes } from 'viem';
 ```
 
 Then `encodePacked` and `keccak256` hash your variables and turn them into `bytes`, just like you did in the contract in `validateSignature`:
 
-```typescript
+```tsx
 const message = keccak256(encodePacked(['address'], [signer1Address]));
 const messageBytes = toBytes(message);
 ```
 
 Finally, call the wallet `signMessage` function with the newly assembled `messageBytes`. You'll need to mark the data representation as `raw`:
 
-```typescript
+```tsx
 const signature = await owner.signMessage({
   message: { raw: messageBytes },
 });
@@ -337,7 +337,7 @@ Test again, and it will pass!
 
 It's up to you to determine the conditions that you're willing to sign a message. Once those conditions are met, you can use a similar process to load a wallet from your private key and sign the message on any TypeScript backend:
 
-```typescript
+```tsx
 const authorizedAccount = privateKeyToAccount(COINBASE_WALLET_KEY as `0x${string}`);
 
 const authorizedClient = createWalletClient({

--- a/apps/base-docs/tutorials/docs/3_farcaster-frames-gating-and-redirects.md
+++ b/apps/base-docs/tutorials/docs/3_farcaster-frames-gating-and-redirects.md
@@ -94,7 +94,7 @@ The text input field is created by adding the `input` property to `getFrameMetad
 
 In this example, it's in `app/page.tsx` on line 24:
 
-```typescript
+```tsx
 import { getFrameMetadata } from '@coinbase/onchainkit';
 import type { Metadata } from 'next';
 import { NEXT_PUBLIC_URL } from './config';
@@ -127,7 +127,7 @@ const frameMetadata = getFrameMetadata({
 
 When the user enters the text, it gets included in the frame message. You can see how it is retrieved in `api/frame/route.ts`. the `getFrameMessageBody` extracts the frame message from the request, and validates it. The returned `message` contains a number of useful properties that can be seen where it is defined in [OnchainKit], in `src/core/types.ts`:
 
-```typescript
+```tsx
 export interface FrameValidationData {
   button: number; // Number of the button clicked
   following: boolean; // Indicates if the viewer clicking the frame follows the cast author
@@ -146,7 +146,7 @@ export interface FrameValidationData {
 
 The demo makes use of the `input` property to add the story text to the button in the next frame:
 
-```typescript
+```tsx
 //api/frames/route.ts
 
 // Extract the input:
@@ -176,7 +176,7 @@ return new NextResponse(
 
 You can now add outbound links to buttons. To do this with [OnchainKit], simply create a button with an `action` property of `link`, and a `target` of the desired url:
 
-```typescript
+```tsx
 {
   action: 'link',
   label: 'Link to Google',
@@ -188,7 +188,7 @@ You can now add outbound links to buttons. To do this with [OnchainKit], simply 
 
 The third button contains a `Redirect to pictures ↗`. The way it works is a little tricky. Start with the `buttons` defined in the original frame in `page.tsx`. The third button is a `post_redirect`:
 
-```typescript
+```tsx
 {
   label: 'Redirect to pictures',
   action: 'post_redirect',
@@ -197,7 +197,7 @@ The third button contains a `Redirect to pictures ↗`. The way it works is a li
 
 Clicking this button hits the `postUrl`, with the requirement that you return a `redirect` response with a status of 302, and a link. You can see that in `route.ts`:
 
-```typescript
+```tsx
 if (message?.button === 3) {
   return NextResponse.redirect(
     'https://www.google.com/search?q=cute+dog+pictures&tbm=isch&source=lnms',
@@ -222,7 +222,7 @@ The community is evolving quickly and many people are fatigued with "Like, follo
 
 To require the user to "like" the cast before seeing images of puppies, simply modify the conditional for the redirect to include that check:
 
-```typescript
+```tsx
 if (message?.button === 3 && message?.liked) {
   return NextResponse.redirect(
     'https://www.google.com/search?q=cute+dog+pictures&tbm=isch&source=lnms',
@@ -233,7 +233,7 @@ if (message?.button === 3 && message?.liked) {
 
 If they haven't, return a version of the original frame with a new message in the third button. In doing so, you've created a loop with a behavior condition for the user to exit:
 
-```typescript
+```tsx
 if (message?.button === 3 && message.liked) {
   return NextResponse.redirect(
     'https://www.google.com/search?q=cute+dog+pictures&tbm=isch&source=lnms',

--- a/apps/base-docs/tutorials/docs/3_farcaster-frames-hyperframes.md
+++ b/apps/base-docs/tutorials/docs/3_farcaster-frames-hyperframes.md
@@ -58,7 +58,7 @@ Open `page.tsx`. Modify the `getFrameMetadata` for the first frame to match the 
 
 ![First Frame](../../assets/images/frames/first-frame.png)
 
-```typescript
+```tsx
 const frameMetadata = getFrameMetadata({
   buttons: [
     {
@@ -92,7 +92,7 @@ Per the [Frames] specification, `state` is not an allowed property on the first 
 
 Configure the rest of the metadata as you see fit. Remember, this won't show up in your frame, but it will appear if someone links your site to another platform that uses the standard Open Graph metadata.
 
-```typescript
+```tsx
 export const metadata: Metadata = {
   title: 'HyperFrames!',
   description: 'Time is a flat circle.',
@@ -118,7 +118,7 @@ The route you'll construct is similar to the example in [`app/api/route.ts`] of 
 
 Stub out the route, but remove the conditionals and the existing response:
 
-```typescript
+```tsx
 import { FrameRequest, getFrameMessage, getFrameHtmlResponse } from '@coinbase/onchainkit';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -152,7 +152,7 @@ To identify which frame sent the request to the endpoint, you can extract the `s
 
 After the first frame, if the `state` property is present, it will appear in the message as `state`, but it will need to be decoded.
 
-```typescript
+```tsx
 let state = { frame: 'start' };
 
 try {
@@ -167,14 +167,14 @@ try {
 
 Add a file called `hyperframes.ts` to the `app` folder. Import:
 
-```typescript
+```tsx
 import { getFrameHtmlResponse } from '@coinbase/onchainkit';
 import { NEXT_PUBLIC_URL } from './config';
 ```
 
 Next, add an interface for the `HyperFrame`:
 
-```typescript
+```tsx
 export type HyperFrame = {
   frame: string;
   1: string | ((text: string) => string) | (() => string);
@@ -196,7 +196,7 @@ If you need to, update the type here to handle more complex cases.
 
 Next, add a `Record` to store your collection of hyperframes, and a function to add frames to the `Record`:
 
-```typescript
+```tsx
 const frames: Record<string, HyperFrame> = {};
 
 export function addHyperFrame(label: string, frame: HyperFrame) {
@@ -206,7 +206,7 @@ export function addHyperFrame(label: string, frame: HyperFrame) {
 
 Finally, add a function to retrieve and return a hyperframe by its `label` and handle the case of an error.
 
-```typescript
+```tsx
 export function getHyperFrame(frame: string, text: string, button: number) {
   const currentFrame = frames[frame];
   const nextFrameIdOrFunction = currentFrame[button as keyof HyperFrame];
@@ -230,7 +230,7 @@ export function getHyperFrame(frame: string, text: string, button: number) {
 
 You can put the hyperframes wherever you want and import them into your route. For the sake of simplicity, this demo will simply include them at the top of the route file. Import
 
-```typescript
+```tsx
 import { addHyperFrame, getHyperFrame } from '../../hyperframes';
 ```
 
@@ -238,7 +238,7 @@ To store the hyperframes, add them to the `Record` type with `addHyperFrame`. To
 
 Add the name of each frame as that frame's `state` as well.
 
-```typescript
+```tsx
 addHyperFrame('start', {
   frame: getFrameHtmlResponse({
     buttons: [
@@ -302,7 +302,7 @@ The second, also has three buttons, mapped to frames as well. Only `start` is im
 
 Return to `route.ts`. To avoid TypeScript errors, you'll need to implement at least a minimum of error handling for the event that the `frame` query parameter or `button` are not present:
 
-```typescript
+```tsx
 if (!frame) {
   return new NextResponse('Frame not found', { status: 404 });
 }
@@ -315,7 +315,7 @@ if (!message?.button) {
 
 Then, simply import and call `getHyperFrame` as the `NextResponse`:
 
-```typescript
+```tsx
 return new NextResponse(getHyperFrame(frame as string, text || '', message?.button));
 ```
 
@@ -325,7 +325,7 @@ Deploy, test with the [Frame Validator], and debug!
 
 It's not very interesting for everyone to be able to explore without restriction, so add a lock with a password! To do so, add hyperframe that contains a function to see if the `text` contains the correct password.
 
-```typescript
+```tsx
 addHyperFrame('shack', {
   frame: getFrameHtmlResponse({
     buttons: [
@@ -358,7 +358,7 @@ addHyperFrame('shack', {
 
 For the event that the user enters the wrong password, simply add a nearly identical frame asking them to try again. If they enter the correct password, take them to a new room via a different hyperframe:
 
-```typescript
+```tsx
 addHyperFrame('shack-bad-password', {
   frame: getFrameHtmlResponse({
     buttons: [

--- a/apps/base-docs/tutorials/docs/3_farcaster-frames-nft-minting.md
+++ b/apps/base-docs/tutorials/docs/3_farcaster-frames-nft-minting.md
@@ -140,7 +140,7 @@ If your NFTs are unique, you'll want to get the picture of the actual NFT once t
 
 Add a route to get the image. Right now, this can just return the existing image:
 
-```typescript
+```tsx
 import { NextResponse } from 'next/server';
 
 export async function GET() {
@@ -159,7 +159,7 @@ export async function GET() {
 
 Update both `route.ts` and `page.tsx` to use this route for the image:
 
-```typescript
+```tsx
 // page.tsx
 const imageUrl = 'https://land-sea-and-sky.vercel.app/api/images/nft';
 
@@ -187,7 +187,7 @@ export const metadata: Metadata = {
 };
 ```
 
-```typescript
+```tsx
 // route.ts
 return new NextResponse(
   getFrameHtmlResponse({
@@ -210,7 +210,7 @@ Import your deployment artifact, if you're using Hardhat. If you're using Foundr
 
 Add your wallet key, and a provider url to your ``.env.local`, then import them as well.
 
-```typescript
+```tsx
 import LandSeaSkyNFT from '../constants/LandSeaSkyNFT.json';
 
 require('dotenv').config();
@@ -223,7 +223,7 @@ Install [viem] with `yarn add viem`.
 
 Import:
 
-```typescript
+```tsx
 import { privateKeyToAccount } from 'viem/accounts';
 import { baseSepolia } from 'viem/chains';
 import { createWalletClient, http } from 'viem';
@@ -231,7 +231,7 @@ import { createWalletClient, http } from 'viem';
 
 Create a ` walletClient`` from the account, created from the private key, and a  `publicClient`` to read from the blockchain.
 
-```typescript
+```tsx
 const nftOwnerAccount = privateKeyToAccount(WALLET_PRIVATE_KEY as `0x${string}`);
 const nftOwnerClient = createWalletClient({
   account: nftOwnerAccount,
@@ -247,7 +247,7 @@ const publicClient = createPublicClient({
 
 Use the address of the Farcaster user, conveniently provided by the template and OnchainKit, to check whether or not the user has minted the NFT:
 
-```typescript
+```tsx
 let minted = false;
 
 try {
@@ -268,7 +268,7 @@ The double !! will force the response into a boolean.
 
 If the address has already minted an NFT, update the button to share a message thanking them, otherwise, try to mint and airdrop an NFT:
 
-```typescript
+```tsx
 if (minted) {
   return new NextResponse(
     getFrameHtmlResponse({
@@ -322,7 +322,7 @@ Open `route.ts` for the image endpoint.
 
 Update it to grab query parameters from your endpoint, and show the grayscale image if either is missing:
 
-```typescript
+```tsx
 const url = new URL(req.url);
   const queryParams = url.searchParams;
 
@@ -353,7 +353,7 @@ There isn't an sdk to install.
 
 Add a folder inside `app` called `types` and a file called `index.ts` inside that. Add the types for etherscan api responses:
 
-```typescript
+```tsx
 // @dev values taken from sample response
 export type EtherscanEventResponse = {
   blockNumber: string;
@@ -386,13 +386,13 @@ export type EtherscanResponse = {
 
 Import these into the image route:
 
-```typescript
+```tsx
 import { EtherscanResponse } from '../../../types';
 ```
 
 Use the etherscan API to get a list of ERC721 Transfer Events for the address for the contract, filter that list to remove any NFT ids that were given away.
 
-```typescript
+```tsx
 if (!minted || !address) {
   // Send the grayscale image
 } else {
@@ -422,7 +422,7 @@ Add another image, to handle users that have minted your NFT, but don't anymore.
 
 ![Sad Whale](../../assets/images/frames/gave-me-away.png)
 
-```typescript
+```tsx
 if (tokenIdsTo.length === 0) {
   const img = await fetch('https://land-sea-and-sky.vercel.app/gave-me-away.png').then((res) =>
     res.blob(),
@@ -445,7 +445,7 @@ Otherwise, create a viem public client and call tokenURI with the id of the firs
 
 You did this already in api/frame. Use the same pattern, but instead call `tokenURI` with the token id:
 
-```typescript
+```tsx
 // Get the actual NFT image from the contract
 const publicClient = createPublicClient({
   chain: baseSepolia,
@@ -469,7 +469,7 @@ console.log({ tokenMetadata });
 
 The tokenURI for the sample contract returns the actual json metadata, json encoded, with the actual svg inside, also base64 encoded. You'll need to decode it, then return it.
 
-```typescript
+```tsx
 // Decode the base64 encoded JSON
 const tokenMetadataJson = JSON.parse(atob(tokenMetadata.split(',')[1]));
 
@@ -493,7 +493,7 @@ This works!
 
 But Farcaster frames expect an image with a 1:91 to 1 ratio. We need to adjust the svg, and clip the extra content, since the svg has pieces that are intended to be out of frame:
 
-```typescript
+```tsx
 function frameSvgStringToBlob(originalSvgString: string): Blob {
   // Define the dimensions based on the 1.91:1 aspect ratio
   const originalSize = 1024;
@@ -525,7 +525,7 @@ function frameSvgStringToBlob(originalSvgString: string): Blob {
 
 Call your new function, then return it:
 
-```typescript
+```tsx
 const img = new Blob([frameSvgStringToBlob(svg)], { type: 'image/svg+xml' });
 // Return the blob
 return new NextResponse(img, {

--- a/apps/base-docs/tutorials/docs/3_farcaster-frames-nocode-minting.md
+++ b/apps/base-docs/tutorials/docs/3_farcaster-frames-nocode-minting.md
@@ -59,7 +59,7 @@ Open `app/config.ts` and update `NEXT_PUBLIC_URL` to your new deployment.
 
 As always, you'll set up the first frame in `app/page.tsx`. Open that up, and change the example to have a single button. You can keep the example that links to Google:
 
-```typescript
+```tsx
 const frameMetadata = getFrameMetadata({
   buttons: [
     {
@@ -95,7 +95,7 @@ It will cost a small amount of gas to create the project. Approve the transactio
 
 Copy the link, and update your button, and change the frame to use the image that you uploaded for your NFT:
 
-```typescript
+```tsx
 const frameMetadata = getFrameMetadata({
   buttons: [
     {

--- a/apps/base-docs/tutorials/docs/3_farcaster-frames-transactions.md
+++ b/apps/base-docs/tutorials/docs/3_farcaster-frames-transactions.md
@@ -104,7 +104,7 @@ Add a new page to the Next.js [App Router] by adding a new folder in `app` calle
 
 Using the sample page as a guide, set up a new frame, and stub for a new page:
 
-```typescript
+```tsx
 import { getFrameMetadata } from '@coinbase/onchainkit';
 import type { Metadata } from 'next';
 import { NEXT_PUBLIC_URL } from '../config';
@@ -177,7 +177,7 @@ Add a new folder called `buttonclicker` inside the `api` folder of your `app` ro
 
 You'll need to import the standard Frames functions you've been using, as well as some utilities from [viem]. You'll also need a new `type` from [OnchainKit].
 
-```typescript
+```tsx
 import { FrameRequest, getFrameMessage, getFrameHtmlResponse } from '@coinbase/onchainkit/frame';
 import { NextRequest, NextResponse } from 'next/server';
 import { encodeFunctionData, formatEther, parseEther } from 'viem';
@@ -191,14 +191,14 @@ You also need to add the contract address to `config.ts`.
 
 If you're using Hardhat json artifacts, add those to your project and import from there.
 
-```typescript
+```tsx
 import ClickTheButtonABI from '../../_contracts/ClickTheButtonAbi';
 import { CLICK_THE_BUTTON_CONTRACT_ADDR } from '../../config';
 ```
 
 The `getResponse` function works similar to other frames. Stub it out first:
 
-```typescript
+```tsx
 async function getResponse(req: NextRequest): Promise<NextResponse | Response> {
   const body: FrameRequest = await req.json();
   const { isValid } = await getFrameMessage(body, { neynarApiKey: 'NEYNAR_ONCHAIN_KIT' });
@@ -219,7 +219,7 @@ export const dynamic = 'force-dynamic';
 
 To begin, you'll need to build the `data` for the transaction. You'll use `encodeFunctionData` from viem to do this, the same as any other onchain app using viem:
 
-```typescript
+```tsx
 const data = encodeFunctionData({
   abi: ClickTheButtonABI,
   functionName: 'clickTheButton',
@@ -228,7 +228,7 @@ const data = encodeFunctionData({
 
 Next, use `FrameTransactionResponse` from [OnchainKit] to build the response the app expects:
 
-```typescript
+```tsx
 const txData: FrameTransactionResponse = {
   chainId: `eip155:${base.id}`,
   method: 'eth_sendTransaction',
@@ -253,7 +253,7 @@ You can use a different `postUrl` to separate concerns with generating the trans
 
 In this case, simply return the original frame with slightly updated buttons and text:
 
-```typescript
+```tsx
 import { FrameRequest, getFrameMessage, getFrameHtmlResponse } from '@coinbase/onchainkit/frame';
 import { NextRequest, NextResponse } from 'next/server';
 import { NEXT_PUBLIC_URL } from '../../config';

--- a/apps/base-docs/tutorials/docs/4_hardhat-profiling-gas.md
+++ b/apps/base-docs/tutorials/docs/4_hardhat-profiling-gas.md
@@ -56,7 +56,7 @@ import "hardhat-gas-reporter"
 
 Configure the plugin in the `hardhat.config.ts` file:
 
-```typescript
+```tsx
 const config: HardhatUserConfig = {
   // ....
   gasReporter: {
@@ -109,7 +109,7 @@ contract Store {
 
 Add a test file called `Store.test.ts` in order to test the gas reporter plugin. The test file should contain the following:
 
-```typescript
+```tsx
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';

--- a/apps/base-docs/tutorials/docs/4_hardhat-profiling-size.md
+++ b/apps/base-docs/tutorials/docs/4_hardhat-profiling-size.md
@@ -236,7 +236,7 @@ From a contract size perspective, having multiple independent contracts will red
 
 In order to explain this example, create a contract called `Computer` that contains a function called `executeProcess`:
 
-```typescript
+```tsx
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 

--- a/apps/base-docs/tutorials/docs/4_intro-to-providers.md
+++ b/apps/base-docs/tutorials/docs/4_intro-to-providers.md
@@ -119,14 +119,13 @@ It is worth digging in to get a better understanding of how these providers char
 Note that the information below may change, and varies by network. Each provider also has different incentives, discounts, and fees for each level of product. They also have different allowances for calls per second, protocols, and number of endpoints. Please check the source to confirm!
 
 |                 | [Alchemy Costs]  | [QuickNode Costs] | [CDP Costs]        |
-| :-------------- | :--------------- | :---------------- | :-------           |
+| :-------------- | :--------------- | :---------------- | :----------------- |
 | Free Tier / Mo. | 3M compute units | 50M credits       | 500M billing units |
 | Mid Tier / Mo.  | 1.5B CUs @ $199  | 3B credits @ $299 | Coming soon        |
 | eth_blocknumber | 10               | 20                | 30                 |
 | eth_call        | 26               | 20                | 30                 |
 | eth_getlogs     | 75               | 20                | 100                |
 | eth_getbalance  | 19               | 20                | 30                 |
-
 
 To give you an idea of usage amounts, a single wagmi `useContractRead` hook set to watch for changes on a single `view` via a TanStack query and `useBlockNumber` will call `eth_blocknumber` and `eth_call` one time each, every 4 seconds.
 
@@ -164,7 +163,7 @@ If you get an error because you are on the wrong version of node, change to the 
 
 Open your new project in the editor of your choice, and open `pages/_app.tsx`. Here, you'll find a familiar Next.js app wrapped in [context providers] for the TanStack QueryProvider, RainbowKit, and wagmi.
 
-```typescript
+```tsx
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <WagmiProvider config={config}>
@@ -194,7 +193,7 @@ Enter a name for your project, select the `App` option, and click `Create`.
 
 Copy the _Project ID_ from the project information page, and paste it in as the `projectId` in `getDefaultWallets`.
 
-```typescript
+```tsx
 const { connectors } = getDefaultWallets({
   appName: 'RainbowKit App',
   projectId: 'YOUR_PROJECT_ID',
@@ -214,7 +213,7 @@ Before you deploy, make sure you configure the rest of the items in the control 
 
 By default, the setup script will configure your app to use the built-in public provider, and connect to a number of popular chains. To simply matters, remove all but `mainnet` and `base`.
 
-```typescript
+```tsx
 const config = getDefaultConfig({
   appName: 'RainbowKit App',
   projectId: 'YOUR_APP_ID_HERE',
@@ -243,7 +242,7 @@ To select your provider(s), you'll use [`createConfig`] instead of `getDefaultCo
 
 First, set up using [QuickNode] as your provider. Replace your import of the default config from RainbowKit with `createConfig` and `http` from wagmi:
 
-```typescript
+```tsx
 import { createConfig, http, WagmiProvider } from 'wagmi';
 // ...Chains import
 import { RainbowKitProvider } from '@rainbow-me/rainbowkit';
@@ -267,7 +266,7 @@ As with your WalletConnect Id, these endpoints will be visible on the frontend. 
 
 Use this endpoint to add an `http` `transport` to your config:
 
-```typescript
+```tsx
 const config = createConfig({
   chains: [mainnet, base],
   ssr: true,
@@ -298,7 +297,7 @@ Once again, remember to configure the [allowlist] when you publish your app, as 
 
 On the dashboard for your new app, click the `API key` button, and copy the **HTTPS** link to the clipboard. Replace your todo with this link:
 
-```typescript
+```tsx
 const config = createConfig({
   chains: [mainnet, base],
   ssr: true,

--- a/apps/base-docs/tutorials/docs/5_farcaster-cast-actions-simple.md
+++ b/apps/base-docs/tutorials/docs/5_farcaster-cast-actions-simple.md
@@ -58,7 +58,7 @@ Cast actions work similarly to the way [Frames] call your api endpoint. As a res
 
 Add a new folder in `api` called `action` with a file called `route.ts` to create a new route in your app. Import dependencies from OnchainKit and Next.js:
 
-```typescript
+```tsx
 import { FrameRequest, getFrameMessage } from '@coinbase/onchainkit/frame';
 import { NextRequest, NextResponse } from 'next/server';
 ```
@@ -67,7 +67,7 @@ You won't be returning a frame, so you don't need `getFrameHtmlResponse`.
 
 Stub out your `POST` handler and response function:
 
-```typescript
+```tsx
 async function getResponse(req: NextRequest): Promise<NextResponse> {
   // TODO
 }
@@ -87,7 +87,7 @@ export const dynamic = 'force-dynamic';
 
 Parse and validate the request exactly the same as you would a frame in the top of `getResponse`:
 
-```typescript
+```tsx
 const body: FrameRequest = await req.json();
 const { isValid, message } = await getFrameMessage(body, { neynarApiKey: 'NEYNAR_ONCHAIN_KIT' });
 
@@ -98,7 +98,7 @@ if (!isValid) {
 
 Instead of returning a frame, you'll return a json `NextResponse` with a string `message` and a 200 status:
 
-```typescript
+```tsx
 return NextResponse.json({ message: 'Hello from the frame route' }, { status: 200 });
 ```
 
@@ -120,7 +120,7 @@ For now, you can add a simple addition to let the user know what time it is.
 
 Modify your `return`:
 
-```typescript
+```tsx
 // Get the current date and time
 const now = new Date();
 const date = now.toLocaleDateString();
@@ -148,7 +148,7 @@ The [Cast Actions Playground] has a nice tool to build this link for you!
 
 To enable your users to install your action from a web page, simply include the link. Update the root of your site to do so:
 
-```typescript
+```tsx
 export default function Page() {
   return (
     <>
@@ -168,7 +168,7 @@ export default function Page() {
 
 Finally, update the frame on your root page to also have the install link:
 
-```typescript
+```tsx
 const frameMetadata = getFrameMetadata({
   buttons: [
     {


### PR DESCRIPTION
**What changed? Why?**

TypeScript code blocks, including tsx, were using ```typescript for syntax highlighting.  This doesn't appropriately highlight embedded html.  Swap to ```tsx, which renders TypeScript the same, but fixes html.  

Old:
![image](https://github.com/base-org/web/assets/123022781/81d21c80-d3ae-4f7c-aad5-7304509752f5)

New:
![image](https://github.com/base-org/web/assets/123022781/86100899-6e4f-4cf4-b7ec-921e9b82c055)


**Notes to reviewers**

**How has it been tested?**
