### PR TITLE
Fix typos and demo code in docs

### DIFF
--- a/apps/base-docs/base-learn/docs/writing-to-contracts/useWriteContract.md
+++ b/apps/base-docs/base-learn/docs/writing-to-contracts/useWriteContract.md
@@ -130,8 +130,8 @@ const handleClaimClick = () => {
 return (
   <div>
     <p>{'Token Balance: ' + tokenBalance}</p>
-    <button disabled={claimIsLoading} onClick={handleClaimClick}>
-      {claimIsLoading ? 'Complete In Wallet' : 'Claim Tokens'}
+    <button disabled={claimIsPending} onClick={handleClaimClick}>
+      {claimIsPending ? 'Complete In Wallet' : 'Claim Tokens'}
     </button>
   </div>
 );

--- a/apps/base-docs/base-learn/docs/writing-to-contracts/useWriteContract.md
+++ b/apps/base-docs/base-learn/docs/writing-to-contracts/useWriteContract.md
@@ -30,7 +30,7 @@ Exploring them separately will highlight the functionality provided by the prepa
 
 :::caution
 
-In this module, you'll'll extend the onchain app you build in the previous module, [Reading and Displaying Data].
+In this module, you'll extend the onchain app you build in the previous module, [Reading and Displaying Data].
 
 :::
 
@@ -54,7 +54,7 @@ You'll need to know how many tokens the user has to be able to make decisions on
 
 You'll need the user's address to use in `args`, which you can conveniently get from the [`useAccount`] hook using the pattern below.
 
-```tsx:
+```tsx
 const { data: balanceData, queryKey: balanceQueryKey } =
   useReadContract({
     address: contractData.address as `0x${string}`,

--- a/apps/base-docs/tutorials/docs/4_intro-to-foundry-setup.md
+++ b/apps/base-docs/tutorials/docs/4_intro-to-foundry-setup.md
@@ -93,7 +93,7 @@ src = 'contracts'
 In order to compile the project, simply run:
 
 ```bash
-forge build:
+forge build
 ```
 
 ## Setting up Foundry with Base

--- a/apps/base-docs/tutorials/docs/5_oracles-chainlink-price-feeds.md
+++ b/apps/base-docs/tutorials/docs/5_oracles-chainlink-price-feeds.md
@@ -138,7 +138,7 @@ Chainlink provides a number of price feeds for Base. For a list of available pri
    // SPDX-License-Identifier: MIT
    pragma solidity ^0.8.0;
 
-   import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+   import "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
 
    contract DataConsumerV3 {
        AggregatorV3Interface internal priceFeed;


### PR DESCRIPTION
**What changed? Why?**
### useWriteContract docs:
1. The tutorial `useWriteContract()` is using `isPending` instead of `isLoading`.
Updated demo code to reflect this.

2. `you'll'll` should be `you'll`

3. Consistent codeblock MarkDown format where `tsx:` should be `tsx`

### foundry setup docs:

4. `forge build:` should be `forge build`

### oracles docs:

5. Chainlink's AggregatorV3Interface path is wrong. Updated path.
https://docs.chain.link/data-feeds/using-data-feeds

**Notes to reviewers**
n/a

**How has it been tested?**
Visually.
