### PR TITLE
Chore: Turned off no-use-before-define ts-eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,6 +90,7 @@ module.exports = {
     '@typescript-eslint/no-empty-interface': ['error', { allowSingleExtends: false }],
     '@typescript-eslint/parameter-properties': 'error',
     '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
+    '@typescript-eslint/no-use-before-define': 'off',
 
     // Correctness
     '@typescript-eslint/switch-exhaustiveness-check': 'error',


### PR DESCRIPTION
**What changed? Why?**
* set the typescript-eslint rule `no-use-before-define` to `off`

**Notes to reviewers**

**How has it been tested?**
locally