### PR TITLE
Add ORA to Oracles page

### DIFF
--- a/apps/base-docs/docs/tools/oracles.md
+++ b/apps/base-docs/docs/tools/oracles.md
@@ -13,6 +13,7 @@ keywords:
     Supra,
     Chainlink,
     Chronicle,
+    ORA,
     Pyth,
     VRF,
     Gelato VRF,
@@ -101,6 +102,18 @@ See this guide to learn how to get started with [Gelato VRF](https://docs.gelato
 
 - Base Mainnet
 - Base Sepolia (Testnet)
+
+---
+
+## ORA
+
+[ORA](https://ora.io) provides an [Onchain AI Oracle](https://docs.ora.io/doc/oao-onchain-ai-oracle/introduction) for Base.
+
+See [this guide](https://docs.ora.io/doc/oao-onchain-ai-oracle/develop-guide/tutorials/interaction-with-oao-tutorial) to learn how to use ORA Onchain AI Oracle.
+
+#### Supported Networks
+
+- Base Mainnet
 
 ---
 


### PR DESCRIPTION
**What changed? Why?**

Added [ORA](https://ora.io) to the Oracles page using the same template existing for the other Oracles.

**Notes to reviewers**

**How has it been tested?**
Yes, it runs locally.

![image](https://github.com/user-attachments/assets/0efa4314-f50a-4074-9c34-d44f5d9b3bbd)
