### PR TITLE
Add withTimeout decorator to APIs

### DIFF
--- a/apps/web/pages/api/decorators.ts
+++ b/apps/web/pages/api/decorators.ts
@@ -15,14 +15,14 @@ export function withExecutionTime(
   };
 }
 
-const defaultTimeout = 5000;
+const defaultTimeout = process.env.DEFAULT_API_TIMEOUT ?? 5000;
 export function withTimeout(
   handler: NextApiHandler,
   timeoutLimit = defaultTimeout,
 ): NextApiHandler {
   return async (req, res) => {
     const timeoutPromise = new Promise((_, reject) =>
-      setTimeout(() => reject(new Error('Request timed out')), timeoutLimit),
+      setTimeout(() => reject(new Error('Request timed out')), timeoutLimit as number),
     );
 
     const handlerPromise = new Promise<void>((resolve, reject) => {

--- a/apps/web/pages/api/decorators.ts
+++ b/apps/web/pages/api/decorators.ts
@@ -1,3 +1,4 @@
+import { logger } from 'apps/web/src/utils/logger';
 import { measureExecutionTime } from 'apps/web/src/utils/metrics';
 import { NextApiRequest, NextApiResponse } from 'next';
 
@@ -11,5 +12,35 @@ export function withExecutionTime(
 ): NextApiHandler {
   return async (req: NextApiRequest, res: NextApiResponse) => {
     await measureExecutionTime(metricName, async () => handler(req, res), tags);
+  };
+}
+
+const defaultTimeout = 5000;
+export function withTimeout(
+  handler: NextApiHandler,
+  timeoutLimit = defaultTimeout,
+): NextApiHandler {
+  return async (req, res) => {
+    const timeoutPromise = new Promise((_, reject) =>
+      setTimeout(() => reject(new Error('Request timed out')), timeoutLimit),
+    );
+
+    const handlerPromise = new Promise<void>((resolve, reject) => {
+      Promise.resolve(handler(req, res))
+        .then(() => resolve())
+        .catch((error) => reject(error));
+    });
+
+    try {
+      await Promise.race([handlerPromise, timeoutPromise]);
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message === 'Request timed out') {
+          logger.error('Request timed out');
+          return res.status(408).json({ error: 'Request timed out' });
+        }
+      }
+      return res.status(500).json({ error: 'Something went wrong' });
+    }
   };
 }

--- a/apps/web/pages/api/name/[alreadyClaimedName].ts
+++ b/apps/web/pages/api/name/[alreadyClaimedName].ts
@@ -1,3 +1,4 @@
+import { withTimeout } from 'apps/web/pages/api/decorators';
 import { queryCbGpt } from 'apps/web/src/cdp/api/cb-gpt';
 import { logger } from 'apps/web/src/utils/logger';
 import { NextApiRequest, NextApiResponse } from 'next';
@@ -35,7 +36,7 @@ Remember, the goal is to provide alternatives that users will find desirable and
 Focus on quality and creativity in your suggestions.`;
 const chatLlm = 'claude-3-5-sonnet@20240620';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResponse>) {
+async function handler(req: NextApiRequest, res: NextApiResponse<ApiResponse>) {
   const { alreadyClaimedName } = req.query;
   if (typeof alreadyClaimedName !== 'string') {
     res.status(400).json({ error: 'name must be a string' });
@@ -65,3 +66,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     }
   }
 }
+
+export default withTimeout(handler);

--- a/apps/web/pages/api/proofs/baseEthHolders/index.ts
+++ b/apps/web/pages/api/proofs/baseEthHolders/index.ts
@@ -1,3 +1,4 @@
+import { withTimeout } from 'apps/web/pages/api/decorators';
 import { logger } from 'apps/web/src/utils/logger';
 import {
   getWalletProofs,
@@ -17,7 +18,7 @@ example return:
   "discountValidatorAddress": "0x..."
 }
 */
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'method not allowed' });
   }
@@ -45,3 +46,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   // If error is not an instance of Error, return a generic error message
   return res.status(500).json({ error: 'An unexpected error occurred' });
 }
+
+export default withTimeout(handler);

--- a/apps/web/pages/api/proofs/bns/index.ts
+++ b/apps/web/pages/api/proofs/bns/index.ts
@@ -1,3 +1,4 @@
+import { withTimeout } from 'apps/web/pages/api/decorators';
 import { logger } from 'apps/web/src/utils/logger';
 import {
   getWalletProofs,
@@ -18,7 +19,7 @@ example return:
   "discountValidatorAddress": "0x..."
 }
 */
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'method not allowed' });
   }
@@ -46,3 +47,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   // If error is not an instance of Error, return a generic error message
   return res.status(500).json({ error: 'An unexpected error occurred' });
 }
+
+export default withTimeout(handler);

--- a/apps/web/pages/api/proofs/cb1/index.ts
+++ b/apps/web/pages/api/proofs/cb1/index.ts
@@ -1,4 +1,4 @@
-import { apiLatencyMetricsNamespace, withExecutionTime } from 'apps/web/pages/api/decorators';
+import { withTimeout } from 'apps/web/pages/api/decorators';
 import { trustedSignerPKey } from 'apps/web/src/constants';
 import { logger } from 'apps/web/src/utils/logger';
 import { DiscountType, ProofsException, proofValidation } from 'apps/web/src/utils/proofs';
@@ -45,7 +45,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (!trustedSignerPKey) {
     return res.status(500).json({ error: 'currently unable to sign' });
   }
-
   try {
     const result = await sybilResistantUsernameSigning(
       address as `0x${string}`,
@@ -64,4 +63,4 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   return res.status(500).json({ error: 'An unexpected error occurred' });
 }
 
-export default withExecutionTime(handler, `${apiLatencyMetricsNamespace}.cb1_proof`);
+export default withTimeout(handler);

--- a/apps/web/pages/api/proofs/cbid/index.ts
+++ b/apps/web/pages/api/proofs/cbid/index.ts
@@ -6,6 +6,7 @@ import {
   proofValidation,
 } from 'apps/web/src/utils/proofs';
 import { logger } from 'apps/web/src/utils/logger';
+import { withTimeout } from 'apps/web/pages/api/decorators';
 
 /*
 this endpoint returns whether or not the account has a cb.id
@@ -18,7 +19,7 @@ example return:
   "discountValidatorAddress": "0x..."
 }
 */
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'method not allowed' });
   }
@@ -47,3 +48,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   // If error is not an instance of Error, return a generic error message
   return res.status(500).json({ error: 'An unexpected error occurred' });
 }
+
+export default withTimeout(handler);

--- a/apps/web/pages/api/proofs/coinbase/index.ts
+++ b/apps/web/pages/api/proofs/coinbase/index.ts
@@ -1,3 +1,4 @@
+import { withTimeout } from 'apps/web/pages/api/decorators';
 import { trustedSignerPKey } from 'apps/web/src/constants';
 import { logger } from 'apps/web/src/utils/logger';
 import {
@@ -38,7 +39,7 @@ export type CoinbaseProofResponse = {
  * }
  * @returns
  */
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'method not allowed' });
   }
@@ -59,7 +60,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     );
     return res.status(200).json(result);
   } catch (error) {
-    console.error(error);
+    logger.error(error);
     if (error instanceof ProofsException) {
       return res.status(error.statusCode).json({ error: error.message });
     }
@@ -69,3 +70,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   // If error is not an instance of Error, return a generic error message
   return res.status(500).json({ error: 'An unexpected error occurred' });
 }
+
+export default withTimeout(handler);

--- a/apps/web/pages/api/proofs/earlyAccess/index.ts
+++ b/apps/web/pages/api/proofs/earlyAccess/index.ts
@@ -1,3 +1,4 @@
+import { withTimeout } from 'apps/web/pages/api/decorators';
 import { logger } from 'apps/web/src/utils/logger';
 import {
   getWalletProofs,
@@ -18,7 +19,7 @@ example return:
   "discountValidatorAddress": "0x..."
 }
 */
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'method not allowed' });
   }
@@ -45,3 +46,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   // If error is not an instance of Error, return a generic error message
   return res.status(500).json({ error: 'An unexpected error occurred' });
 }
+
+export default withTimeout(handler);

--- a/apps/web/pages/api/registry/entries.ts
+++ b/apps/web/pages/api/registry/entries.ts
@@ -2,9 +2,10 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { db } from 'apps/web/src/utils/ocsRegistry';
 import { kv } from '@vercel/kv';
 import { logger } from 'apps/web/src/utils/logger';
+import { withTimeout } from 'apps/web/pages/api/decorators';
 
 const pageKey = 'api.ocs_registry.entries';
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { page = '1', limit = '10', category, curation } = req.query;
 
   const pageNum = parseInt(page as string, 10);
@@ -56,3 +57,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate');
   res.status(200).json(response);
 }
+
+export default withTimeout(handler);

--- a/apps/web/pages/api/registry/featured.ts
+++ b/apps/web/pages/api/registry/featured.ts
@@ -2,9 +2,10 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { db } from 'apps/web/src/utils/ocsRegistry';
 import { kv } from '@vercel/kv';
 import { logger } from 'apps/web/src/utils/logger';
+import { withTimeout } from 'apps/web/pages/api/decorators';
 
 const pageKey = 'api.ocs_registry.featured';
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(req: NextApiRequest, res: NextApiResponse) {
   const content = await db
     .selectFrom('content')
     .where('is_featured', '=', true)
@@ -28,3 +29,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate');
   res.status(200).json(response);
 }
+
+export default withTimeout(handler);


### PR DESCRIPTION
**What changed? Why?**
Add withTimeout decorator to APIs. This is to prevent APIs taking resources with no timeout limits.

**Notes to reviewers**

**How has it been tested?**
tested locally faking a 10 second wait to provoke the 409