### PR TITLE
Update status codes on proofs API for better monitoring

### DIFF
--- a/apps/web/pages/api/basenames/avatar/upload.ts
+++ b/apps/web/pages/api/basenames/avatar/upload.ts
@@ -46,6 +46,6 @@ export default async function handler(request: NextApiRequest, response: NextApi
 
     return response.status(200).json(jsonResponse);
   } catch (error) {
-    return response.status(400).json({ error: (error as Error).message });
+    return response.status(500).json({ error: (error as Error).message });
   }
 }

--- a/apps/web/pages/api/proofs/baseEthHolders/index.ts
+++ b/apps/web/pages/api/proofs/baseEthHolders/index.ts
@@ -42,5 +42,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   // If error is not an instance of Error, return a generic error message
-  return res.status(409).json({ error: 'An unexpected error occurred' });
+  return res.status(500).json({ error: 'An unexpected error occurred' });
 }

--- a/apps/web/pages/api/proofs/bns/index.ts
+++ b/apps/web/pages/api/proofs/bns/index.ts
@@ -43,5 +43,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   // If error is not an instance of Error, return a generic error message
-  return res.status(409).json({ error: 'An unexpected error occurred' });
+  return res.status(500).json({ error: 'An unexpected error occurred' });
 }

--- a/apps/web/pages/api/proofs/cb1/index.ts
+++ b/apps/web/pages/api/proofs/cb1/index.ts
@@ -1,5 +1,5 @@
 import { trustedSignerPKey } from 'apps/web/src/constants';
-import { DiscountType, proofValidation } from 'apps/web/src/utils/proofs';
+import { DiscountType, ProofsException, proofValidation } from 'apps/web/src/utils/proofs';
 import { sybilResistantUsernameSigning } from 'apps/web/src/utils/proofs/sybil_resistance';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
@@ -52,12 +52,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     );
     return res.status(200).json(result);
   } catch (error) {
-    console.error(error);
-    if (error instanceof Error) {
-      return res.status(409).json({ error: error.message });
+    if (error instanceof ProofsException) {
+      return res.status(error.statusCode).json({ error: error.message });
     }
-
-    // If error is not an instance of Error, return a generic error message
-    return res.status(409).json({ error: 'An unexpected error occurred' });
+    console.error(error);
   }
+
+  // If error is not an instance of Error, return a generic error message
+  return res.status(500).json({ error: 'An unexpected error occurred' });
 }

--- a/apps/web/pages/api/proofs/cbid/index.ts
+++ b/apps/web/pages/api/proofs/cbid/index.ts
@@ -44,5 +44,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     console.error(error);
   }
   // If error is not an instance of Error, return a generic error message
-  return res.status(409).json({ error: 'An unexpected error occurred' });
+  return res.status(500).json({ error: 'An unexpected error occurred' });
 }

--- a/apps/web/pages/api/proofs/coinbase/index.ts
+++ b/apps/web/pages/api/proofs/coinbase/index.ts
@@ -1,5 +1,10 @@
 import { trustedSignerPKey } from 'apps/web/src/constants';
-import { DiscountType, proofValidation, VerifiedAccount } from 'apps/web/src/utils/proofs';
+import {
+  DiscountType,
+  ProofsException,
+  proofValidation,
+  VerifiedAccount,
+} from 'apps/web/src/utils/proofs';
 import { sybilResistantUsernameSigning } from 'apps/web/src/utils/proofs/sybil_resistance';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { Address } from 'viem';
@@ -54,11 +59,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(200).json(result);
   } catch (error) {
     console.error(error);
-    if (error instanceof Error) {
-      return res.status(409).json({ error: error.message });
+    if (error instanceof ProofsException) {
+      return res.status(error.statusCode).json({ error: error.message });
     }
-
-    // If error is not an instance of Error, return a generic error message
-    return res.status(409).json({ error: 'An unexpected error occurred' });
+    console.error(error);
   }
+
+  // If error is not an instance of Error, return a generic error message
+  return res.status(500).json({ error: 'An unexpected error occurred' });
 }

--- a/apps/web/pages/api/proofs/earlyAccess/index.ts
+++ b/apps/web/pages/api/proofs/earlyAccess/index.ts
@@ -42,5 +42,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     console.error(error);
   }
   // If error is not an instance of Error, return a generic error message
-  return res.status(409).json({ error: 'An unexpected error occurred' });
+  return res.status(500).json({ error: 'An unexpected error occurred' });
 }

--- a/apps/web/src/utils/proofs/requests.ts
+++ b/apps/web/src/utils/proofs/requests.ts
@@ -49,7 +49,7 @@ export async function getWalletProofs(
   const hasPreviouslyRegistered = await hasRegisteredWithDiscount([address], chain);
   // if any linked address registered previously return an error
   if (hasPreviouslyRegistered) {
-    throw new ProofsException('This address has already claimed a username.', 400);
+    throw new ProofsException('This address has already claimed a username.', 409);
   }
   const [content] = await getProofsByNamespaceAndAddress(address, namespace, caseInsensitive);
   const proofs = content?.proofs ? (JSON.parse(content.proofs) as `0x${string}`[]) : [];

--- a/apps/web/src/utils/proofs/sybil_resistance.ts
+++ b/apps/web/src/utils/proofs/sybil_resistance.ts
@@ -87,6 +87,9 @@ async function signMessageWithTrustedSigner(
   targetAddress: Address,
   expiry: number,
 ) {
+  if (!trustedSignerAddress || !isAddress(trustedSignerAddress)) {
+    throw new Error('Must provide a valid trustedSignerAddress');
+  }
   // encode the message
   const message = encodePacked(
     ['bytes2', 'address', 'address', 'address', 'uint64'],


### PR DESCRIPTION
**What changed? Why?**
Updating to something more standardized.
409 means user has already claimed
500 means server or unexpected error


This will help us have better monitoring and alerts
**Notes to reviewers**

**How has it been tested?**
local testing directly to API calls