### PR TITLE
Fix: updated logic for base and premium pricing in banner

### DIFF
--- a/apps/web/src/components/Basenames/PremiumExplainerModal/index.tsx
+++ b/apps/web/src/components/Basenames/PremiumExplainerModal/index.tsx
@@ -6,7 +6,7 @@ import { formatEther } from 'viem';
 
 type CustomTooltipProps = {
   active?: boolean;
-  singleYearEthCost?: bigint;
+  baseSingleYearEthCost?: bigint;
   launchTimeSeconds?: bigint;
   payload: [
     {
@@ -21,10 +21,10 @@ type CustomTooltipProps = {
 function CustomTooltip({
   active,
   payload,
-  singleYearEthCost,
+  baseSingleYearEthCost,
   launchTimeSeconds,
 }: CustomTooltipProps) {
-  if (active && payload?.length && launchTimeSeconds && singleYearEthCost) {
+  if (active && payload?.length && launchTimeSeconds && baseSingleYearEthCost) {
     const premium = payload[0].value;
     const hours = payload[0].payload.hours;
     const seconds = hours * 60 * 60;
@@ -37,7 +37,7 @@ function CustomTooltip({
       minute: '2-digit',
       hour12: true,
     });
-    const nameBasePrice = Number(formatEther(singleYearEthCost));
+    const nameBasePrice = Number(formatEther(baseSingleYearEthCost));
     const formattedBasePrice = nameBasePrice.toLocaleString(undefined, {
       maximumFractionDigits: 6,
     });
@@ -60,46 +60,32 @@ function CustomTooltip({
   return null;
 }
 
-function getSingleYearCost(length: number) {
-  if (length <= 3) {
-    return BigInt(100000000000000000);
-  }
-  if (length <= 4) {
-    return BigInt(10000000000000000);
-  }
-  if (length <= 9) {
-    return BigInt(1000000000000000);
-  }
-  return BigInt(100000000000000);
-}
-
 type PremiumExplainerModalProps = {
   isOpen: boolean;
   toggleModal: () => void;
   premiumEthAmount: bigint | undefined;
-  singleYearEthCost: bigint;
-  nameLength: number;
+  baseSingleYearEthCost: bigint;
 };
 const chartMarginValues = { top: 2, right: 2, left: 2, bottom: 2 };
 export function PremiumExplainerModal({
   isOpen,
   toggleModal,
   premiumEthAmount,
-  singleYearEthCost,
-  nameLength,
+  baseSingleYearEthCost,
 }: PremiumExplainerModalProps) {
   const { data: launchTimeSeconds } = useBasenamesLaunchTime();
 
-  const normalSingleYearCost = getSingleYearCost(nameLength);
-
-  if (!premiumEthAmount || !singleYearEthCost) return null;
-  const formattedOneYearCost = Number(formatEther(normalSingleYearCost)).toLocaleString(undefined, {
-    maximumFractionDigits: 6,
-  });
+  if (!premiumEthAmount || !baseSingleYearEthCost) return null;
+  const formattedOneYearCost = Number(formatEther(baseSingleYearEthCost)).toLocaleString(
+    undefined,
+    {
+      maximumFractionDigits: 6,
+    },
+  );
   const formattedPremium = Number(formatEther(premiumEthAmount)).toLocaleString(undefined, {
     maximumFractionDigits: 6,
   });
-  const ethTotal = singleYearEthCost;
+  const ethTotal = premiumEthAmount + baseSingleYearEthCost;
   const formattedTotal = Number(formatEther(ethTotal)).toLocaleString(undefined, {
     maximumFractionDigits: 4,
   });
@@ -160,7 +146,7 @@ export function PremiumExplainerModal({
                 content={
                   // @ts-expect-error type wants an unnecessary prop
                   <CustomTooltip
-                    singleYearEthCost={normalSingleYearCost}
+                    baseSingleYearEthCost={baseSingleYearEthCost}
                     launchTimeSeconds={launchTimeSeconds}
                   />
                 }

--- a/apps/web/src/components/Basenames/PremiumExplainerModal/index.tsx
+++ b/apps/web/src/components/Basenames/PremiumExplainerModal/index.tsx
@@ -83,11 +83,11 @@ export function PremiumExplainerModal({
     },
   );
   const formattedPremium = Number(formatEther(premiumEthAmount)).toLocaleString(undefined, {
-    maximumFractionDigits: 6,
+    maximumFractionDigits: formattedOneYearCost.length - 2,
   });
   const ethTotal = premiumEthAmount + baseSingleYearEthCost;
   const formattedTotal = Number(formatEther(ethTotal)).toLocaleString(undefined, {
-    maximumFractionDigits: 4,
+    maximumFractionDigits: formattedOneYearCost.length - 2,
   });
   return (
     <Modal isOpen={isOpen} onClose={toggleModal} title="">

--- a/apps/web/src/components/Basenames/RegistrationForm/index.tsx
+++ b/apps/web/src/components/Basenames/RegistrationForm/index.tsx
@@ -17,7 +17,6 @@ import { Icon } from 'apps/web/src/components/Icon/Icon';
 import TransactionError from 'apps/web/src/components/TransactionError';
 import TransactionStatus from 'apps/web/src/components/TransactionStatus';
 import { usePremiumEndDurationRemaining } from 'apps/web/src/hooks/useActiveEthPremiumAmount';
-import { useActiveEthPremiumAmount } from 'apps/web/src/hooks/useActivePremiumAmount';
 import useBasenameChain from 'apps/web/src/hooks/useBasenameChain';
 import { useEthPriceFromUniswap } from 'apps/web/src/hooks/useEthPriceFromUniswap';
 import {
@@ -105,7 +104,13 @@ export default function RegistrationForm() {
   const ethUsdPrice = useEthPriceFromUniswap();
   const { data: initialPrice } = useNameRegistrationPrice(selectedName, years);
   const { data: singleYearEthCost } = useNameRegistrationPrice(selectedName, 1);
-  const { basePrice, premiumPrice } = useRentPrice(selectedName, 1)
+  const { basePrice: singleYearBasePrice, premiumPrice } = useRentPrice(selectedName, 1);
+  const formattedPremiumCost = Number(formatEther(premiumPrice ?? 0)).toLocaleString(
+    undefined,
+    {
+      maximumFractionDigits: 3,
+    },
+  );
   const { data: discountedPrice } = useDiscountedNameRegistrationPrice(
     selectedName,
     years,
@@ -158,11 +163,9 @@ export default function RegistrationForm() {
   const usdPrice = hasResolvedUSDPrice ? formatUsdPrice(price, ethUsdPrice) : '--.--';
   const nameIsFree = !hasRegisteredWithDiscount && price === 0n;
 
-  const { data: premiumEthAmount } = useActiveEthPremiumAmount();
   const premiumEndTimestamp = usePremiumEndDurationRemaining();
 
-  const isPremiumActive = premiumEthAmount && premiumEthAmount !== 0n;
-  // const isPremiumActive = premiumPrice && premiumPrice !== 0n;
+  const isPremiumActive = premiumPrice && premiumPrice !== 0n;
   const mainRegistrationElementClasses = classNames(
     'z-10 flex flex-col items-start justify-between gap-6 bg-[#F7F7F7] p-8 text-gray-60 shadow-xl md:flex-row md:items-center',
     {
@@ -178,10 +181,10 @@ export default function RegistrationForm() {
           {isPremiumActive && (
             <div className="flex justify-between gap-4 rounded-t-2xl bg-gradient-to-r from-[#B139FF] to-[#FF9533] px-6 py-4 text-white">
               <p>
-                Temporary premium of {premiumEthAmount} ETH{' '}
+                Temporary premium of {formattedPremiumCost} ETH{' '}
                 {premiumEndTimestamp && <>ends in {premiumEndTimestamp}</>}
               </p>
-              {Boolean(premiumEthAmount && singleYearEthCost) && (
+              {Boolean(premiumPrice && singleYearEthCost) && (
                 <button type="button" className="underline" onClick={togglePremiumExplainerModal}>
                   Learn more
                 </button>
@@ -347,10 +350,10 @@ export default function RegistrationForm() {
           isOpen={learnMoreAboutDiscountsModalOpen}
           toggleModal={toggleLearnMoreModal}
         />
-        {Boolean(premiumEthAmount && singleYearEthCost) && (
+        {Boolean(premiumPrice && singleYearEthCost) && (
           <PremiumExplainerModal
-            premiumEthAmount={premiumPrice as bigint}
-            baseSingleYearEthCost={basePrice as bigint}
+            premiumEthAmount={premiumPrice}
+            baseSingleYearEthCost={singleYearBasePrice}
             isOpen={premiumExplainerModalOpen}
             toggleModal={togglePremiumExplainerModal}
             nameLength={selectedName?.length}

--- a/apps/web/src/components/Basenames/RegistrationForm/index.tsx
+++ b/apps/web/src/components/Basenames/RegistrationForm/index.tsx
@@ -25,6 +25,7 @@ import {
   useNameRegistrationPrice,
 } from 'apps/web/src/hooks/useNameRegistrationPrice';
 import { useRegisterNameCallback } from 'apps/web/src/hooks/useRegisterNameCallback';
+import { useRentPrice } from 'apps/web/src/hooks/useRentPrice';
 import { IS_EARLY_ACCESS } from 'apps/web/src/utils/usernames';
 import classNames from 'classnames';
 import { ActionType } from 'libs/base-ui/utils/logEvent';
@@ -104,6 +105,7 @@ export default function RegistrationForm() {
   const ethUsdPrice = useEthPriceFromUniswap();
   const { data: initialPrice } = useNameRegistrationPrice(selectedName, years);
   const { data: singleYearEthCost } = useNameRegistrationPrice(selectedName, 1);
+  const { basePrice, premiumPrice } = useRentPrice(selectedName, 1)
   const { data: discountedPrice } = useDiscountedNameRegistrationPrice(
     selectedName,
     years,
@@ -160,6 +162,7 @@ export default function RegistrationForm() {
   const premiumEndTimestamp = usePremiumEndDurationRemaining();
 
   const isPremiumActive = premiumEthAmount && premiumEthAmount !== 0n;
+  // const isPremiumActive = premiumPrice && premiumPrice !== 0n;
   const mainRegistrationElementClasses = classNames(
     'z-10 flex flex-col items-start justify-between gap-6 bg-[#F7F7F7] p-8 text-gray-60 shadow-xl md:flex-row md:items-center',
     {
@@ -346,8 +349,8 @@ export default function RegistrationForm() {
         />
         {Boolean(premiumEthAmount && singleYearEthCost) && (
           <PremiumExplainerModal
-            premiumEthAmount={premiumEthAmount}
-            singleYearEthCost={singleYearEthCost as bigint}
+            premiumEthAmount={premiumPrice as bigint}
+            baseSingleYearEthCost={basePrice as bigint}
             isOpen={premiumExplainerModalOpen}
             toggleModal={togglePremiumExplainerModal}
             nameLength={selectedName?.length}

--- a/apps/web/src/hooks/useRentPrice.ts
+++ b/apps/web/src/hooks/useRentPrice.ts
@@ -1,0 +1,29 @@
+import { USERNAME_REGISTRAR_CONTROLLER_ADDRESSES } from 'apps/web/src/addresses/usernames';
+import RegistrarControllerABI from 'apps/web/src/abis/RegistrarControllerABI';
+import { useBasenamesLaunchTime } from 'apps/web/src/hooks/useBasenamesLaunchTime';
+import { useMemo } from 'react';
+import { useReadContract } from 'wagmi';
+import { base } from 'viem/chains';
+import { normalizeEnsDomainName } from 'apps/web/src/utils/usernames';
+
+function secondsInYears(years: number) {
+  const secondsPerYear = 365.25 * 24 * 60 * 60; // .25 accounting for leap years
+  return BigInt(Math.round(years * secondsPerYear));
+}
+
+export function useRentPrice(name: string, years: number) {
+  const normalizedName = normalizeEnsDomainName(name);
+
+  const { data } = useReadContract({
+    abi: RegistrarControllerABI,
+    address: USERNAME_REGISTRAR_CONTROLLER_ADDRESSES[base.id],
+    functionName: 'rentPrice',
+    args: [normalizedName, secondsInYears(years)],
+    chainId: base.id,
+  });
+
+  const basePrice = data?.base;
+  const premiumPrice = data?.premium;
+  
+  return { basePrice, premiumPrice };
+}

--- a/apps/web/src/hooks/useRentPrice.ts
+++ b/apps/web/src/hooks/useRentPrice.ts
@@ -1,7 +1,5 @@
 import { USERNAME_REGISTRAR_CONTROLLER_ADDRESSES } from 'apps/web/src/addresses/usernames';
 import RegistrarControllerABI from 'apps/web/src/abis/RegistrarControllerABI';
-import { useBasenamesLaunchTime } from 'apps/web/src/hooks/useBasenamesLaunchTime';
-import { useMemo } from 'react';
 import { useReadContract } from 'wagmi';
 import { base } from 'viem/chains';
 import { normalizeEnsDomainName } from 'apps/web/src/utils/usernames';
@@ -11,10 +9,17 @@ function secondsInYears(years: number) {
   return BigInt(Math.round(years * secondsPerYear));
 }
 
+type RentPriceResponseType = {
+  data: {
+    base: bigint;
+    premium: bigint;
+  };
+};
+
 export function useRentPrice(name: string, years: number) {
   const normalizedName = normalizeEnsDomainName(name);
 
-  const { data } = useReadContract({
+  const { data }: RentPriceResponseType = useReadContract({
     abi: RegistrarControllerABI,
     address: USERNAME_REGISTRAR_CONTROLLER_ADDRESSES[base.id],
     functionName: 'rentPrice',
@@ -24,6 +29,6 @@ export function useRentPrice(name: string, years: number) {
 
   const basePrice = data?.base;
   const premiumPrice = data?.premium;
-  
+
   return { basePrice, premiumPrice };
 }


### PR DESCRIPTION
**What changed? Why?**
* created hook to use the `rentPrice` contract method, returning a tuple with base price and premium price
* leverage useRentPrice in the Registration form, updating:
  * logic for when to show the banner
  * the premium price displayed to users on the banner and in the learn more modal
* updated number of significant digits shown in the premium explainer modal

**Notes to reviewers**

**How has it been tested?**
locally