### PR TITLE
Fix datadog env var name to be available on the FE

### DIFF
--- a/apps/web/app/datadog.ts
+++ b/apps/web/app/datadog.ts
@@ -4,8 +4,8 @@
 import { datadogRum } from "@datadog/browser-rum";
 
 datadogRum.init({
-    applicationId: process.env.DATADOG_APP_ID ?? "",
-    clientToken: process.env.DATADOG_CLIENT_TOKEN ?? "",
+    applicationId: process.env.NEXT_PUBLIC_DATADOG_APP_ID ?? "",
+    clientToken: process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN ?? "",
     // `site` refers to the Datadog site parameter of your organization
     // see https://docs.datadoghq.com/getting_started/site/
     site: 'datadoghq.com',


### PR DESCRIPTION
**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
