### PR TITLE
[Improvement] Remove “frames” title from the profile

### DIFF
--- a/apps/web/src/components/Basenames/UsernameProfileSectionFrames/index.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionFrames/index.tsx
@@ -8,7 +8,6 @@ import {
 } from 'apps/web/src/components/Basenames/UsernameProfileSectionFrames/Context';
 import FarcasterAccountModal from 'apps/web/src/components/Basenames/UsernameProfileSectionFrames/FarcasterAccountModal';
 import FrameListItem from 'apps/web/src/components/Basenames/UsernameProfileSectionFrames/FrameListItem';
-import UsernameProfileSectionTitle from 'apps/web/src/components/Basenames/UsernameProfileSectionTitle';
 import { Button, ButtonSizes } from 'apps/web/src/components/Button/Button';
 import ImageAdaptive from 'apps/web/src/components/ImageAdaptive';
 import { ActionType } from 'libs/base-ui/utils/logEvent';
@@ -69,8 +68,7 @@ function SectionContent() {
   }
   return (
     <section>
-      <div className="flex flex-row justify-between">
-        <UsernameProfileSectionTitle title="Frames" />
+      <div className="flex flex-row-reverse justify-between">
         {currentWalletIsProfileOwner && (
           <Link
             onClick={handleAddFrameLinkClick}


### PR DESCRIPTION
|before|after|
|-|-|
|<img width="792" alt="image" src="https://github.com/user-attachments/assets/2d0d324b-5b9c-478a-8968-69f5e7bfd0c9">|<img width="836" alt="image" src="https://github.com/user-attachments/assets/21053588-f229-47e8-a68a-ba389d1bcfde">|
