### PR TITLE
Update cookie-policy.mdx

### DIFF
--- a/apps/base-docs/docs/cookie-policy.mdx
+++ b/apps/base-docs/docs/cookie-policy.mdx
@@ -53,7 +53,7 @@ Strictly Necessary cookies are essential for our Services to function and theref
 cannot be switched off. They are usually only set in response to actions made by you
 which amount to a request for services, such as setting your privacy preferences,
 logging in, or filling in forms. These also include cookies we may rely on for security
-purposes, such as to prevent unauthorised access attempts. You can set your browser to
+purposes, such as to prevent unauthorized access attempts. You can set your browser to
 block or alert you about these cookies at any time, but some features of our Services
 may not work.
 


### PR DESCRIPTION
**What changed? Why?**

The word "unauthorised" is incorrectly spelled in American English. The correct spelling is "unauthorized."

**Notes to reviewers**

Please update this.

**How has it been tested?**
