### PR TITLE
Fix: Remove Banners and Modal after successful claim

### DIFF
--- a/apps/web/src/components/Basenames/RegistrationFlow.tsx
+++ b/apps/web/src/components/Basenames/RegistrationFlow.tsx
@@ -48,6 +48,7 @@ export function RegistrationFlow() {
   const searchParams = useSearchParams();
   const [, setIsModalOpen] = useLocalStorage('BasenamesLaunchModalVisible', true);
   const [, setIsBannerVisible] = useLocalStorage('basenamesLaunchBannerVisible', true);
+  const [, setIsDocsBannerVisible] = useLocalStorage('basenamesLaunchDocsBannerVisible', true);
 
   const {
     registrationStep,
@@ -121,8 +122,9 @@ export function RegistrationFlow() {
     if (isSuccess) {
       setIsModalOpen(false);
       setIsBannerVisible(false);
+      setIsDocsBannerVisible(false);
     }
-  }, [isSuccess, setIsModalOpen, setIsBannerVisible]);
+  }, [isSuccess, setIsModalOpen, setIsBannerVisible, setIsDocsBannerVisible]);
 
   return (
     <>

--- a/apps/web/src/components/Basenames/RegistrationFlow.tsx
+++ b/apps/web/src/components/Basenames/RegistrationFlow.tsx
@@ -1,6 +1,6 @@
 'use client';
 import dynamic from 'next/dynamic';
-
+import { useLocalStorage } from 'usehooks-ts';
 import { Transition } from '@headlessui/react';
 import { useAnalytics } from 'apps/web/contexts/Analytics';
 import RegistrationBackground from 'apps/web/src/components/Basenames/RegistrationBackground';
@@ -46,6 +46,8 @@ export function RegistrationFlow() {
   const { chain } = useAccount();
   const { logEventWithContext } = useAnalytics();
   const searchParams = useSearchParams();
+  const [, setIsModalOpen] = useLocalStorage('BasenamesLaunchModalVisible', true);
+  const [, setIsBannerVisible] = useLocalStorage('basenamesLaunchBannerVisible', true);
 
   const {
     registrationStep,
@@ -114,6 +116,13 @@ export function RegistrationFlow() {
       setSelectedName(claimQuery.replace(`.${USERNAME_DOMAINS[basenameChain.id]}`, ''));
     }
   }, [basenameChain.id, searchParams, setSelectedName]);
+
+  useEffect(() => {
+    if (isSuccess) {
+      setIsModalOpen(false);
+      setIsBannerVisible(false);
+    }
+  }, [isSuccess, setIsModalOpen, setIsBannerVisible]);
 
   return (
     <>


### PR DESCRIPTION
**What changed? Why?**
* added an effect triggered by `isSuccess` to remove the banners and modals on base-web and base-docs

**Notes to reviewers**

**How has it been tested?**
locally