### PR TITLE
chore: add two csp entries

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -83,6 +83,8 @@ const contentSecurityPolicy = {
     greenhouseDomains,
     ccaLiteDomains,
     ccaDomain,
+    'https://enhanced-provider.rainbow.me',
+    'https://*.coinbase.com',
     'wss://www.walletlink.org/rpc', // coinbase wallet connection
     'https://analytics-service-dev.cbhq.net',
     'mainnet.base.org',


### PR DESCRIPTION
- coinbase domain (potentially related to some smart wallet/sdk failures)
- rainbow api for improved ens resolution when mainnet is not accessible to its provider