### PR TITLE
Add bns discount validator endpoint

### DIFF
--- a/apps/web/pages/api/proofs/bns/index.ts
+++ b/apps/web/pages/api/proofs/bns/index.ts
@@ -44,10 +44,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(400).json({ error: 'chain must be Base or Base Sepolia' });
   }
 
-  if (!isBasenameSupportedChain(parsedChain)) {
-    return res.status(400).json({ error: 'chain must be Base or Base Sepolia' });
-  }
-
   try {
     const hasPreviouslyRegistered = await hasRegisteredWithDiscount([address], parsedChain);
 

--- a/apps/web/pages/api/proofs/bns/index.ts
+++ b/apps/web/pages/api/proofs/bns/index.ts
@@ -1,0 +1,80 @@
+import { USERNAME_BNS_DISCOUNT_VALIDATORS } from 'apps/web/src/addresses/usernames';
+import { isBasenameSupportedChain } from 'apps/web/src/hooks/useBasenameChain';
+import {
+  getProofsByNamespaceAndAddress,
+  hasRegisteredWithDiscount,
+  ProofTableNamespace,
+} from 'apps/web/src/utils/proofs';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { Address, isAddress } from 'viem';
+
+export type BNSProofResponse = {
+  discountValidatorAddress: Address;
+  address: Address;
+  namespace: string;
+  proofs: `0x${string}`[];
+};
+
+/*
+this endpoint returns whether or not the account has a bns account
+if result array is empty, user has no bns account
+example return: 
+{
+  "address": "0xB18e4C959bccc8EF86D78DC297fb5efA99550d85",
+  "namespace": "bns_discount",
+  "proofs": "[0x56ce3bbc909b90035ae373d32c56a9d81d26bb505dd935cdee6afc384bcaed8d, 0x99e940ed9482bf59ba5ceab7df0948798978a1acaee0ecb41f64fe7f40eedd17]"
+  "discountValidatorAddress": "0x..."
+}
+*/
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'method not allowed' });
+  }
+  const { address, chain } = req.query;
+  if (!address || Array.isArray(address) || !isAddress(address)) {
+    return res.status(400).json({ error: 'A single valid address is required' });
+  }
+
+  if (!chain || Array.isArray(chain)) {
+    return res.status(400).json({ error: 'invalid chain' });
+  }
+
+  let parsedChain = parseInt(chain);
+  if (!isBasenameSupportedChain(parsedChain)) {
+    return res.status(400).json({ error: 'chain must be Base or Base Sepolia' });
+  }
+
+  if (!isBasenameSupportedChain(parsedChain)) {
+    return res.status(400).json({ error: 'chain must be Base or Base Sepolia' });
+  }
+
+  try {
+    const hasPreviouslyRegistered = await hasRegisteredWithDiscount([address], parsedChain);
+
+    // if any linked address registered previously return an error
+    if (hasPreviouslyRegistered) {
+      return res.status(400).json({ error: 'This address has already claimed a username.' });
+    }
+    const [content] = await getProofsByNamespaceAndAddress(
+      address,
+      ProofTableNamespace.BNSDiscount,
+    );
+
+    const proofs = content?.proofs ? (JSON.parse(content.proofs) as `0x${string}`[]) : [];
+    if (proofs.length === 0) {
+      return res.status(404).json({ error: 'address is not eligible for early access' });
+    }
+
+    const responseData: EarlyAccessProofResponse = {
+      ...content,
+      proofs,
+      discountValidatorAddress: USERNAME_BNS_DISCOUNT_VALIDATORS[parsedChain],
+    };
+
+    return res.status(200).json(responseData);
+  } catch (error: unknown) {
+    console.error(error);
+  }
+
+  return res.status(404).json({ error: 'address is not eligible for early access' });
+}

--- a/apps/web/src/addresses/usernames.ts
+++ b/apps/web/src/addresses/usernames.ts
@@ -38,6 +38,11 @@ export const USERNAME_EA_DISCOUNT_VALIDATORS: AddressMap = {
   [base.id]: '0x6E89d99643DB1223697C77A9F8B2Cb07E898e743',
 };
 
+export const USERNAME_BNS_DISCOUNT_VALIDATORS: AddressMap = {
+  [baseSepolia.id]: '0x',
+  [base.id]: '0x',
+};
+
 export const USERNAME_1155_DISCOUNT_VALIDATORS: AddressMap = {
   [baseSepolia.id]: '0xE41Cd25f429E10744938d5048646E721ac630aF3',
   [base.id]: '0x',

--- a/apps/web/src/utils/proofs/proofs_storage.ts
+++ b/apps/web/src/utils/proofs/proofs_storage.ts
@@ -8,6 +8,7 @@ type Database = {
 export enum ProofTableNamespace {
   Usernames = 'usernames',
   UsernamesEarlyAccess = 'usernames_early_access',
+  BNSDiscount = 'basenames_bns_discount',
 }
 
 type ProofsTable = {


### PR DESCRIPTION
**What changed? Why?**
Add bns discount validator endpoint. This will set up a merkle tree for all users that have Basenames.app names so that they can claim a discount

**Notes to reviewers**
validator address is still not defined, however the merkle tree has been created.

**How has it been tested?**
tested locally using addresses on the merkle tree.
