### PR TITLE
Change OnchainKit links from github to site

### DIFF
--- a/apps/base-docs/tutorials/docs/3_farcaster-frames-gating-and-redirects.md
+++ b/apps/base-docs/tutorials/docs/3_farcaster-frames-gating-and-redirects.md
@@ -250,7 +250,7 @@ In this tutorial, you learned how to use the main features of Frames - text inpu
 [Base Learn]: https://docs.base.org/base-learn/docs/welcome
 [Farcaster]: https://www.farcaster.xyz/
 [a-frame-in-100-lines]: https://github.com/Zizzamia/a-frame-in-100-lines
-[OnchainKit]: https://github.com/coinbase/onchainkit
+[OnchainKit]: https://onchainkit.xyz
 [Vercel]: https://vercel.com
 [Frame Validator]: https://warpcast.com/~/developers/frames
 [Base channel]: https://warpcast.com/~/channel/base

--- a/apps/base-docs/tutorials/docs/3_farcaster-frames-hyperframes.md
+++ b/apps/base-docs/tutorials/docs/3_farcaster-frames-hyperframes.md
@@ -416,12 +416,12 @@ In this tutorial, you learned how to implement a system of HyperFrames - frames 
 
 [Farcaster]: https://www.farcaster.xyz/
 [a-frame-in-100-lines]: https://github.com/Zizzamia/a-frame-in-100-lines
-[OnchainKit]: https://github.com/coinbase/onchainkit
+[OnchainKit]: https://onchainkit.xyz
 [Vercel]: https://vercel.com
 [Frame Validator]: https://warpcast.com/~/developers/frames
 [deploying with Vercel]: /tutorials/farcaster-frames-deploy-to-vercel
 [Frames]: https://docs.farcaster.xyz/learn/what-is-farcaster/frames
 [NFT Minting Frame]: /tutorials/farcaster-frames-nft-minting
 [old-school adventure game]: https://warpcast.com/briandoyle81/0x108f1cdb
-[changelog]: https://github.com/coinbase/onchainkit/blob/main/CHANGELOG.md
+[changelog]: https://onchainkit.xyz/blob/main/CHANGELOG.md
 [`app/api/route.ts`]: https://github.com/Zizzamia/a-frame-in-100-lines/blob/main/app/api/frame/route.ts

--- a/apps/base-docs/tutorials/docs/3_farcaster-frames-nft-minting.md
+++ b/apps/base-docs/tutorials/docs/3_farcaster-frames-nft-minting.md
@@ -590,7 +590,7 @@ In this tutorial, you learned how to create [Farcaster] frames. You then updated
 [testnet version of Opensea]: https://testnets.opensea.io/
 [Farcaster]: https://www.farcaster.xyz/
 [a-frame-in-100-lines]: https://github.com/Zizzamia/a-frame-in-100-lines
-[OnchainKit]: https://github.com/coinbase/onchainkit
+[OnchainKit]: https://onchainkit.xyz
 [Vercel]: https://vercel.com
 [Frame Validator]: https://warpcast.com/~/developers/frames
 [Base channel]: https://warpcast.com/~/channel/base

--- a/apps/base-docs/tutorials/docs/3_farcaster-frames-nocode-minting.md
+++ b/apps/base-docs/tutorials/docs/3_farcaster-frames-nocode-minting.md
@@ -116,7 +116,7 @@ In this tutorial, you learned how to make a simple [Frame] on [Farcaster] that i
 [mint.fun]: https://mint.fun/
 [Farcaster]: https://www.farcaster.xyz/
 [a-frame-in-100-lines]: https://github.com/Zizzamia/a-frame-in-100-lines
-[OnchainKit]: https://github.com/coinbase/onchainkit
+[OnchainKit]: https://onchainkit.xyz
 [Vercel]: https://vercel.com
 [Frame Validator]: https://warpcast.com/~/developers/frames
 [Base channel]: https://warpcast.com/~/channel/base

--- a/apps/base-docs/tutorials/docs/3_farcaster-frames-transactions.md
+++ b/apps/base-docs/tutorials/docs/3_farcaster-frames-transactions.md
@@ -363,7 +363,7 @@ contract ClickTheButton is Ownable {
 [Base Learn]: https://docs.base.org/base-learn/docs/welcome
 [Farcaster]: https://www.farcaster.xyz/
 [a-frame-in-100-lines]: https://github.com/Zizzamia/a-frame-in-100-lines
-[OnchainKit]: https://github.com/coinbase/onchainkit
+[OnchainKit]: https://onchainkit.xyz
 [Vercel]: https://vercel.com
 [Frame Validator]: https://warpcast.com/~/developers/frames
 [Base channel]: https://warpcast.com/~/channel/base

--- a/apps/base-docs/tutorials/docs/5_farcaster-cast-actions-simple.md
+++ b/apps/base-docs/tutorials/docs/5_farcaster-cast-actions-simple.md
@@ -200,7 +200,7 @@ Watch the [Base Channel] to stay up-to-date on new developments!
 [Cast Action]: https://warpcast.notion.site/Spec-Farcaster-Actions-84d5a85d479a43139ea883f6823d8caa
 [Farcaster]: https://www.farcaster.xyz/
 [a-frame-in-100-lines]: https://github.com/Zizzamia/a-frame-in-100-lines
-[OnchainKit]: https://github.com/coinbase/onchainkit
+[OnchainKit]: https://onchainkit.xyz
 [Vercel]: https://vercel.com
 [Frame Validator]: https://warpcast.com/~/developers/frames
 [Base channel]: https://warpcast.com/~/channel/base


### PR DESCRIPTION
**What changed? Why?**
Frames tutorials predate onchainkit.xyz and linked to the repo in github.  Updated them to link to the site instead.

**Notes to reviewers**

**How has it been tested?**
