### PR TITLE
make the onchainscore heatmap scroll rtl

### DIFF
--- a/apps/web/src/components/Basenames/UsernameProfileSectionHeatmap/index.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionHeatmap/index.tsx
@@ -441,6 +441,7 @@ export default function UsernameProfileSectionHeatmap() {
           </div>
           <div
             ref={containerRef}
+            style={{ direction: 'rtl' }}
             className="w-full max-w-full overflow-x-auto overflow-y-hidden whitespace-nowrap"
           >
             <CalendarHeatmap


### PR DESCRIPTION
This causes the heatmap to begin scrolling from a start position on the right-hand side of the div. Doing this keeps the most current date in view by default. 