### PR TITLE
feat: add + icon instead of text

### DIFF
--- a/apps/web/src/components/Basenames/UsernameProfileSectionFrames/index.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionFrames/index.tsx
@@ -16,6 +16,7 @@ import Link from 'next/link';
 import { useCallback } from 'react';
 import cornerGarnish from './corner-garnish.svg';
 import frameIcon from './frame-icon.svg';
+import { Icon } from 'apps/web/src/components/Icon/Icon';
 
 function SectionContent() {
   const { profileUsername, currentWalletIsProfileOwner } = useUsernameProfile();
@@ -72,10 +73,10 @@ function SectionContent() {
         {currentWalletIsProfileOwner && (
           <Link
             onClick={handleAddFrameLinkClick}
-            className="text-sm text-palette-foregroundMuted"
+            className="rounded-lg bg-palette-backgroundAlternate p-2 text-sm text-palette-foreground"
             href={`/name/${profileUsername}/configure-frames`}
           >
-            + Add Frame
+            <Icon name="plus" color="currentColor" width="12px" height="12px" />
           </Link>
         )}
       </div>


### PR DESCRIPTION
|before|after|
|-|-|
|<img width="833" alt="image" src="https://github.com/user-attachments/assets/192f0da4-6904-4d65-9051-5d397eee6a02">|<img width="867" alt="image" src="https://github.com/user-attachments/assets/f5f46116-4d2b-43a1-b4f6-13914209826c">|