### PR TITLE
Fix: Tutorial Pills Should Scroll On Overflow

### DIFF
--- a/apps/base-docs/src/components/FooterCategory/index.tsx
+++ b/apps/base-docs/src/components/FooterCategory/index.tsx
@@ -20,7 +20,7 @@ function FooterLink({ title, href, analyticsData }: FooterLinkType) {
   }, [logEvent]);
 
   return (
-    <li key={title} className={styles.footerCategoryListItem}>
+    <li key={href} className={styles.footerCategoryListItem}>
       <a href={href} className={styles.footerCategoryLink} onClick={linkClick}>
         {title}
       </a>
@@ -34,7 +34,7 @@ export default function FooterCategory({ title, links }: FooterCategoryProps) {
       <h4 className={styles.footerCategoryTitle}>{title}</h4>
       <ul className={styles.footerCategoryList}>
         {links.map((link) => (
-          <FooterLink title={link.title} href={link.href} analyticsData={link.analyticsData} />
+          <FooterLink key={link.href} title={link.title} href={link.href} analyticsData={link.analyticsData} />
         ))}
       </ul>
     </div>

--- a/apps/base-docs/src/pages/tutorials/styles.module.css
+++ b/apps/base-docs/src/pages/tutorials/styles.module.css
@@ -107,6 +107,7 @@
   font-size: 0.9rem;
   line-height: 1.25;
   font-weight: 400;
+  overflow: scroll;
 }
 
 .tutorialAuthor {


### PR DESCRIPTION
**What changed? Why?**
* added overflow scroll for tutorial pills

**Notes to reviewers**

**How has it been tested?**
