### PR TITLE
Return the real discountValidator address on proof endpoints

### DIFF
--- a/apps/web/src/utils/proofs/proofs_storage.ts
+++ b/apps/web/src/utils/proofs/proofs_storage.ts
@@ -6,7 +6,6 @@ type Database = {
 };
 
 export enum ProofTableNamespace {
-  Usernames = 'usernames',
   UsernamesEarlyAccess = 'usernames_early_access',
   BNSDiscount = 'basenames_bns_discount',
   BaseEthHolders = 'basenames_base_eth_holders_discount',

--- a/apps/web/src/utils/proofs/requests.ts
+++ b/apps/web/src/utils/proofs/requests.ts
@@ -1,4 +1,4 @@
-import { isAddress } from 'viem';
+import { Address, isAddress } from 'viem';
 import { isBasenameSupportedChain } from 'apps/web/src/hooks/useBasenameChain';
 import { hasRegisteredWithDiscount } from 'apps/web/src/utils/proofs/sybil_resistance';
 import { MerkleTreeProofResponse, ProofsException } from 'apps/web/src/utils/proofs/types';
@@ -6,7 +6,21 @@ import {
   getProofsByNamespaceAndAddress,
   ProofTableNamespace,
 } from 'apps/web/src/utils/proofs/proofs_storage';
-import { USERNAME_CB_ID_DISCOUNT_VALIDATORS } from 'apps/web/src/addresses/usernames';
+import {
+  USERNAME_BASE_ETH_HOLDERS_DISCOUNT_VALIDATORS,
+  USERNAME_BNS_DISCOUNT_VALIDATORS,
+  USERNAME_CB_ID_DISCOUNT_VALIDATORS,
+  USERNAME_EA_DISCOUNT_VALIDATORS,
+} from 'apps/web/src/addresses/usernames';
+
+const validators: {
+  [key in ProofTableNamespace]: Record<number, Address>;
+} = {
+  [ProofTableNamespace.CBIDDiscount]: USERNAME_CB_ID_DISCOUNT_VALIDATORS,
+  [ProofTableNamespace.BaseEthHolders]: USERNAME_BASE_ETH_HOLDERS_DISCOUNT_VALIDATORS,
+  [ProofTableNamespace.BNSDiscount]: USERNAME_BNS_DISCOUNT_VALIDATORS,
+  [ProofTableNamespace.UsernamesEarlyAccess]: USERNAME_EA_DISCOUNT_VALIDATORS,
+};
 
 export function proofValidation(
   address: string | string[] | undefined,
@@ -45,7 +59,7 @@ export async function getWalletProofs(
   const responseData: MerkleTreeProofResponse = {
     ...content,
     proofs,
-    discountValidatorAddress: USERNAME_CB_ID_DISCOUNT_VALIDATORS[chain],
+    discountValidatorAddress: validators[namespace][chain],
   };
   return responseData;
 }


### PR DESCRIPTION
**What changed? Why?**
Return the real discountValidator address on proof endpoints.

Currently discountValidator was always returning the CB.id address. this change will use the real discount validator based on namespace.

**Notes to reviewers**

**How has it been tested?**
Tested against BNS, BaseEth, and CBID proof endpoints
