### PR TITLE
Update useSprig.ts

### DIFF
--- a/libs/base-ui/hooks/useSprig.ts
+++ b/libs/base-ui/hooks/useSprig.ts
@@ -2,15 +2,16 @@ import { useEffect, useState } from 'react';
 
 type SprigEnvironmentId = string | undefined;
 const isDevelopment = process.env.NODE_ENV === 'development';
+
 export default function useSprig(environmentId: SprigEnvironmentId) {
-  const [Sprig, setSprig] = useState<unknown>(null);
+  const [Sprig, setSprig] = useState<unknown>(undefined);
 
   useEffect(() => {
     // Disabled for development
     if (isDevelopment) return;
 
     if (!environmentId) {
-      console.warn('Sprig is not configured');
+      console.warn('Sprig is not configured. Please provide a valid environmentId.');
       return;
     }
 
@@ -23,12 +24,12 @@ export default function useSprig(environmentId: SprigEnvironmentId) {
         void sprigInit('track', 'pageload');
         setSprig(sprigInit);
       } catch (error) {
-        console.error('Failed to load the Sprig module:', error);
+        console.error('Failed to load the Sprig module:', error, 'Environment ID:', environmentId);
       }
     };
 
     void loadSprig();
-  }, []);
+  }, [environmentId]); // Добавлен environmentId в зависимости
 
   return Sprig;
 }


### PR DESCRIPTION
Refined type handling in `useSprig` by clarifying the initial state type and ensuring `environmentId` is correctly tracked as a dependency. Also tweaked console warnings for easier debugging.