### PR TITLE
Feat: GetStarted page Discoverability

### DIFF
--- a/apps/base-docs/docusaurus.config.js
+++ b/apps/base-docs/docusaurus.config.js
@@ -179,6 +179,14 @@ const config = {
           eventContext: 'navbar',
         },
         {
+          to: 'https://base.org/getstarted',
+          navposition: 'bottomLeft',
+          label: 'Get Started',
+          type: 'custom-navbarLink',
+          eventLabel: 'getstarted',
+          eventContext: 'navbar',
+        },
+        {
           to: '/docs',
           navposition: 'bottomLeft',
           label: 'Docs',
@@ -187,18 +195,17 @@ const config = {
           eventContext: 'navbar',
         },
         {
-          to: '/tutorials',
-          navposition: 'bottomLeft',
-          label: 'Tutorials',
-          type: 'custom-navbarLink',
-          eventLabel: 'tutorials',
-          eventContext: 'navbar',
-        },
-        {
           to: '/base-learn/docs/welcome',
           navposition: 'bottomLeft',
           label: 'Learn',
           items: [
+            {
+              label: 'Tutorials',
+              to: '/tutorials',
+              type: 'custom-dropdownLink',
+              eventLabel: 'tutorials',
+              eventContext: 'navbar',
+            },
             {
               label: 'Learn to Build Onchain',
               to: '/base-learn/docs/welcome',

--- a/apps/web/src/components/GetStarted/BuildersMostWanted.tsx
+++ b/apps/web/src/components/GetStarted/BuildersMostWanted.tsx
@@ -42,8 +42,8 @@ export default async function BuildersMostWanted() {
         />
         <ResourceCard
           title="Host a Meetup"
-          description="Sign up to host a meetup with other Based builders anywhere in the world"
-          href="/"
+          description="Apply to bring Based people together in your community."
+          href="https://docs.google.com/forms/d/e/1FAIpQLSf5wnzD_czyYOyHFeOmFK_rjsJj7Utovo3jWwR40JizPqmDZg/viewform"
           topLeft={<Icon name="people" color="white" />}
           classnames="bg-purple-60 border-purple-60"
         />

--- a/apps/web/src/components/GetStarted/StartBuilding.tsx
+++ b/apps/web/src/components/GetStarted/StartBuilding.tsx
@@ -46,7 +46,7 @@ export default async function StartBuilding() {
         />
         <ResourceCard
           title="Support Team"
-          description="If you're ever in need, contact our Support Team via Disord"
+          description="If you're ever in need, please reach out in a dedicated Discord support channel"
           href="https://discord.com/invite/buildonbase"
           topLeft={<span className="font-mono">02</span>}
           topRight={<Icon name="diagonalUpArrow" width="16px" height="16px" />}

--- a/apps/web/src/components/Home/Hero.tsx
+++ b/apps/web/src/components/Home/Hero.tsx
@@ -113,7 +113,7 @@ export function Hero() {
             <div className="flex flex-col space-y-6">
               <div className="flex flex-col items-center gap-2 pt-7 md:flex-row">
                 <ButtonWithLinkAndEventLogging
-                  href="/getstarted"
+                  href="/getstarted/?utm_source=basedocs&utm_medium=hero"
                   eventName="getstarted"
                   target="_blank"
                   rel="noreferrer noopener"

--- a/apps/web/src/components/Home/Hero.tsx
+++ b/apps/web/src/components/Home/Hero.tsx
@@ -4,7 +4,7 @@ import { motion, useReducedMotion } from 'framer-motion';
 import { ButtonVariants } from 'apps/web/src/components/Button/Button';
 import { ButtonWithLinkAndEventLogging } from 'apps/web/src/components/Button/ButtonWithLinkAndEventLogging';
 import { gradientBgMap, textGradientMap, Verb, verbs } from 'apps/web/src/styles/hero';
-import { bridgeUrl, docsUrl } from 'apps/web/src/constants';
+import { docsUrl } from 'apps/web/src/constants';
 
 const subtitleCopy =
   'Base is a secure, low-cost, builder-friendly Ethereum L2 built to bring the next billion users onchain.';
@@ -113,25 +113,25 @@ export function Hero() {
             <div className="flex flex-col space-y-6">
               <div className="flex flex-col items-center gap-2 pt-7 md:flex-row">
                 <ButtonWithLinkAndEventLogging
-                  href={docsUrl}
+                  href="/getstarted"
+                  eventName="getstarted"
                   target="_blank"
                   rel="noreferrer noopener"
-                  eventName="docs"
                   linkClassNames="w-full"
                   fullWidth
                 >
-                  Read the docs
+                  Get Started
                 </ButtonWithLinkAndEventLogging>
                 <ButtonWithLinkAndEventLogging
-                  href={bridgeUrl}
+                  href={docsUrl}
+                  eventName="docs"
                   target="_blank"
                   rel="noreferrer noopener"
-                  eventName="bridge"
                   linkClassNames="w-full"
                   fullWidth
                   variant={ButtonVariants.Secondary}
                 >
-                  Bridge assets
+                  Read the Docs
                 </ButtonWithLinkAndEventLogging>
               </div>
               <p className="block w-full font-mono uppercase text-white lg:hidden">

--- a/apps/web/src/components/Layout/Nav/DesktopNav.tsx
+++ b/apps/web/src/components/Layout/Nav/DesktopNav.tsx
@@ -171,6 +171,7 @@ function DesktopNav({ color }: DesktopNavProps) {
         Bridge
       </a>
       <Dropdown label="Developers" color={color}>
+        <DropdownLink href="/getstarted" label="Get Started" color={color} eventName="getstarted" />
         <DropdownLink href={docsUrl} label="Docs" color={color} externalLink eventName="docs" />
         <DropdownLink
           href="https://base.org/learn"

--- a/apps/web/src/components/Layout/Nav/DesktopNav.tsx
+++ b/apps/web/src/components/Layout/Nav/DesktopNav.tsx
@@ -171,7 +171,12 @@ function DesktopNav({ color }: DesktopNavProps) {
         Bridge
       </a>
       <Dropdown label="Developers" color={color}>
-        <DropdownLink href="/getstarted" label="Get Started" color={color} eventName="getstarted" />
+        <DropdownLink
+          href="/getstarted/?utm_source=dotorg&utm_medium=nav"
+          label="Get Started"
+          color={color}
+          eventName="getstarted"
+        />
         <DropdownLink href={docsUrl} label="Docs" color={color} externalLink eventName="docs" />
         <DropdownLink
           href="https://base.org/learn"

--- a/apps/web/src/components/Layout/Nav/MobileMenu.tsx
+++ b/apps/web/src/components/Layout/Nav/MobileMenu.tsx
@@ -228,7 +228,7 @@ function MobileMenu({ color }: MobileMenuProps) {
                   label="Developers"
                 >
                   <DropdownLink
-                    href="/getstarted"
+                    href="/getstarted/?utm_source=dotorg&utm_medium=nav"
                     label="Get Started"
                     eventName="getstarted"
                   />

--- a/apps/web/src/components/Layout/Nav/MobileMenu.tsx
+++ b/apps/web/src/components/Layout/Nav/MobileMenu.tsx
@@ -228,6 +228,11 @@ function MobileMenu({ color }: MobileMenuProps) {
                   label="Developers"
                 >
                   <DropdownLink
+                    href="/getstarted"
+                    label="Get Started"
+                    eventName="getstarted"
+                  />
+                  <DropdownLink
                     href="https://docs.base.org"
                     label="Docs"
                     externalLink


### PR DESCRIPTION
**What changed? Why?**
* Added `Get Started` link to base-web navbar
* Added `Get Started` link to base-docs navbar (nesting `Tutorials` under Learn Dropdown)
* Updated baseweb hero CTAs: `Get Started` + `Read the Docs` (deprecating `Bridge Assets`)
* Updated copy/links for two resource cards

**Notes to reviewers**

**How has it been tested?**
locally