### PR TITLE
Update 500.tsx: Add alt text for image

### DIFF
--- a/apps/bridge/pages/500.tsx
+++ b/apps/bridge/pages/500.tsx
@@ -19,7 +19,7 @@ export default memo(function ServerError() {
         <div className="h-screen grow">
           <div className="mt-2 mb-2 flex h-full min-h-[440px] w-full flex-row items-center justify-center">
             <div className="flex flex-col items-center justify-center text-center">
-              <Image src="/icons/empty-transaction.png" width="240" height="240" alt="" />
+              <Image src="/icons/empty-transaction.png" width="240" height="240" alt="Icon with blue ovals" />
               <h3 className="pt-16 font-display text-2xl text-white">Connection trouble</h3>
               <span className="pt-2 text-base text-[#8A919E]">
                 The site is currently unavailable. We are working on a fix right now.


### PR DESCRIPTION
Added alt text to the image in 500.tsx for accessibility purposes. The image previously had no description, and now includes concise alt text: "Icon with blue ovals," improving support for screen readers and search engines.