### PR TITLE
Adding sim Explorer (evm.storage) to Block Explorer docs

### DIFF
--- a/apps/base-docs/docs/tools/block-explorers.md
+++ b/apps/base-docs/docs/tools/block-explorers.md
@@ -59,6 +59,20 @@ A testnet explorer for [Base Sepolia](https://sepolia.basescan.org/) is also ava
 
 ---
 
+## sim Explorer
+
+[sim Explorer](https://explorer.sim.io) (formerly evm.storage) is a dev focused explorer available for Base. 
+
+With sim Explorer, you can:
+
+- Explore contract storage, regardless of verification status
+- Navigate contracts and accounts by address, ENS, or Basenames, and time-travel to view state at any block height
+- Trace transactions with unparalleled visibility into storage operations
+- Simulate transactions, explore and share simulated traces
+- View flattened source code without navigating through multiple files
+
+---
+
 ## DexGuru
 
 [DexGuru](https://base.dex.guru) provides a familiar UI with data on transactions, blocks, account balances and more. Developers can use it to verify smart contracts and debug transactions with interactive traces and logs visualization.


### PR DESCRIPTION
**What changed? Why?**
👋 We added support for Base on evm.storage, adding it here per discussion with your team

**Notes to reviewers**
theres many unique capabilities not available on other similar tools,  we tried to find a good balance between shilling and capturing the unique features
**How has it been tested?**
Minor change, page renders and builds locally 
<img width="1473" alt="Screenshot 2024-10-09 at 5 09 41 PM" src="https://github.com/user-attachments/assets/4c5c78ac-3d6a-4008-99b8-b5b2b70cfb7c">
