### PR TITLE
stringify errorResponse to cb-gpt query

### DIFF
--- a/apps/web/src/cdp/api/cb-gpt.ts
+++ b/apps/web/src/cdp/api/cb-gpt.ts
@@ -39,7 +39,7 @@ export async function queryCbGpt(query: CbGptQuery): Promise<QueryCbGptResponse>
     }
 
     if (response.status === 401 || response.status === 403) {
-      throw new Error(`Forbidden: ${response.status} ${errorResponse}`);
+      throw new Error(`Forbidden: ${response.status} ${JSON.stringify(errorResponse)}`);
     }
 
     if (response.status === 500 && typeof errorResponse !== 'string' && errorResponse.code === 13) {


### PR DESCRIPTION
**What changed? Why?**
stringify errorResponse to cb-gpt query.

If we get a json object, it will not show anything relevant, this fixes it.

**Notes to reviewers**

**How has it been tested?**
local test