### PR TITLE
Make cbId search lowercase and case sensitive to search by index

### DIFF
--- a/apps/web/pages/api/proofs/cbid/index.ts
+++ b/apps/web/pages/api/proofs/cbid/index.ts
@@ -29,9 +29,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     const responseData = await getWalletProofs(
-      address as `0x${string}`,
+      // to lower case to be able to use index on huge dataset
+      (address as string).toLowerCase() as `0x${string}`,
       parseInt(chain as string),
       ProofTableNamespace.CBIDDiscount,
+      false,
     );
 
     return res.status(200).json(responseData);

--- a/apps/web/src/utils/proofs/proofs_storage.ts
+++ b/apps/web/src/utils/proofs/proofs_storage.ts
@@ -10,7 +10,7 @@ export enum ProofTableNamespace {
   UsernamesEarlyAccess = 'usernames_early_access',
   BNSDiscount = 'basenames_bns_discount',
   BaseEthHolders = 'basenames_base_eth_holders_discount',
-  CBIDDiscount = 'usernames_cbid_discount',
+  CBIDDiscount = 'basenames_cbid_discount',
 }
 
 type ProofsTable = {
@@ -26,12 +26,19 @@ const proofTableName = 'proofs';
 export async function getProofsByNamespaceAndAddress(
   address: Address,
   namespace: ProofTableNamespace,
+  caseInsensitive = true, // set false for big data sets
 ) {
-  return createKysely<Database>()
+  let query = createKysely<Database>()
     .selectFrom(proofTableName)
-    .where('address', 'ilike', address)
-    .where('namespace', '=', namespace.valueOf())
-    .selectAll()
-    .limit(1)
-    .execute();
+    .where('namespace', '=', namespace.valueOf());
+
+  /**
+   * use = when possible to search by namespace_address index otherwise it's a text based search.
+   */
+  if (caseInsensitive) {
+    query = query.where('address', 'ilike', address);
+  } else {
+    query = query.where('address', '=', address);
+  }
+  return query.selectAll().limit(1).execute();
 }

--- a/apps/web/src/utils/proofs/requests.ts
+++ b/apps/web/src/utils/proofs/requests.ts
@@ -30,13 +30,14 @@ export async function getWalletProofs(
   address: `0x${string}`,
   chain: number,
   namespace: ProofTableNamespace,
+  caseInsensitive = true, // set false for big data sets
 ): Promise<MerkleTreeProofResponse> {
   const hasPreviouslyRegistered = await hasRegisteredWithDiscount([address], chain);
   // if any linked address registered previously return an error
   if (hasPreviouslyRegistered) {
     throw new ProofsException('This address has already claimed a username.', 400);
   }
-  const [content] = await getProofsByNamespaceAndAddress(address, namespace);
+  const [content] = await getProofsByNamespaceAndAddress(address, namespace, caseInsensitive);
   const proofs = content?.proofs ? (JSON.parse(content.proofs) as `0x${string}`[]) : [];
   if (proofs.length === 0) {
     throw new ProofsException(`address is not eligible for [${namespace}] this discount.`, 404);


### PR DESCRIPTION
**What changed? Why?**
Make cbId search lowercase
Update cbid discount namespace
allow for exact match search on db

This is done to optimize to very large datasets like cbid. Searching through ilike would result in long delays and time outs.

**Notes to reviewers**

**How has it been tested?**
tested locally with real data set
