### PR TITLE
require response content-type be an image

### DIFF
--- a/apps/web/app/frames/img-proxy/route.ts
+++ b/apps/web/app/frames/img-proxy/route.ts
@@ -14,6 +14,11 @@ export async function GET(request: NextRequest) {
       throw new Error(`Failed to fetch image: ${response.statusText}`);
     }
     const contentType = response.headers.get('content-type');
+
+    if (!contentType || !contentType.startsWith('image') || contentType.includes('svg')) {
+      return NextResponse.json({ error: 'Unsupported content type' }, { status: 400 });
+    }
+
     const imageBuffer = await response.arrayBuffer();
     return new NextResponse(imageBuffer, {
       status: 200,
@@ -23,7 +28,6 @@ export async function GET(request: NextRequest) {
       },
     });
   } catch (error) {
-    console.error('Error fetching image:', error);
     return NextResponse.json({ error: 'Failed to fetch image' }, { status: 500 });
   }
 }


### PR DESCRIPTION
enforces only image content, and disallows svg

![image](https://github.com/user-attachments/assets/511d6d2e-da36-4b6b-bada-2fe479290636)
