### PR TITLE
Basename fixes aug 26

### DIFF
--- a/apps/web/src/components/Basenames/ProfilePromo/index.tsx
+++ b/apps/web/src/components/Basenames/ProfilePromo/index.tsx
@@ -8,13 +8,22 @@ import { Button } from 'apps/web/src/components/Button/Button';
 import { Icon } from 'apps/web/src/components/Icon/Icon';
 import Image from 'next/image';
 import { useLocalStorage } from 'usehooks-ts';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import Link from 'next/link';
 import { ActionType, ComponentType } from 'libs/base-ui/utils/logEvent';
 import { useAnalytics } from 'apps/web/contexts/Analytics';
+import { useAccount } from 'wagmi';
+import useBaseEnsName from 'apps/web/src/hooks/useBaseEnsName';
 
 export default function ProfilePromo() {
   const [shouldShowPromo, setShouldShowPromo] = useLocalStorage('shouldShowPromo', true);
+  // Web3 data
+  const { address } = useAccount();
+  const { data: basename, isLoading: basenameIsLoading } = useBaseEnsName({
+    address,
+  });
+  const hasExistingBasename = address && basename && !basenameIsLoading;
+
   const { logEventWithContext } = useAnalytics();
   const onClose = useCallback(() => {
     logEventWithContext('profile_promo_close', ActionType.click, {
@@ -22,12 +31,19 @@ export default function ProfilePromo() {
     });
     setShouldShowPromo(false);
   }, [logEventWithContext, setShouldShowPromo]);
+
   const onCTA = useCallback(() => {
     logEventWithContext('profile_promo_cta', ActionType.click, {
       componentType: ComponentType.button,
     });
     setShouldShowPromo(false);
   }, [logEventWithContext, setShouldShowPromo]);
+
+  useEffect(() => {
+    if (hasExistingBasename) {
+      setShouldShowPromo(false);
+    }
+  }, [hasExistingBasename, setShouldShowPromo]);
 
   if (!shouldShowPromo) {
     return null;

--- a/apps/web/src/components/Basenames/RegistrationForm/index.tsx
+++ b/apps/web/src/components/Basenames/RegistrationForm/index.tsx
@@ -228,24 +228,31 @@ export default function RegistrationForm() {
                 </button>
               </div>
               {hasExistingBasename && (
-                <Tooltip
-                  content={
-                    <>
-                      This will cause apps that support basenames to resolve{' '}
-                      <strong>{formatBaseEthDomain(selectedName, basenameChain.id)}</strong> when
-                      looking up your address.
-                    </>
-                  }
+                <Label
+                  className="mt-4 flex w-full items-center justify-center gap-2 text-center"
+                  htmlFor="reverseRecord"
                 >
-                  <Label className="mt-4 flex items-center justify-center gap-2 text-center">
-                    <input
-                      type="checkbox"
-                      checked={reverseRecord}
-                      onChange={onChangeReverseRecord}
-                    />
+                  <input
+                    type="checkbox"
+                    checked={reverseRecord}
+                    onChange={onChangeReverseRecord}
+                    id="reverseRecord"
+                  />
+                  <span className="flex flex-row items-center gap-2 text-sm">
                     Set as Primary Name
-                  </Label>
-                </Tooltip>
+                    <Tooltip
+                      content={
+                        <>
+                          This will cause apps that support basenames to resolve{' '}
+                          <strong>{formatBaseEthDomain(selectedName, basenameChain.id)}</strong>{' '}
+                          when looking up your address.
+                        </>
+                      }
+                    >
+                      <Icon name="info" color="currentColor" width="0.8rem" height="0.8rem" />
+                    </Tooltip>
+                  </span>
+                </Label>
               )}
             </div>
             <div className="min-w-[14rem] self-start text-left">

--- a/apps/web/src/components/SearchAddressInput/index.tsx
+++ b/apps/web/src/components/SearchAddressInput/index.tsx
@@ -101,7 +101,9 @@ export default function SearchAddressInput({ onChange }: SearchAddressInputProps
             >
               <span>
                 View {showUsername && <strong>{username}</strong>}
-                {finalAddress && <strong>{truncateMiddle(finalAddress, 6, 4)}</strong>}{' '}
+                {!showUsername && finalAddress && (
+                  <strong>{truncateMiddle(finalAddress, 6, 4)}</strong>
+                )}{' '}
                 {baseBlockExplorerName}
               </span>
               <Icon name="external-link" color="currentColor" height="0.8rem" width="0.8rem" />


### PR DESCRIPTION
- Hide Basename Promo if user already has a basename
- fix the search address/basename explorer URL
- Add info icon and tooltip to the "Set as Primary Name" input in the registration flow.