### PR TITLE
Make the social share buttons clickable

### DIFF
--- a/apps/web/src/components/Basenames/RegistrationFlow.tsx
+++ b/apps/web/src/components/Basenames/RegistrationFlow.tsx
@@ -300,7 +300,7 @@ export function RegistrationFlow() {
             appear
             show={isSuccess}
             className={classNames(
-              'top-full z-40 pt-20 transition-opacity',
+              'top-full z-40 mt-20 transition-opacity',
               'mx-auto w-full',
               registrationTransitionDuration,
             )}


### PR DESCRIPTION
**What changed? Why?**

Using padding instead of margin meant that the transition element was invisibly covering the social share buttons making them unclickable.

**Notes to reviewers**

**How has it been tested?**
