### PR TITLE
Chore: Bridge Links Should Open in Current Tab

### DIFF
--- a/apps/base-docs/docusaurus.config.js
+++ b/apps/base-docs/docusaurus.config.js
@@ -316,6 +316,40 @@ const config = {
             },
           ],
         },
+        {
+          type: 'dropdown',
+          label: 'Socials',
+          navposition: 'topRight',
+          items: [
+            {
+              label: 'Discord',
+              icon: 'discord',
+              type: 'custom-dropdownLink',
+              target: '_blank',
+              to: "https://discord.com/invite/buildonbase",
+              eventLabel: 'socials_discord',
+              eventContext: 'navbar',
+            },
+            {
+              label: 'Twitter',
+              icon: 'twitter',
+              type: 'custom-dropdownLink',
+              target: '_blank',
+              to: "https://www.twitter.com/base",
+              eventLabel: 'socials_twitter',
+              eventContext: 'navbar',
+            },
+            {
+              label: 'Github',
+              icon: 'github',
+              type: 'custom-dropdownLink',
+              target: '_blank',
+              to: "https://www.github.com/base-org",
+              eventLabel: 'socials_github',
+              eventContext: 'navbar',
+            },
+          ]
+        },
         // Langauge selection dropdown will be supported in the future
         // {
         //   type: 'localeDropdown',

--- a/apps/base-docs/docusaurus.config.js
+++ b/apps/base-docs/docusaurus.config.js
@@ -250,7 +250,6 @@ const config = {
           label: 'Bridge',
           navposition: 'topRight',
           to: 'https://bridge.base.org/',
-          target: '_blank',
           type: 'custom-navbarLink',
           eventLabel: 'bridge',
           eventContext: 'navbar',

--- a/apps/base-docs/src/css/navbar.css
+++ b/apps/base-docs/src/css/navbar.css
@@ -34,10 +34,10 @@
 }
 
 /* Enable if dropdown menus overflow right boundary */
-/* .navbar__items--right .dropdown__menu {
+.navbar__items--right .dropdown__menu {
   left: auto !important;
   right: 0 !important;
-} */
+}
 
 .navbar__item,
 .navbar__link {
@@ -76,8 +76,15 @@
   background-color: rgb(var(--gray100));
 }
 
