### PR TITLE
Fix typos in frontend docs

### DIFF
--- a/apps/base-docs/base-learn/docs/frontend-setup/building-an-onchain-app.md
+++ b/apps/base-docs/base-learn/docs/frontend-setup/building-an-onchain-app.md
@@ -63,11 +63,11 @@ Onchain libraries and packages tend to require very current versions of Node. If
 
 In Next.js with the app router, the root of your app is found in `app/layout.tsx`, if you followed the recommended setup options. As you want the blockchain provider context to be available for the entire app, you'll add it here.
 
-You'll need to set up your providers in a second file, so that you can add `"use client";` to the top. Doing so forces this code to be run client side, which is necessary since your server won't have access to your users' wallet information.
+You'll need to set up your providers in a second file, so that you can add `'use client';` to the top. Doing so forces this code to be run client side, which is necessary since your server won't have access to your users' wallet information.
 
 :::caution
 
-You must configure these wrappers in a separate file. It will not work if you try to add them and `"use client":` directly in `layout.tsx`!
+You must configure these wrappers in a separate file. It will not work if you try to add them and `'use client';` directly in `layout.tsx`!
 
 :::
 
@@ -75,7 +75,7 @@ Add a new file in the `app` folder called `providers.tsx`.
 
 ### Imports
 
-As discussed above, add `"use client":` to the top of the file.
+As discussed above, add `'use client';` to the top of the file.
 
 Continue with the imports:
 

--- a/apps/base-docs/base-learn/docs/frontend-setup/building-an-onchain-app.md
+++ b/apps/base-docs/base-learn/docs/frontend-setup/building-an-onchain-app.md
@@ -63,7 +63,7 @@ Onchain libraries and packages tend to require very current versions of Node. If
 
 In Next.js with the app router, the root of your app is found in `app/layout.tsx`, if you followed the recommended setup options. As you want the blockchain provider context to be available for the entire app, you'll add it here.
 
-You'll need to set up your providers in a second file, so that you can add `"use client":` to the top. Doing so forces this code to be run client side, which is necessary since your server won't have access to your users' wallet information.
+You'll need to set up your providers in a second file, so that you can add `"use client";` to the top. Doing so forces this code to be run client side, which is necessary since your server won't have access to your users' wallet information.
 
 :::caution
 

--- a/apps/base-docs/base-learn/docs/frontend-setup/building-an-onchain-app.md
+++ b/apps/base-docs/base-learn/docs/frontend-setup/building-an-onchain-app.md
@@ -51,11 +51,9 @@ The [quick start] guide for RainbowKit also contains step-by-step instructions f
 
 Start by installing the dependencies:
 
-:::bash
-
+```bash
 npm install @rainbow-me/rainbowkit wagmi viem@2.x @tanstack/react-query
-
-:::
+```
 
 :::info
 Onchain libraries and packages tend to require very current versions of Node. If you're not already using it, you may want to install [nvm].

--- a/apps/base-docs/base-learn/docs/frontend-setup/wallet-connectors.md
+++ b/apps/base-docs/base-learn/docs/frontend-setup/wallet-connectors.md
@@ -63,7 +63,7 @@ The [Building an Onchain App] tutorial will show you how to do this!
 
 ### Coinbase Smart Wallet
 
-If you have the Coinbase Wallet extension, you might be wondering were the smart wallet can be found. By default, the smart wallet will only be invoked if you click the `Coinbase Wallet` button to log in **and** you **don't** have the browser extension. To test, open a private window with extensions disabled and try to log in.
+If you have the Coinbase Wallet extension, you might be wondering where the smart wallet can be found. By default, the smart wallet will only be invoked if you click the `Coinbase Wallet` button to log in **and** you **don't** have the browser extension. To test, open a private window with extensions disabled and try to log in.
 
 Selecting `Rainbow`, `MetaMask`, or `WalletConnect` will display a QR code so that the user can log in with their phone. Picking `Coinbase Wallet` will instead invoke the smart wallet login.
 

--- a/apps/base-docs/tutorials/docs/0_intro-to-providers.md
+++ b/apps/base-docs/tutorials/docs/0_intro-to-providers.md
@@ -335,7 +335,7 @@ In this tutorial, you've learned how Providers supply blockchain connection as a
 [Subgraph]: https://thegraph.com/docs/en/developing/creating-a-subgraph/
 [data for Base Sepolia here]: https://github.com/wagmi-dev/viem/blob/main/src/chains/definitions/baseSepolia.ts
 [Base]: https://docs.base.org/network-information
-[Optimism]: https://community.optimism.io/docs/useful-tools/networks/
+[Optimism]: https://docs.optimism.io/chain/networks
 [EIP-1193]: https://eips.ethereum.org/EIPS/eip-1193
 [QuickNode]: https://www.quicknode.com/
 [Alchemy Costs]: https://docs.alchemy.com/reference/compute-unit-costs


### PR DESCRIPTION
**What changed? Why?**

1.  "were" should be "where"
2. Markdown code block format ":::" should be "```"
3. Code example's `"use client":` should be `"use client";`
4. Consistent styling to RainbowKit and wagmi. Updated style to `'use client';`
5. Optimism's network information URL is broken. Updated link to https://docs.optimism.io/chain/networks

**Notes to reviewers**
n/a

**How has it been tested?**
Visually.