### PR TITLE
feat: adds support for smart wallet's batched calls status tracking

### DIFF
--- a/apps/web/src/components/Basenames/RegistrationContext.tsx
+++ b/apps/web/src/components/Basenames/RegistrationContext.tsx
@@ -42,7 +42,7 @@ export type RegistrationContextProps = {
   setSelectedName: Dispatch<SetStateAction<string>>;
   registerNameTransactionHash: `0x${string}` | undefined;
   setRegisterNameTransactionHash: Dispatch<SetStateAction<`0x${string}` | undefined>>;
-  registerNameCallsBatchId: string | undefined;
+  registerNameCallsBatchId: string;
   setRegisterNameCallsBatchId: Dispatch<SetStateAction<string>>;
   loadingDiscounts: boolean;
   discount: DiscountData | undefined;
@@ -159,6 +159,7 @@ export default function RegistrationProvider({ children }: RegistrationProviderP
   useEffect(() => {
     if (transactionIsFetching || callsIsFetching) {
       logEventWithContext('register_name_transaction_processing', ActionType.change);
+
       setRegistrationStep(RegistrationSteps.Pending);
     }
 

--- a/apps/web/src/components/Basenames/RegistrationContext.tsx
+++ b/apps/web/src/components/Basenames/RegistrationContext.tsx
@@ -21,6 +21,7 @@ import {
 } from 'react';
 import { Address, TransactionReceipt } from 'viem';
 import { useAccount, useWaitForTransactionReceipt } from 'wagmi';
+import { useCallsStatus } from 'wagmi/experimental';
 
 export enum RegistrationSteps {
   Search = 'search',
@@ -41,6 +42,8 @@ export type RegistrationContextProps = {
   setSelectedName: Dispatch<SetStateAction<string>>;
   registerNameTransactionHash: `0x${string}` | undefined;
   setRegisterNameTransactionHash: Dispatch<SetStateAction<`0x${string}` | undefined>>;
+  registerNameCallsBatchId: string | undefined;
+  setRegisterNameCallsBatchId: Dispatch<SetStateAction<string>>;
   loadingDiscounts: boolean;
   discount: DiscountData | undefined;
   allActiveDiscounts: Set<Discount>;
@@ -67,6 +70,10 @@ export const RegistrationContext = createContext<RegistrationContextProps>({
   },
   registerNameTransactionHash: '0x',
   setRegisterNameTransactionHash: function () {
+    return undefined;
+  },
+  registerNameCallsBatchId: '',
+  setRegisterNameCallsBatchId: function () {
     return undefined;
   },
   loadingDiscounts: true,
@@ -135,11 +142,23 @@ export default function RegistrationProvider({ children }: RegistrationProviderP
       enabled: !!registerNameTransactionHash,
     },
   });
+  const [registerNameCallsBatchId, setRegisterNameCallsBatchId] = useState<string>('');
+
+  const {
+    data: callsData,
+    isFetching: callsIsFetching,
+    isSuccess: callsIsSuccess,
+    error: callsError,
+  } = useCallsStatus({
+    id: registerNameCallsBatchId,
+    query: {
+      enabled: !!registerNameCallsBatchId,
+    },
+  });
 
   useEffect(() => {
-    if (transactionIsFetching) {
+    if (transactionIsFetching || callsIsFetching) {
       logEventWithContext('register_name_transaction_processing', ActionType.change);
-
       setRegistrationStep(RegistrationSteps.Pending);
     }
 
@@ -148,9 +167,7 @@ export default function RegistrationProvider({ children }: RegistrationProviderP
         logEventWithContext('register_name_transaction_success', ActionType.change);
         // Reload current ENS name
         baseEnsNameRefetch()
-          .then(() => {
-            setRegistrationStep(RegistrationSteps.Success);
-          })
+          .then(() => setRegistrationStep(RegistrationSteps.Success))
           .catch(() => {});
       }
 
@@ -160,8 +177,25 @@ export default function RegistrationProvider({ children }: RegistrationProviderP
         });
       }
     }
+    if (callsIsSuccess && callsData) {
+      const successCall = callsData.receipts?.find((receipt) => receipt.status === 'success');
+      if (successCall) {
+        logEventWithContext('register_name_transaction_success', ActionType.change);
+        baseEnsNameRefetch()
+          .then(() => setRegistrationStep(RegistrationSteps.Success))
+          .catch(() => {});
+      } else {
+        const failCall = callsData.receipts?.find((receipt) => receipt.status !== 'success');
+        logEventWithContext('register_name_transaction_reverted', ActionType.change, {
+          error: `Smart wallet transaction reverted: ${failCall?.transactionHash}`,
+        });
+      }
+    }
   }, [
     baseEnsNameRefetch,
+    callsData,
+    callsIsFetching,
+    callsIsSuccess,
     logEventWithContext,
     setRegistrationStep,
     transactionData,
@@ -198,16 +232,20 @@ export default function RegistrationProvider({ children }: RegistrationProviderP
       setRegistrationStep,
       registerNameTransactionHash,
       setRegisterNameTransactionHash,
+      registerNameCallsBatchId,
+      setRegisterNameCallsBatchId,
       loadingDiscounts,
       discount,
       allActiveDiscounts,
       transactionData,
-      transactionError,
+      transactionError: transactionError ?? callsError,
     };
   }, [
     allActiveDiscounts,
+    callsError,
     discount,
     loadingDiscounts,
+    registerNameCallsBatchId,
     registerNameTransactionHash,
     registrationStep,
     searchInputFocused,

--- a/apps/web/src/components/Basenames/RegistrationForm/index.tsx
+++ b/apps/web/src/components/Basenames/RegistrationForm/index.tsx
@@ -67,6 +67,7 @@ export default function RegistrationForm() {
     transactionError,
     selectedName,
     setRegisterNameTransactionHash,
+    setRegisterNameCallsBatchId,
     discount,
     loadingDiscounts,
   } = useRegistration();
@@ -104,6 +105,7 @@ export default function RegistrationForm() {
   const {
     callback: registerName,
     data: registerNameTransactionHash,
+    callBatchId,
     isPending: registerNameTransactionIsPending,
     error: registerNameError,
   } = useRegisterNameCallback(
@@ -115,12 +117,18 @@ export default function RegistrationForm() {
   );
 
   useEffect(() => {
-    if (registerNameTransactionHash) {
+    if (registerNameTransactionHash ?? callBatchId) {
       logEventWithContext('register_name_transaction_approved', ActionType.change);
-
-      setRegisterNameTransactionHash(registerNameTransactionHash);
     }
-  }, [logEventWithContext, registerNameTransactionHash, setRegisterNameTransactionHash]);
+    if (callBatchId) setRegisterNameCallsBatchId(callBatchId);
+    if (registerNameTransactionHash) setRegisterNameTransactionHash(registerNameTransactionHash);
+  }, [
+    callBatchId,
+    logEventWithContext,
+    registerNameTransactionHash,
+    setRegisterNameCallsBatchId,
+    setRegisterNameTransactionHash,
+  ]);
 
   const registerNameCallback = useCallback(() => {
     registerName()

--- a/apps/web/src/hooks/useRegisterNameCallback.ts
+++ b/apps/web/src/hooks/useRegisterNameCallback.ts
@@ -21,6 +21,7 @@ function secondsInYears(years: number): bigint {
 type UseRegisterNameCallbackReturnValue = {
   callback: () => Promise<void>;
   data: `0x${string}` | undefined;
+  callBatchId: string | undefined;
   isPending: boolean;
   error: string | undefined | null;
 };
@@ -35,7 +36,7 @@ export function useRegisterNameCallback(
   const { address, chainId, isConnected } = useAccount();
   const { basenameChain } = useBasenameChain();
   const {
-    data: paymasterData,
+    data: callBatchId,
     writeContractsAsync,
     isPending: paymasterIsPending,
     error: paymasterError,
@@ -148,7 +149,8 @@ export function useRegisterNameCallback(
 
   return {
     callback: registerName,
-    data: data ?? (paymasterData as `0x${string}`),
+    data,
+    callBatchId,
     isPending: isPending ?? paymasterIsPending,
     // @ts-expect-error error will be string renderable
     error: error ?? paymasterError,


### PR DESCRIPTION
This should enable requesting from connected wallets the status of a `sendCalls` batch id for name registrations and ties the status of the batch transactions into the existing pending/success/fail logic flow for transaction hashes sent via the traditional flow. 