### PR TITLE
Remove og image from headTags

### DIFF
--- a/apps/base-docs/docusaurus.config.js
+++ b/apps/base-docs/docusaurus.config.js
@@ -55,13 +55,6 @@ const config = {
     {
       tagName: 'meta',
       attributes: {
-        property: 'og:image',
-        content: 'https://docs.base.org/img/base-open-graph.png',
-      },
-    },
-    {
-      tagName: 'meta',
-      attributes: {
         name: 'twitter:card',
         content: 'summary_large_image',
       },
@@ -86,13 +79,6 @@ const config = {
         name: 'twitter:description',
         content:
           'Explore the documentation for Base, a secure, low-cost, builder-friendly Ethereum L2.',
-      },
-    },
-    {
-      tagName: 'meta',
-      attributes: {
-        name: 'twitter:image',
-        content: 'https://docs.base.org/img/base-open-graph.png',
       },
     },
   ],


### PR DESCRIPTION
**What changed? Why?**
I think using `headTags` overrides other settings for og:image.  Per the docs, setting `image` in `themeConfig` serves as a fallback for both `og:image` and `twitter:image` if something else doesn't provide it.

I expect this PR will have no change for docs pages and fix the og image for learn pages

https://docusaurus.io/docs/api/themes/configuration#meta-image

**Notes to reviewers**

**How has it been tested?**
