### PR TITLE
fix: disable trailingSlash to fix relative link resolution in docs

### DIFF
--- a/apps/base-docs/docusaurus.config.js
+++ b/apps/base-docs/docusaurus.config.js
@@ -3,6 +3,7 @@ dotenv.config();
 
 const baseConfig = {
   baseUrl: '/',
+  trailingSlash: false,
   favicon: 'img/favicon.ico',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
**What changed? Why?**

The `trailingSlash` setting in the `docusaurus.config.js` of `apps/base-docs` has to be set to `false`. This configuration change is necessary because URLs ending with a slash are causing pages to be misinterpreted as directories. This misinterpretation leads to to issues with relative links not resolving correctly, as seen in [**Deployment Exercise**](https://docs.base.org/base-learn/docs/deployment-to-testnet/deployment-to-testnet-exercise/) where the links [Basic Math](https://docs.base.org/base-learn/docs/contracts-and-basic-functions/basic-functions-exercise) and [Testnets](https://docs.base.org/base-learn/docs/deployment-to-testnet/test-networks) don't work. By removing the forced trailing slash every relative link in the page now works.

**Notes to reviewers**

I encourage to manually verify the links behaviors by visiting the pages like [Deployment Exercise](https://docs.base.org/base-learn/docs/deployment-to-testnet/deployment-to-testnet-exercise/) and testing the links throughout such as `Basic Math` and `Testnets`.

**How has it been tested?**

The configuration change was tested locally. After implementing the change, URLs no longer end with a slash unless it's manually inserted in the url, and internal navigation via relative links were checked to work across various documentation pages.