### PR TITLE
Strip username for reserved name lookup

### DIFF
--- a/apps/web/src/components/Basenames/UsernameProfileNotFound/index.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileNotFound/index.tsx
@@ -18,11 +18,12 @@ export default function UsernameProfileNotFound() {
   if (!username) {
     redirect(`/names`);
   }
+  const strippedUsername = username.replace(/\.base\.eth$/, '');
   const {
     isLoading: isLoadingNameAvailability,
     data: isNameAvailable,
     isFetching,
-  } = useIsNameAvailable(username);
+  } = useIsNameAvailable(strippedUsername);
 
   if (isFetching && isLoadingNameAvailability) {
     return (


### PR DESCRIPTION
**What changed? Why?**
Need to strip `.base.eth` from username before lookup

**Notes to reviewers**

**How has it been tested?**
