### PR TITLE
feat: better invalid frame styling

### DIFF
--- a/apps/web/src/components/Basenames/UsernameProfileSectionFrames/FrameTheme.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionFrames/FrameTheme.tsx
@@ -135,12 +135,11 @@ function TransitionWrapper({
 }
 
 export const components: FrameUIComponents<StylingProps> = {
-  Error: (frameErrorProps) => {
-    console.log('jf frameErrorProps', frameErrorProps);
+  Error: () => {
     return (
       <div className={baseRootClasses}>
-        <p className="flex flex-row items-center justify-start gap-1 rounded-xl border border-red-30 bg-red-0 px-4 py-2 text-sm font-medium text-palette-negative">
-          <ExclamationCircleIcon className="h-4 w-4 rounded-full" /> invalid frame
+        <p className="flex flex-row items-center justify-start gap-1 text-palette-foregroundMuted">
+          <ExclamationCircleIcon className="h-4 w-4 rounded-full" /> Failed to load frame
         </p>
       </div>
     );

--- a/apps/web/src/components/Basenames/UsernameProfileSectionFrames/FrameTheme.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionFrames/FrameTheme.tsx
@@ -5,11 +5,15 @@ import classNames from 'classnames';
 import Image from 'next/image';
 import { useEffect, useMemo, useState } from 'react';
 import baseLoading from './base-loading.gif';
+import { ExclamationCircleIcon } from '@heroicons/react/16/solid';
 
 type StylingProps = {
   className?: string;
   style?: React.CSSProperties;
 };
+
+const baseRootClasses =
+  'relative flex flex-col rounded-3xl items-center justify-center overflow-hidden bg-transparent relative border border-palette-line/20 min-w-[245px] min-h-[245px]';
 
 export const theme: FrameUITheme<StylingProps> = {
   Error: {
@@ -17,8 +21,7 @@ export const theme: FrameUITheme<StylingProps> = {
       'flex flex-col rounded-3xl overflow-hidden bg-transparent relative items-center justify-center opacity-50',
   },
   Root: {
-    className:
-      'relative flex flex-col rounded-3xl items-center justify-center overflow-hidden bg-transparent relative border border-palette-line/20 min-w-[245px] min-h-[245px]',
+    className: baseRootClasses,
   },
   ButtonsContainer: {
     className:
@@ -132,6 +135,16 @@ function TransitionWrapper({
 }
 
 export const components: FrameUIComponents<StylingProps> = {
+  Error: (frameErrorProps) => {
+    console.log('jf frameErrorProps', frameErrorProps);
+    return (
+      <div className={baseRootClasses}>
+        <p className="flex flex-row items-center justify-start gap-1 rounded-xl border border-red-30 bg-red-0 px-4 py-2 text-sm font-medium text-palette-negative">
+          <ExclamationCircleIcon className="h-4 w-4 rounded-full" /> invalid frame
+        </p>
+      </div>
+    );
+  },
   LoadingScreen: (props, stylingProps) => {
     return (
       <div className="absolute inset-0 flex items-center justify-center">


### PR DESCRIPTION
|before|after|
|-|-|
|<img width="428" alt="image" src="https://github.com/user-attachments/assets/bfd41b7e-ce1d-4d72-a26b-b97abaca22e0">|<img width="428" alt="image" src="https://github.com/user-attachments/assets/efbcf373-5c6e-4a23-827b-47e722b3000a">|