### PR TITLE
fix: name ownership recipient ens casing sensitivity

### DIFF
--- a/apps/web/src/components/SearchAddressInput/index.tsx
+++ b/apps/web/src/components/SearchAddressInput/index.tsx
@@ -33,7 +33,7 @@ export default function SearchAddressInput({ onChange }: SearchAddressInputProps
   const { basenameChain } = useBasenameChain();
 
   const { data: basenameAddress, isLoading: basenameAddressIsLoading } = useEnsAddress({
-    name: value,
+    name: value.toLocaleLowerCase(),
     universalResolverAddress: USERNAME_L2_RESOLVER_ADDRESSES[basenameChain.id],
     chainId: basenameChain.id,
     query: {
@@ -45,7 +45,7 @@ export default function SearchAddressInput({ onChange }: SearchAddressInputProps
   /* 3. User enters an ENS name */
   const validEnsName = isEnsName(value);
   const { data: ensAddress, isLoading: ensAddressIsLoading } = useEnsAddress({
-    name: value,
+    name: value.toLocaleLowerCase(),
     chainId: mainnet.id,
     query: {
       enabled: validEnsName,

--- a/apps/web/src/components/SearchAddressInput/index.tsx
+++ b/apps/web/src/components/SearchAddressInput/index.tsx
@@ -33,7 +33,7 @@ export default function SearchAddressInput({ onChange }: SearchAddressInputProps
   const { basenameChain } = useBasenameChain();
 
   const { data: basenameAddress, isLoading: basenameAddressIsLoading } = useEnsAddress({
-    name: value.toLocaleLowerCase(),
+    name: value.toLowerCase(),
     universalResolverAddress: USERNAME_L2_RESOLVER_ADDRESSES[basenameChain.id],
     chainId: basenameChain.id,
     query: {
@@ -45,7 +45,7 @@ export default function SearchAddressInput({ onChange }: SearchAddressInputProps
   /* 3. User enters an ENS name */
   const validEnsName = isEnsName(value);
   const { data: ensAddress, isLoading: ensAddressIsLoading } = useEnsAddress({
-    name: value.toLocaleLowerCase(),
+    name: value.toLowerCase(),
     chainId: mainnet.id,
     query: {
       enabled: validEnsName,


### PR DESCRIPTION
**What changed? Why?**
When you type in an ens or basename in the search input on the ownership change modal, it was case sensitive.

So `Garey.base.eth` wouldn't resolve, but `garey.base.eth` would resolve.

This change validates the ens name against `inputValue.toLocaleLowerCase()` and now the ens will resolve appropriately without casing sensitivity.

| BEFORE | AFTER |
| -------- | ------- |
| <img width="496" alt="Screenshot 2024-10-13 at 8 27 10 AM" src="https://github.com/user-attachments/assets/19eaae7b-3cf6-4e33-8ab6-51c0b498a4b2"> | <img width="495" alt="Screenshot 2024-10-13 at 8 47 18 AM" src="https://github.com/user-attachments/assets/717cd756-e0e1-455b-aedd-115a2fc2e5f0"> |

**Notes to reviewers**

**How has it been tested?**
Locally tested, see screenshots.