### PR TITLE
Remove sendToDatadog from logger and metrics

### DIFF
--- a/apps/web/pages/api/decorators.ts
+++ b/apps/web/pages/api/decorators.ts
@@ -1,19 +1,7 @@
 import { logger } from 'apps/web/src/utils/logger';
-import { measureExecutionTime } from 'apps/web/src/utils/metrics';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 type NextApiHandler = (req: NextApiRequest, res: NextApiResponse) => void | Promise<void>;
-
-export const apiLatencyMetricsNamespace = 'baseorg.api.latency';
-export function withExecutionTime(
-  handler: NextApiHandler,
-  metricName: string,
-  tags: string[] = [],
-): NextApiHandler {
-  return async (req: NextApiRequest, res: NextApiResponse) => {
-    await measureExecutionTime(metricName, async () => handler(req, res), tags);
-  };
-}
 
 const defaultTimeout = process.env.DEFAULT_API_TIMEOUT ?? 5000;
 export function withTimeout(

--- a/apps/web/pages/api/proofs/cb1/index.ts
+++ b/apps/web/pages/api/proofs/cb1/index.ts
@@ -4,7 +4,6 @@ import { logger } from 'apps/web/src/utils/logger';
 import { DiscountType, ProofsException, proofValidation } from 'apps/web/src/utils/proofs';
 import { sybilResistantUsernameSigning } from 'apps/web/src/utils/proofs/sybil_resistance';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import tracer from 'apps/web/tracer/tracer';
 
 /**
  * This endpoint checks if the provided address has access to the cb1 attestation.
@@ -35,8 +34,6 @@ import tracer from 'apps/web/tracer/tracer';
  * }
  */
 async function handler(req: NextApiRequest, res: NextApiResponse) {
-  // leave in for testing for now
-  tracer.dogstatsd.increment('proofs.cb1.endpoint.hit');
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'method not allowed' });
   }

