### PR TITLE
Fix: Fixed colliding react keys in ecosystem search

### DIFF
--- a/apps/web/src/components/Ecosystem/List.tsx
+++ b/apps/web/src/components/Ecosystem/List.tsx
@@ -97,7 +97,7 @@ export function List() {
       </div>
       <div className="flex flex-col gap-10 lg:grid lg:grid-cols-4">
         {truncatedApps.map((app) => (
-          <Card {...app} key={app.name} />
+          <Card {...app} key={app.url} />
         ))}
       </div>
       {showEmptyState && (

--- a/apps/web/src/data/ecosystem.json
+++ b/apps/web/src/data/ecosystem.json
@@ -194,7 +194,7 @@
       "infra"
     ],
     "description": "Upgrade Your Web3 Experience with Lore as your primary explorer for Ethereum, Avalanche (C-Chain), Fantom Opera, Base. Stay ahead of the curve with LoreAI, notifications, and more.",
-    "url": "https://searchcrypto.com/",
+    "url": "https://lorescan.com/",
     "imageUrl": "/images/partners/lore.png"
   },
   {

--- a/apps/web/src/data/ecosystem.json
+++ b/apps/web/src/data/ecosystem.json
@@ -1945,15 +1945,6 @@
     "imageUrl": "/images/partners/omni_network.webp"
   },
   {
-    "name": "OpenCover",
-    "url": "https://opencover.com",
-    "description": "OpenCover makes it easy and affordable to cover your portfolio against onchain risks such as smart contract exploits and oracle failures.",
-    "tags": [
-      "infra"
-    ],
-    "imageUrl": "/images/partners/opencover.webp"
-  },
-  {
     "name": "Pyth Network",
     "url": "https://pyth.network/",
     "description": "Pyth delivers real-time market data feeds to 20+ blockchains by sourcing from exchanges, market makers, and trading firms. 150+ DeFi apps trust and rely on Pyth to stay competitive.\n\nOnly Pyth provides the speed, market coverage, and robustness needed to onboard millions of users.",


### PR DESCRIPTION
**What changed? Why?**
* Changed the value we use as the react-key for ecosystem cards from the app's name to the app URL. 
* Deleted duplicate entry for OpenCover

**Notes to reviewers**
* Considered simply changing the names of the colliding entries to be unique. 
* Decided against that as it's less future-proof than using the URL. It's reasonable for apps to share the same name. They should never share the same url.

**How has it been tested?**
Locally.