### PR TITLE
Chore: Change order of Learn Dropdown links

### DIFF
--- a/apps/base-docs/docusaurus.config.js
+++ b/apps/base-docs/docusaurus.config.js
@@ -200,17 +200,17 @@ const config = {
           label: 'Learn',
           items: [
             {
-              label: 'Tutorials',
-              to: '/tutorials',
-              type: 'custom-dropdownLink',
-              eventLabel: 'tutorials',
-              eventContext: 'navbar',
-            },
-            {
               label: 'Learn to Build Onchain',
               to: '/base-learn/docs/welcome',
               type: 'custom-dropdownLink',
               eventLabel: 'camp_learn',
+              eventContext: 'navbar',
+            },
+            {
+              label: 'Tutorials',
+              to: '/tutorials',
+              type: 'custom-dropdownLink',
+              eventLabel: 'tutorials',
               eventContext: 'navbar',
             },
             {


### PR DESCRIPTION
**What changed? Why?**
* `Tutorials` now goes after `Learn to Build Onchain`

**Notes to reviewers**

**How has it been tested?**
locally