### PR TITLE
fix: bump @frames.js/render version

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
     "@coinbase/onchainkit": "^0.28.5",
     "@datadog/browser-logs": "^5.23.3",
     "@datadog/browser-rum": "^5.23.3",
-    "@frames.js/render": "^0.3.7",
+    "@frames.js/render": "^0.3.12",
     "@guildxyz/sdk": "2.6.0",
     "@headlessui/react": "^1.7.19",
     "@heroicons/react": "^2.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -357,7 +357,7 @@ __metadata:
     "@coinbase/onchainkit": ^0.28.5
     "@datadog/browser-logs": ^5.23.3
     "@datadog/browser-rum": ^5.23.3
-    "@frames.js/render": ^0.3.7
+    "@frames.js/render": ^0.3.12
     "@guildxyz/sdk": 2.6.0
     "@headlessui/react": ^1.7.19
     "@heroicons/react": ^2.1.3
@@ -3693,13 +3693,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@frames.js/render@npm:^0.3.7":
-  version: 0.3.7
-  resolution: "@frames.js/render@npm:0.3.7"
+"@frames.js/render@npm:^0.3.12":
+  version: 0.3.12
+  resolution: "@frames.js/render@npm:0.3.12"
   dependencies:
     "@farcaster/core": ^0.14.7
     "@noble/ed25519": ^2.0.0
-    frames.js: ^0.19.1
+    frames.js: ^0.19.3
   peerDependencies:
     "@lens-protocol/client": 2.0.0
     "@rainbow-me/rainbowkit": ^2.1.2
@@ -3712,7 +3712,7 @@ __metadata:
     react-native: ^0.74.3
     viem: ^2.7.8
     wagmi: ^2.9.10
-  checksum: 1391c86861b5d8c637f6c3fdea265ad0f81a0a8b7bed57180e90e998302a709131efe4488a7a1dc3dae84ef128c1a4db94dd9599ba795cb9b8ef5e3f8595d670
+  checksum: e8600f67eeb2527f8052f044abbaa8e58124cda72011a5998910a350ba6a6dd3d803974f6e11bd5b0439935f5be3dd29f862700d68970f068060f9fb57ab3d92
   languageName: node
   linkType: hard
 
@@ -8867,6 +8867,17 @@ __metadata:
     satori: 0.10.9
     yoga-wasm-web: 0.3.3
   checksum: b8bf5614c669f20d5cd985cfce1724c267da8fcd0441819b7d782b4fc0db6eceff5623d7714668e0654e55b0d6ba89d3c2918b3e435570ab1ce1e0f3390032e3
+  languageName: node
+  linkType: hard
+
+"@vercel/og@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "@vercel/og@npm:0.6.3"
+  dependencies:
+    "@resvg/resvg-wasm": 2.4.0
+    satori: 0.10.9
+    yoga-wasm-web: 0.3.3
+  checksum: bae2fa64533faf7ae25fabecca30ed1c213d3856aa823777997ea29155237bb7cdd18af1b9add31c7959ec69cd996287ad0c58ef9b221a05e16f2c38c64be0b5
   languageName: node
   linkType: hard
 
@@ -15212,11 +15223,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"frames.js@npm:^0.19.1":
-  version: 0.19.1
-  resolution: "frames.js@npm:0.19.1"
+"frames.js@npm:^0.19.3":
+  version: 0.19.3
+  resolution: "frames.js@npm:0.19.3"
   dependencies:
-    "@vercel/og": ^0.6.2
+    "@vercel/og": ^0.6.3
     cheerio: ^1.0.0-rc.12
     protobufjs: ^7.2.6
     viem: ^2.7.8
@@ -15228,7 +15239,7 @@ __metadata:
     next: ^14.1.0
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: 56e9735c3005a2ade000f43790a3446f98e71b827bd95be80e609eb1ae7e9fa7eaf778676fdabd882420ace1230cfec7174318fea6a5d7858b9cd044074c04aa
+  checksum: 28d6465e12e658b28768bfa8860b155eee443ac3cf0f8d32a4701dd92e2bb182dbc83f2e8d4a378fe75b35903bda34c4fe16f3351438845c05b5fd272f481052
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What changed? Why?**

Bump `@frames.js/render` from `^0.3.7` to `^0.3.12` to include a fix for some frames including this one [2048 frame](https://warpcast.com/m0nt0y4/0x1c93e658) and a couple others so that they work correctly. Here's the [upstream fix](https://github.com/framesjs/frames.js/pull/498).

**Notes to reviewers**

**How has it been tested?**

This is tested via unit tests in frames.js. For this bugfix we added a new one [here](https://github.com/framesjs/frames.js/blob/b2f70cb00e127fde7a8e8b7f263394a02fb5240a/packages/frames.js/src/frame-parsers/open-frames.test.ts#L710) in [this PR](https://github.com/framesjs/frames.js/pull/498)