### PR TITLE
Added Registry FAQ page

### DIFF
--- a/apps/base-docs/docs/tools/registry-faq.md
+++ b/apps/base-docs/docs/tools/registry-faq.md
@@ -1,0 +1,40 @@
+---
+title: Onchain Registry FAQ
+slug: /tools/registry-faq
+description: Frequently asked questions for the Onchain Registry.
+keywords: [onchain registry, registry FAQ, Base registry, Base, Base apps]
+hide_table_of_contents: true
+---
+
+# Onchain Registry FAQ
+
+---
+
+### What happens after I submit my project?
+
+We want to keep the Registry as open and permissionless as we can, but we also need to run entries through a lightweight review process to make sure we are protecting our end users as much as reasonably possible. All reviews are queued based on order of submission. Review times will vary based on the complexity of the entry.
+
+---
+
+### How do I edit my entry if I made a mistake?
+
+To edit your original entry, use our [Registry edit form](https://base.org/registry-edit). This form will ask you for your original entry ID, which you can find at the bottom of your original entry's confirmation email. On the edit form, you only need to fill in the fields that you would like to change.
+
+---
+
+### Why was my entry rejected?
+
+Some common examples of projects we cannot feature at this time include:
+
+- Expired NFT mints
+- ERC-404 collections (e.g. tokens that can be used as fractionalized NFT assets)
+- Platforms that offer investment strategies/financial advice or involve the offer, sale or distribution of unregistered securities in violation of applicable securities laws
+- Services, products or platforms that do not comply with the Coinbase [Prohibited Use Policy](https://www.coinbase.com/legal/prohibited_use)
+
+---
+
+### How can I pull entries from the Registry?
+
+We offer an Onchain Registry API that gives users the ability to display Onchain Registry entries on their own surfaces. Our Onchain Registry API docs can be found [here](/docs/tools/registry-api/).
+
+---

--- a/apps/base-docs/sidebars.js
+++ b/apps/base-docs/sidebars.js
@@ -42,7 +42,13 @@ module.exports = {
         'tools/onramps',
         'tools/onboarding',
         'tools/bridges-mainnet',
-        'tools/registry-api',
+        {
+          type: 'category',
+          label: 'Onchain Registry',
+          collapsible: true,
+          collapsed: true,
+          items: ['tools/registry-api', 'tools/registry-faq'],
+        },
         {
           type: 'category',
           label: 'Toolchains',


### PR DESCRIPTION
**What changed? Why?**
Added in an FAQ for the Onchain Registry and edited the navbar to show the API docs and FAQ under a dropdown.

**How has it been tested?**
I ran the docs site and tested locally