### PR TITLE
Cb gpt error detail

### DIFF
--- a/apps/web/src/cdp/api/cb-gpt.ts
+++ b/apps/web/src/cdp/api/cb-gpt.ts
@@ -40,7 +40,7 @@ export async function queryCbGpt(query: CbGptQuery): Promise<QueryCbGptResponse>
 
     if (response.status === 401 || response.status === 403) {
       console.error(errorResponse);
-      throw new Error(`${response.status} ${errorResponse}`);
+      throw new Error(`Forbidden: ${response.status} ${errorResponse}`);
     }
 
     if (response.status === 500 && typeof errorResponse !== 'string' && errorResponse.code === 13) {

--- a/apps/web/src/cdp/api/cb-gpt.ts
+++ b/apps/web/src/cdp/api/cb-gpt.ts
@@ -39,7 +39,8 @@ export async function queryCbGpt(query: CbGptQuery): Promise<QueryCbGptResponse>
     }
 
     if (response.status === 401 || response.status === 403) {
-      throw new Error('Unauthorized access: ensure the calling IP is permitted.');
+      console.error(errorResponse);
+      throw new Error(`${response.status} ${errorResponse}`);
     }
 
     if (response.status === 500 && typeof errorResponse !== 'string' && errorResponse.code === 13) {


### PR DESCRIPTION
**What changed? Why?**
add errorResponse to cb-gpt.

We need more details to know why th ings might be forbidden. Example error in localhost:
`{"error":"failed to generate suggestions 403 go/sg/7b420819-a6a3-4e43-b1d2-38043fc2d53b"}`

This would help us debug
**Notes to reviewers**

**How has it been tested?**
local test