### PR TITLE
Update 01_basename_social_dropdown.md

### DIFF
--- a/apps/base-docs/tutorials/docs/01_basename_social_dropdown.md
+++ b/apps/base-docs/tutorials/docs/01_basename_social_dropdown.md
@@ -292,7 +292,7 @@ import IdentityWrapper from '../components/IdentityWrapper';
 
 Example code snippets are available for:
 
-- [IdentityWrapper componenet](https://gist.github.com/hughescoin/5e5cd6cbfb3c6d1cada0a9d206b003c6)
+- [IdentityWrapper component](https://gist.github.com/hughescoin/5e5cd6cbfb3c6d1cada0a9d206b003c6)
 - [Page.tsx](https://gist.github.com/hughescoin/49afc9e999d69d372a67186e804e693b)
 
 ## Conclusion


### PR DESCRIPTION
**What changed? Why?**

The corrected word is "component."

**Notes to reviewers**

<img width="888" alt="Снимок экрана 2024-10-15 в 13 42 02" src="https://github.com/user-attachments/assets/386d5880-153e-400e-a9e4-c39d2aeae2a2">

**How has it been tested?**
