### PR TITLE
add phantom to connect wallet modal

### DIFF
--- a/apps/web/app/AppProviders.tsx
+++ b/apps/web/app/AppProviders.tsx
@@ -14,6 +14,7 @@ import { connectorsForWallets, RainbowKitProvider } from '@rainbow-me/rainbowkit
 import {
   coinbaseWallet,
   metaMaskWallet,
+  phantomWallet,
   rainbowWallet,
   uniswapWallet,
   walletConnectWallet,
@@ -44,7 +45,14 @@ const connectors = connectorsForWallets(
   [
     {
       groupName: 'Recommended',
-      wallets: [coinbaseWallet, metaMaskWallet, uniswapWallet, rainbowWallet, walletConnectWallet],
+      wallets: [
+        coinbaseWallet,
+        metaMaskWallet,
+        uniswapWallet,
+        rainbowWallet,
+        phantomWallet,
+        walletConnectWallet,
+      ],
     },
   ],
   {


### PR DESCRIPTION
**What changed? Why?**
Added Phantom to ecosystem page and connect wallet modal, per [Jesse's tweet](https://x.com/jessepollak/status/1844909899962364304).
**Notes to reviewers**
Thank you for the [warm welcome](https://x.com/jessepollak/status/1843348984926199815) to Base! Phantom added Base support on Monday 10/7.
**How has it been tested?**
Ran locally to confirm. See screenshot below
![Screenshot 2024-10-14 at 11 08 52 AM](https://github.com/user-attachments/assets/40bc5cde-1c3b-433f-a9c6-e409b37899a4)
