### PR TITLE
Log better error message and do not return to client

### DIFF
--- a/apps/web/pages/api/name/[alreadyClaimedName].ts
+++ b/apps/web/pages/api/name/[alreadyClaimedName].ts
@@ -58,9 +58,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     });
     res.status(200).json({ suggestion: JSON.parse(suggestion.response) as string[] });
   } catch (e) {
-    console.error(e);
+    console.error(`Error in queryCbGpt: ${(e as Error).message}`);
     if (e instanceof Error) {
-      res.status(500).json({ error: `failed to generate suggestions ${e.message}` });
+      res.status(500).json({ error: 'failed to generate suggestions' });
     }
   }
 }


### PR DESCRIPTION
**What changed? Why?**
Make the error log more searchable in Datadog and do not surface the internal error to the client.

**Notes to reviewers**

**How has it been tested?**
