### PR TITLE
tiny viewports now get centered badges

### DIFF
--- a/apps/web/src/components/Basenames/UsernameProfileSectionBadges/index.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionBadges/index.tsx
@@ -19,7 +19,7 @@ function BadgesLoop({
   currentWalletIsOwner?: boolean;
 }) {
   return (
-    <ul className="mb-12 mt-6 flex flex-row flex-wrap gap-8">
+    <ul className="mb-12 mt-6 flex flex-col flex-wrap items-center gap-8 sm:flex-row sm:items-start">
       {Object.keys(badges).map((badge) => {
         const hasBadge = !!badges[badge as BadgeNames];
         const score =


### PR DESCRIPTION
|before|after|
|-|-|
|<img width="385" alt="image" src="https://github.com/user-attachments/assets/722323fa-872c-4437-a128-087c1e1bc8a5">|<img width="377" alt="image" src="https://github.com/user-attachments/assets/b3942dcd-1d55-48e6-877f-e73c4b30c643">|