--- a/apps/web/pages/api/proofs/coinbase/index.ts
+++ b/apps/web/pages/api/proofs/coinbase/index.ts
@@ -10,7 +10,6 @@ import {
 import { sybilResistantUsernameSigning } from 'apps/web/src/utils/proofs/sybil_resistance';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { Address } from 'viem';
-import tracer from 'apps/web/tracer/tracer';
 
 // Coinbase verified account *and* CB1 structure
 export type CoinbaseProofResponse = {
@@ -41,8 +40,6 @@ export type CoinbaseProofResponse = {
  * @returns
  */
 async function handler(req: NextApiRequest, res: NextApiResponse) {
-  // leave in for testing for now
-  tracer.dogstatsd.increment('proofs.coinbase.endpoint.hit');
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'method not allowed' });
   }

--- a/apps/web/src/utils/metrics.ts
+++ b/apps/web/src/utils/metrics.ts
@@ -1,84 +1,19 @@
-import { logger } from 'apps/web/src/utils/logger';
+import { tracer } from 'dd-trace';
 
 type Metric = {
   metric: string;
-  points: [number];
-  type: MetricTypeEnum;
-  tags?: string[];
-  interval?: number; // Required for type 'rate'
+  point: number;
+  tags?: Record<string, string | number>;
 };
 
-export enum MetricTypeEnum {
-  unspecified,
-  count,
-  gauge,
-  rate,
+export async function sendMetric(metric: Metric) {
+  tracer.dogstatsd.increment(metric.metric, metric.point, metric.tags);
 }
-
-type MetricLoggerOptions = {
-  datadogApiKey: string;
-  service: string;
-};
-
-class CustomMetricLogger {
-  private datadogApiKey: string;
-
-  private service: string;
-
-  constructor(options: MetricLoggerOptions) {
-    this.datadogApiKey = options.datadogApiKey;
-    this.service = options.service;
-  }
-
-  private async sendToDatadog(metrics: Metric[]) {
-    const nowInSeconds = Math.round(Date.now() / 1000);
-    const payload = {
-      series: metrics.map((metric) => ({
-        ...metric,
-        points: metric.points.map((point) => ({ timestamp: nowInSeconds, value: point })),
-        tags: metric.tags
-          ? [...metric.tags, `service:${this.service}`]
-          : [`service:${this.service}`],
-      })),
-    };
-
-    try {
-      await fetch(`https://api.datadoghq.com/api/v2/series`, {
-        method: 'POST',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-          'DD-API-KEY': this.datadogApiKey,
-        },
-        body: JSON.stringify(payload),
-      });
-    } catch (error) {
-      logger.error('Failed to send metrics to Datadog', error);
-    }
-  }
-
-  public sendMetric(metric: Metric) {
-    this.sendToDatadog([metric]).catch((error) => {
-      logger.error('Failed to send metrics to Datadog', error);
-    });
-  }
-
-  public sendMetrics(metrics: Metric[]) {
-    this.sendToDatadog(metrics).catch((error) => {
-      logger.error('Failed to send metrics to Datadog', error);
-    });
-  }
-}
-
-export const metricLogger = new CustomMetricLogger({
-  datadogApiKey: process.env.DD_API_KEY ?? '',
-  service: 'base-org',
-});
 
 export async function measureExecutionTime<T>(
   metricName: string,
   fn: () => Promise<T>,
-  tags: string[] = [],
+  tags: Record<string, string | number>,
 ): Promise<T> {
   const startTime = performance.now();
   const result = await fn();
@@ -86,11 +21,7 @@ export async function measureExecutionTime<T>(
   const durationMs = endTime - startTime;
 
   // Send the execution time as a metric
-  metricLogger.sendMetric({
-    metric: metricName,
-    points: [durationMs],
-    type: MetricTypeEnum.gauge,
-    tags: tags,
-  });
+  tracer.dogstatsd.gauge(metricName, durationMs, tags);
+
   return result;
 }

--- a/apps/web/src/utils/proofs/sybil_resistance.ts
+++ b/apps/web/src/utils/proofs/sybil_resistance.ts
@@ -1,4 +1,4 @@
-import { Attestation, getAttestations } from '@coinbase/onchainkit/identity';
+import { getAttestations } from '@coinbase/onchainkit/identity';
 import { kv } from '@vercel/kv';
 import { CoinbaseProofResponse } from 'apps/web/pages/api/proofs/coinbase';
 import RegistrarControllerABI from 'apps/web/src/abis/RegistrarControllerABI';
@@ -7,7 +7,7 @@ import {
   USERNAME_CB_DISCOUNT_VALIDATORS,
   USERNAME_EA_DISCOUNT_VALIDATORS,
 } from 'apps/web/src/addresses/usernames';
-import { getLinkedAddresses, LinkedAddresses } from 'apps/web/src/cdp/api';
+import { getLinkedAddresses } from 'apps/web/src/cdp/api';
 import {
   ATTESTATION_VERIFIED_ACCOUNT_SCHEMA_IDS,
   ATTESTATION_VERIFIED_CB1_ACCOUNT_SCHEMA_IDS,
@@ -16,7 +16,6 @@ import {
 } from 'apps/web/src/constants';
 import { getBasenamePublicClient } from 'apps/web/src/hooks/useBasenameChain';
 import { logger } from 'apps/web/src/utils/logger';
-import { measureExecutionTime } from 'apps/web/src/utils/metrics';
 import {
   DiscountType,
   DiscountTypes,
@@ -39,7 +38,6 @@ import { base, baseSepolia } from 'viem/chains';
 
 const EXPIRY = process.env.USERNAMES_SIGNATURE_EXPIRATION_SECONDS ?? '30';
 const previousClaimsKVPrefix = 'username:claims:';
-const latencyMetricsNamespace = 'baseorg.proofs.sybil.latency';
 
 type DiscountTypesByChainId = Record<number, DiscountTypes>;
 const discountTypes: DiscountTypesByChainId = {
@@ -132,17 +130,11 @@ export async function sybilResistantUsernameSigning(
     throw new ProofsException('Must provide a valid discountValidatorAddress', 500);
   }
 
-  const attestations = await measureExecutionTime<Attestation[]>(
-    `${latencyMetricsNamespace}.get_attestations`,
-    async () => {
-      return getAttestations(
-        address,
-        // @ts-expect-error onchainkit expects a different type for Chain (??)
-        { id: chainId },
-        { schemas: [schema] },
-      );
-    },
-    [discountType],
+  const attestations = await getAttestations(
+    address,
+    // @ts-expect-error onchainkit expects a different type for Chain (??)
+    { id: chainId },
+    { schemas: [schema] },
   );
 
   if (!attestations?.length) {
@@ -152,20 +144,9 @@ export async function sybilResistantUsernameSigning(
     (attestation) => JSON.parse(attestation.decodedDataJson)[0] as VerifiedAccount,
   );
 
-  let { linkedAddresses, idemKey } = await measureExecutionTime<LinkedAddresses>(
-    `${latencyMetricsNamespace}.get_linked_addresses`,
-    async () => {
-      return getLinkedAddresses(address as string);
-    },
-  );
+  let { linkedAddresses, idemKey } = await getLinkedAddresses(address as string);
 
-  const hasPreviouslyRegistered = await measureExecutionTime<boolean>(
-    `${latencyMetricsNamespace}.has_previously_registered`,
-    async () => {
-      return hasRegisteredWithDiscount(linkedAddresses, chainId);
-    },
-    [discountType],
-  );
+  const hasPreviouslyRegistered = await hasRegisteredWithDiscount(linkedAddresses, chainId);
 
   // if any linked address registered previously return an error
   if (hasPreviouslyRegistered) {
@@ -195,23 +176,16 @@ export async function sybilResistantUsernameSigning(
   const expirationTimeUnix = Math.floor(Date.now() / 1000) + parseInt(EXPIRY);
   try {
     // generate and sign the message
-    const signedMessage = await measureExecutionTime<`0x${string}`>(
-      `${latencyMetricsNamespace}.sign_message`,
-      async () => {
-        return signMessageWithTrustedSigner(address, discountValidatorAddress, expirationTimeUnix);
-      },
-      [discountType],
+    const signedMessage = await signMessageWithTrustedSigner(
+      address,
+      discountValidatorAddress,
+      expirationTimeUnix,
     );
+
     const claim: PreviousClaim = { address, signedMessage };
     previousClaims[discountType] = claim;
 
-    await measureExecutionTime(
-      `${latencyMetricsNamespace}.kv_storage`,
-      async () => {
-        await kv.set(kvKey, previousClaims, { nx: true, ex: parseInt(EXPIRY) });
-      },
-      [discountType],
-    );
+    await kv.set(kvKey, previousClaims, { nx: true, ex: parseInt(EXPIRY) });
 
     return {
       signedMessage: claim.signedMessage,


### PR DESCRIPTION
**What changed? Why?**
Remove sendToDatadog from logger. This is being removed in favor of using the datadog agent and custom Coinbase infrastructure. 

**Notes to reviewers**

**How has it been tested?**
tested locally