### PR TITLE
Chore: Remove basenames banners from web and docs

### DIFF
--- a/apps/base-docs/src/theme/Navbar/index.js
+++ b/apps/base-docs/src/theme/Navbar/index.js
@@ -2,19 +2,11 @@ import React from 'react';
 
 import NavbarLayout from '@theme/Navbar/Layout';
 import NavbarContent from '@theme/Navbar/Content';
-import Banner from '../../components/Banner/Banner';
 
 export default function Navbar() {
   return (
-    <>
-      <Banner
-        bannerName="basenamesLaunchDocsBanner"
-        href="https://base.org/names?utm_source=docs&utm_medium=banner"
-        text="Claim Your Basename Today!"
-      />
-      <NavbarLayout>
-        <NavbarContent />
-      </NavbarLayout>
-    </>
+    <NavbarLayout>
+      <NavbarContent />
+    </NavbarLayout>
   );
 }

--- a/apps/web/src/components/Layout/Nav/Nav.tsx
+++ b/apps/web/src/components/Layout/Nav/Nav.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Link from 'next/link';
-import dynamic from 'next/dynamic';
 import { usePathname } from 'next/dist/client/components/navigation';
 import AnalyticsProvider from 'apps/web/contexts/Analytics';
 import DesktopNav from './DesktopNav';

--- a/apps/web/src/components/Layout/Nav/Nav.tsx
+++ b/apps/web/src/components/Layout/Nav/Nav.tsx
@@ -10,10 +10,6 @@ import logoBlack from './logoBlack.svg';
 import logoWhite from './logoWhite.svg';
 import Image, { StaticImageData } from 'next/image';
 
-const DynamicBanner = dynamic(async () => import('base-ui/components/Layout/Nav/Banner'), {
-  ssr: false,
-});
-
 const BLACK_NAV_PATHS = [
   '/',
   '/jobs/apply',
@@ -29,11 +25,6 @@ export default function Nav() {
   const logo = color === 'black' ? (logoBlack as StaticImageData) : (logoWhite as StaticImageData);
   return (
     <AnalyticsProvider context="navbar">
-      <DynamicBanner
-        bannerName="basenamesLaunchBanner"
-        href="https://base.org/names?utm_source=dotorg&utm_medium=banner"
-        text="Claim Your Basename Today!"
-      />
       <nav className="z-10 flex h-24 w-full max-w-[1440px] flex-row items-center justify-between gap-16 self-center bg-transparent p-8">
         <Link href="/" aria-label="Base Homepage">
           <Image src={logo} alt="Base Logo" title="Base Logo" width="106" />


### PR DESCRIPTION
**What changed? Why?**
* removed basenames launch banner from base-web and base-docs

**Notes to reviewers**

**How has it been tested?**
locally