### PR TITLE
Add direct link to discord channel in Learn sidebar

### DIFF
--- a/apps/base-docs/base-learn/docs/help-on-discord.md
+++ b/apps/base-docs/base-learn/docs/help-on-discord.md
@@ -1,0 +1,17 @@
+---
+title: Get Help on Discord
+description: Discover how to get help with Base Learn on Discord.
+hide_table_of_contents: false
+image: /img/base-learn-open-graph.png
+---
+
+Need help?
+
+Whether you're confused about something weird in Solidity, having trouble getting through the frontend material, or just stuck on an exercise - we're here to help!
+
+First, join the [Base Discord].
+
+Then, get help from the community, Based Advocates, and the authors of the program in the [Base Learn] channel!
+
+[Base Discord]: https://base.org/discord
+[Base Learn Channel]: https://discord.com/channels/1067165013397213286/1108389436644917328

--- a/apps/base-docs/base-learn/sidebars.js
+++ b/apps/base-docs/base-learn/sidebars.js
@@ -1,5 +1,10 @@
 const sidebars = {
   docs: [
+    {
+      type: 'link',
+      label: 'Get Help on Discord',
+      href: 'https://discord.com/channels/1067165013397213286/1108389436644917328',
+    },
     ['docs/welcome'],
     {
       type: 'category',

--- a/apps/base-docs/base-learn/sidebars.js
+++ b/apps/base-docs/base-learn/sidebars.js
@@ -1,9 +1,8 @@
 const sidebars = {
   docs: [
     {
-      type: 'link',
-      label: 'Get Help on Discord',
-      href: 'https://discord.com/channels/1067165013397213286/1108389436644917328',
+      type: 'doc',
+      id: 'docs/help-on-discord',
     },
     ['docs/welcome'],
     {


### PR DESCRIPTION
**What changed? Why?**
I suspect part of the drop-off in chats in the Base Learn Discord channel is that people can't find it in all the channels we have now.

Added a page with signup info and a link in the nav sidebar of Base Learn pages.

**Notes to reviewers**

**How has it been tested?**
Locally/manually