### PR TITLE
Fix: Frame env var references

### DIFF
--- a/apps/web/pages/api/basenames/frame/constants.ts
+++ b/apps/web/pages/api/basenames/frame/constants.ts
@@ -2,6 +2,6 @@ import { isDevelopment } from 'apps/web/src/constants';
 import { base } from 'viem/chains';
 
 export const DOMAIN = isDevelopment ? `http://localhost:3000` : 'https://www.base.org';
-export const NEYNAR_API_KEY = process.env.NEXT_PUBLIC_NEYNAR_API_KEY;
+export const NEYNAR_API_KEY = process.env.NEYNAR_API_KEY;
 
 export const CHAIN = base;

--- a/apps/web/src/utils/frames.ts
+++ b/apps/web/src/utils/frames.ts
@@ -56,7 +56,7 @@ export async function fetchCast({
   })}`;
   const options = {
     method: 'GET',
-    headers: { accept: 'application/json', api_key: process.env.NEXT_PUBLIC_NEYNAR_API_KEY },
+    headers: { accept: 'application/json', api_key: process.env.NEYNAR_API_KEY },
   };
   try {
     const response = await fetch(url, options);


### PR DESCRIPTION
**What changed? Why?**
* fixed environment variable references in the basenames claim frame

**Notes to reviewers**

**How has it been tested?**