+.dropdown__link__container {
+  padding: 10px var(--spacing-5);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
+}
+
 .dropdown__link {
-  padding: 20px var(--spacing-5);
   color: rgb(var(--gray0)) !important;
   font-size: var(--title3-font-size);
   line-height: var(--title3-line-height);

--- a/apps/base-docs/src/theme/Navbar/Content/index.js
+++ b/apps/base-docs/src/theme/Navbar/Content/index.js
@@ -1,17 +1,17 @@
 import React, { useCallback } from 'react';
 import { useThemeConfig, ErrorCauseBoundary } from '@docusaurus/theme-common';
 import { useNavbarMobileSidebar } from '@docusaurus/theme-common/internal';
-import NavbarItem from '@theme/NavbarItem';
-import NavbarColorModeToggle from '@theme/Navbar/ColorModeToggle';
-import SearchBar from '@theme/SearchBar';
-import NavbarMobileSidebarToggle from '@theme/Navbar/MobileSidebar/Toggle';
-import NavbarLogo from '@theme/Navbar/Logo';
-import NavbarSearch from '@theme/Navbar/Search';
-import styles from './styles.module.css';
 
-import Icon from '../../../components/Icon';
+import NavbarColorModeToggle from '@theme/Navbar/ColorModeToggle';
+import NavbarItem from '@theme/NavbarItem';
+import NavbarLogo from '@theme/Navbar/Logo';
+import NavbarMobileSidebarToggle from '@theme/Navbar/MobileSidebar/Toggle';
+import NavbarSearch from '@theme/Navbar/Search';
+import SearchBar from '@theme/SearchBar';
+
 import { CustomConnectButton } from '../../NavbarItem/ComponentTypes';
-import logEvent, { ActionType, AnalyticsEventImportance, ComponentType } from "base-ui/utils/logEvent";
+import Icon from '../../../components/Icon';
+import styles from './styles.module.css';
 
 function useNavbarItems() {
   // TODO temporary casting until ThemeConfig type is improved
@@ -40,77 +40,10 @@ ${JSON.stringify(item, null, 2)}`,
   );
 }
 function NavbarLayoutTopContent({ left, right }) {
-  const discordClick = useCallback(() => {
-    logEvent(
-      'social_discord',
-      {
-        action: ActionType.click,
-        component: ComponentType.icon,
-        context: 'navbar',
-      },
-      AnalyticsEventImportance.low
-    );
-  }, [logEvent])
-
-  const twitterClick = useCallback(() => {
-    logEvent(
-      'social_twitter',
-      {
-        action: ActionType.click,
-        component: ComponentType.icon,
-        context: 'navbar',
-      },
-      AnalyticsEventImportance.low
-    );  }, [logEvent])
-
-  const githubClick = useCallback(() => {
-    logEvent(
-      'social_github',
-      {
-        action: ActionType.click,
-        component: ComponentType.icon,
-        context: 'navbar',
-      },
-      AnalyticsEventImportance.low
-    );
-  }, [logEvent])
-
-
   return (
     <div className="navbar__inner">
       <div className="navbar__items">{left}</div>
-      <div className="navbar__items navbar__items--right">
-        {right}
-        <div className="navbar__social__links">
-          <a
-            href="https://discord.com/invite/buildonbase"
-            target="_blank"
-            rel="noreferrer"
-            aria-label="Base on Discord"
-            onClick={discordClick}
-          >
-            <Icon name="discord" />
-          </a>
-          <a
-            href="https://www.twitter.com/base"
-            target="_blank"
-            rel="noreferrer"
-            aria-label="Base on Twitter"
-            onClick={twitterClick}
-          >
-            <Icon name="twitter" />
-          </a>
-          <a
-            href="https://www.github.com/base-org"
-            target="_blank"
-            rel="noreferrer"
-            aria-label="Base on Github"
-            onClick={githubClick}
-          >
-            <Icon name="github" />
-          </a>
-        </div>
-      </div>
+      <div className="navbar__items navbar__items--right">{right}</div>
     </div>
   );
 }

--- a/apps/base-docs/src/theme/NavbarItem/ComponentTypes.js
+++ b/apps/base-docs/src/theme/NavbarItem/ComponentTypes.js
@@ -1,5 +1,7 @@
 import React, { useCallback, useEffect } from 'react';
 import { useAccount } from 'wagmi';
+import { ConnectButton } from '@rainbow-me/rainbowkit';
+import '@rainbow-me/rainbowkit/styles.css';
 
 import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
 import DropdownNavbarItem from '@theme/NavbarItem/DropdownNavbarItem';
@@ -10,17 +12,18 @@ import DocNavbarItem from '@theme/NavbarItem/DocNavbarItem';
 import DocSidebarNavbarItem from '@theme/NavbarItem/DocSidebarNavbarItem';
 import DocsVersionNavbarItem from '@theme/NavbarItem/DocsVersionNavbarItem';
 import DocsVersionDropdownNavbarItem from '@theme/NavbarItem/DocsVersionDropdownNavbarItem';
-import { ConnectButton } from '@rainbow-me/rainbowkit';
-import '@rainbow-me/rainbowkit/styles.css';
-import styles from './styles.module.css';
-import { WalletAvatar } from '../../components/WalletAvatar';
+
+import sanitizeEventString from 'base-ui/utils/sanitizeEventString';
 import logEvent, {
   ActionType,
   AnalyticsEventImportance,
   ComponentType,
   identify,
 } from 'base-ui/utils/logEvent';
-import sanitizeEventString from 'base-ui/utils/sanitizeEventString';
+
+import styles from './styles.module.css';
+import { WalletAvatar } from '../../components/WalletAvatar';
+import Icon from '../../components/Icon';
 
 export const CustomConnectButton = ({ className }) => {
   return (
@@ -173,25 +176,28 @@ export const CustomNavbarLink = (props) => {
 export const CustomDropdownLink = (props) => {
   return (
     <li>
-      <a
-        href={props.to}
-        target={props.target ?? '_self'}
-        className="dropdown__link"
-        style={{ cursor: 'pointer' }}
-        onClick={() => {
-          logEvent(
-            props.eventLabel,
-            {
-              action: ActionType.click,
-              componentType: ComponentType.link,
-              context: props.eventContext,
-            },
-            AnalyticsEventImportance.high,
-          );
-        }}
-      >
-        {props.label}
-      </a>
+      <div className="dropdown__link__container">
+        {props.icon && <Icon name={props.icon} width="24" height="24" />}
+        <a
+          href={props.to}
+          target={props.target ?? '_self'}
+          className="dropdown__link"
+          style={{ cursor: 'pointer' }}
+          onClick={() => {
+            logEvent(
+              props.eventLabel,
+              {
+                action: ActionType.click,
+                componentType: ComponentType.link,
+                context: props.eventContext,
+              },
+              AnalyticsEventImportance.high,
+            );
+          }}
+        >
+          {props.label}
+        </a>
+      </div>
     </li>
   );
 };

--- a/apps/web/src/components/Layout/Nav/DesktopNav.tsx
+++ b/apps/web/src/components/Layout/Nav/DesktopNav.tsx
@@ -139,7 +139,6 @@ function DesktopNav({ color }: DesktopNavProps) {
         className={`inline-flex items-center font-mono text-xl ${
           color === 'black' ? 'text-black' : 'text-white'
         }`}
-        target="_blank"
         rel="noreferrer noopener"
       >
         Bridge


### PR DESCRIPTION
**What changed? Why?**
* Removed `target ='_blank'` from Navbar bridge links on docs.base.org and base.org

**Notes to reviewers**

**How has it been tested?**
locally