### PR TITLE
Fix: Dynamically import three.js libraries

### DIFF
--- a/apps/web/app/(base-org)/(root)/page.tsx
+++ b/apps/web/app/(base-org)/(root)/page.tsx
@@ -17,16 +17,16 @@ import Link from 'apps/web/src/components/Link';
 import MissionSection from 'apps/web/src/components/base-org/root/MissionSection';
 import OpLogo from 'apps/web/public/images/op_logo.svg';
 
-const DynamicThreeHero = dynamic(async () => import('apps/web/src/components/ThreeHero'), {
-  ssr: false,
-});
-
+const Scene = dynamic(
+  async () => import('apps/web/src/components/ThreeHero').then((mod) => mod.Scene),
+  { ssr: false },
+);
 export default async function Home() {
   return (
     <ErrorsProvider context="base_landing_page">
       <AnalyticsProvider context="hero">
         <div className="relative z-10 h-screen w-full">
-          <DynamicThreeHero />
+          <Scene />
           <div className="absolute bottom-0 z-20 flex w-full flex-col justify-between gap-6 pb-20 text-white lg:flex-row">
             <div className="lg:ml-20">
               <Container>

--- a/apps/web/src/components/ThreeHero/DynamicRigidBody.tsx
+++ b/apps/web/src/components/ThreeHero/DynamicRigidBody.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect, useState, forwardRef } from 'react';
+import type { RigidBodyProps, RapierRigidBody, RigidBody } from '@react-three/rapier';
+
+// RigidBody cannot be imported using dynamic() due to some import issues
+export const DynamicRigidBody = forwardRef<RapierRigidBody, RigidBodyProps>(
+  ({ children, ...props }, ref) => {
+    const [RigidBodyDynamic, setRigidBody] = useState<typeof RigidBody>();
+
+    // Import happens on render
+    useEffect(() => {
+      import('@react-three/rapier')
+        .then((mod) => {
+          setRigidBody(() => mod.RigidBody);
+        })
+        .catch((error) => console.log('error', error));
+    }, []);
+
+    if (!RigidBodyDynamic) return null;
+
+    return (
+      <RigidBodyDynamic ref={ref} {...props}>
+        {children}
+      </RigidBodyDynamic>
+    );
+  },
+);
+
+DynamicRigidBody.displayName = 'DynamicRigidBody';
+
+export default DynamicRigidBody;

--- a/apps/web/src/components/ThreeHero/DynamicRigidBody.tsx
+++ b/apps/web/src/components/ThreeHero/DynamicRigidBody.tsx
@@ -2,20 +2,22 @@
 
 import { useEffect, useState, forwardRef } from 'react';
 import type { RigidBodyProps, RapierRigidBody, RigidBody } from '@react-three/rapier';
+import { useErrors } from 'apps/web/contexts/Errors';
 
 // RigidBody cannot be imported using dynamic() due to some import issues
 export const DynamicRigidBody = forwardRef<RapierRigidBody, RigidBodyProps>(
   ({ children, ...props }, ref) => {
     const [RigidBodyDynamic, setRigidBody] = useState<typeof RigidBody>();
+    const { logError } = useErrors();
 
-    // Import happens on render
+    // Import needs to happens on render
     useEffect(() => {
       import('@react-three/rapier')
         .then((mod) => {
           setRigidBody(() => mod.RigidBody);
         })
-        .catch((error) => console.log('error', error));
-    }, []);
+        .catch((error) => logError(error, 'Failed to load RigidBody'));
+    }, [logError]);
 
     if (!RigidBodyDynamic) return null;
 

--- a/apps/web/src/components/ThreeHero/PhysicsMesh.tsx
+++ b/apps/web/src/components/ThreeHero/PhysicsMesh.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+// Libraries
+import { useMemo, useRef } from 'react';
+import dynamic from 'next/dynamic';
+
+// Components
+import DynamicRigidBody from 'apps/web/src/components/ThreeHero/DynamicRigidBody';
+
+// 3D libraries - types
+import type { BallArgs, RapierRigidBody } from '@react-three/rapier';
+
+// 3D Libraries - static - These cannot be dynamically imported
+import { Vector3 } from 'three';
+import { randFloatSpread } from 'three/src/math/MathUtils.js';
+import { useFrame, useThree } from '@react-three/fiber';
+
+// Dynamic - react-three/rapier
+const BallCollider = dynamic(
+  async () => import('@react-three/rapier').then((mod) => mod.BallCollider),
+  { ssr: false },
+);
+
+const ballArguments: BallArgs = [1];
+
+export function PhysicsMesh({
+  r = randFloatSpread,
+  scale = 1,
+  gravityEffect = 0.2,
+  children,
+}: {
+  r?: (a: number) => number;
+  scale?: number;
+  gravityEffect?: number;
+  children: React.ReactNode;
+}) {
+  const rigidBodyApiRef = useRef<RapierRigidBody>(null);
+  const { viewport } = useThree();
+  const vec = new Vector3();
+
+  const randomNumberBetween = (min: number, max: number) => {
+    const posOrNeg = Math.random() > 0.5 ? 1 : -1;
+    const num = Math.min(Math.random() * (max - min) + min, 14);
+    return posOrNeg * num;
+  };
+
+  const pos = useMemo(
+    () =>
+      new Vector3(
+        randomNumberBetween(viewport.width * 0.5, viewport.width * 2),
+        randomNumberBetween(viewport.height * 0.5, viewport.height * 2),
+        randomNumberBetween(viewport.width * 0.5, viewport.width * 2),
+      ),
+    [viewport.height, viewport.width],
+  );
+  const rot = useMemo(() => new Vector3(r(Math.PI), r(Math.PI), r(Math.PI)), [r]);
+
+  useFrame(() => {
+    if (!rigidBodyApiRef.current) return;
+    const vector = rigidBodyApiRef.current.translation();
+    const vector3 = new Vector3(vector.x, vector.y, vector.z);
+    rigidBodyApiRef.current.applyImpulse(
+      vec.copy(vector3).negate().multiplyScalar(gravityEffect),
+      true,
+    );
+  });
+
+  return (
+    <DynamicRigidBody
+      linearDamping={4}
+      angularDamping={1}
+      friction={0.1}
+      position={pos.toArray()}
+      rotation={rot.toArray()}
+      ref={rigidBodyApiRef}
+      colliders={false}
+      scale={scale}
+    >
+      <BallCollider args={ballArguments} />
+      {children}
+    </DynamicRigidBody>
+  );
+}

--- a/apps/web/src/components/ThreeHero/index.tsx
+++ b/apps/web/src/components/ThreeHero/index.tsx
@@ -10,6 +10,19 @@ import dynamic from 'next/dynamic';
 import Image, { StaticImageData } from 'next/image';
 import Link from 'apps/web/src/components/Link';
 
+// 3D libraries - types
+import type { Vector3 } from '@react-three/fiber';
+import type { Vector3Tuple } from '@react-three/rapier';
+import type {
+  ColorRepresentation,
+  Mesh,
+  BufferGeometry,
+  NormalBufferAttributes,
+  Material,
+} from 'three';
+
+import { Bloom, SMAA, EffectComposer } from '@react-three/postprocessing';
+
 // Assets
 import {
   BaseLogo,
@@ -30,17 +43,6 @@ import {
 
 import baseLogo from './assets/base-logo.svg';
 import environmentLight from './assets/environmentLight.jpg';
-
-// 3D libraries - types
-import type { Vector3 } from '@react-three/fiber';
-import type { Vector3Tuple } from '@react-three/rapier';
-import type {
-  ColorRepresentation,
-  Mesh,
-  BufferGeometry,
-  NormalBufferAttributes,
-  Material,
-} from 'three';
 
 // 3D libraries - dynamic imports
 
@@ -70,20 +72,6 @@ const Environment = dynamic(
 
 // Dynamic - react-three/rapier
 const Physics = dynamic(async () => import('@react-three/rapier').then((mod) => mod.Physics), {
-  ssr: false,
-});
-
-// Dynamic - react-three/postprocessing
-const EffectComposer = dynamic(
-  async () => import('@react-three/postprocessing').then((mod) => mod.EffectComposer),
-  { ssr: false },
-);
-
-const Bloom = dynamic(async () => import('@react-three/postprocessing').then((mod) => mod.Bloom), {
-  ssr: false,
-});
-
-const SMAA = dynamic(async () => import('@react-three/postprocessing').then((mod) => mod.SMAA), {
   ssr: false,
 });
 

--- a/apps/web/src/components/ThreeHero/models.tsx
+++ b/apps/web/src/components/ThreeHero/models.tsx
@@ -26,9 +26,11 @@ import type { MeshProps, Vector3, Euler } from '@react-three/fiber';
 import type { CylinderArgs, BallArgs, RapierRigidBody } from '@react-three/rapier';
 
 // 3D Libraries - static - These cannot be dynamically imported
-import { Color, MathUtils, Group, Vector3 as ThreeVector3 } from 'three';
+import { Color, Group, Vector3 as ThreeVector3 } from 'three';
+import { lerp, randFloatSpread } from 'three/src/math/MathUtils.js';
 import { useGLTF } from '@react-three/drei';
 import { useFrame, useLoader, useThree } from '@react-three/fiber';
+import { RigidBody } from '@react-three/rapier';
 import { SVGLoader } from 'three-stdlib';
 
 // 3D libraries - dynamic imports
@@ -43,10 +45,6 @@ const CylinderCollider = dynamic(
   async () => import('@react-three/rapier').then((mod) => mod.CylinderCollider),
   { ssr: false },
 );
-
-const RigidBody = dynamic(async () => import('@react-three/rapier').then((mod) => mod.RigidBody), {
-  ssr: false,
-});
 
 // Dynamic - react-three/drei
 const Center = dynamic(async () => import('@react-three/drei').then((mod) => mod.Center), {
@@ -123,12 +121,12 @@ export function BaseLogo() {
     if (!logoRef.current) return;
 
     if (doneRef.current) {
-      logoRef.current.rotation.y = MathUtils.lerp(logoRef.current.rotation.y, pointer.x, 0.05);
-      logoRef.current.rotation.x = MathUtils.lerp(logoRef.current.rotation.x, -pointer.y, 0.05);
+      logoRef.current.rotation.y = lerp(logoRef.current.rotation.y, pointer.x, 0.05);
+      logoRef.current.rotation.x = lerp(logoRef.current.rotation.x, -pointer.y, 0.05);
     } else {
-      logoRef.current.rotation.y = MathUtils.lerp(logoRef.current.rotation.y, 0, 0.05);
+      logoRef.current.rotation.y = lerp(logoRef.current.rotation.y, 0, 0.05);
     }
-    logoRef.current.position.z = MathUtils.lerp(logoRef.current.position.z, 0, 0.05);
+    logoRef.current.position.z = lerp(logoRef.current.position.z, 0, 0.05);
 
     // lerp never gets to 0
     if (logoRef.current.position.z > -0.01) {
@@ -153,7 +151,7 @@ export function BaseLogo() {
 const ballArguments: BallArgs = [1];
 export function PhysicsMesh({
   vec = new ThreeVector3(),
-  r = MathUtils.randFloatSpread,
+  r = randFloatSpread,
   scale = 1,
   gravityEffect = 0.2,
   children,

--- a/apps/web/src/components/ThreeHero/models.tsx
+++ b/apps/web/src/components/ThreeHero/models.tsx
@@ -59,7 +59,7 @@ useGLTF.setDecoderPath('draco/');
 
 /* Constants */
 export const blue = '#105eff';
-export const blackColor = '#141414'; // equivalent to rgb(0.08, 0.08, 0.08)
+export const blackColor = '#444'; // equivalent to rgb(0.08, 0.08, 0.08)
 
 /* Models */
 export function BlackMaterial() {

--- a/apps/web/src/components/ThreeHero/models.tsx
+++ b/apps/web/src/components/ThreeHero/models.tsx
@@ -4,7 +4,7 @@
 import { useGLTF, Center } from '@react-three/drei';
 import { MeshProps, Vector3, Euler, useLoader } from '@react-three/fiber';
 
-import * as THREE from 'three';
+import { Color, Mesh, Shape } from 'three';
 import { SVGLoader, SVGResult } from 'three-stdlib';
 import { PhysicsMesh } from './index';
 
@@ -23,14 +23,14 @@ import cursorModel from './assets/cursor.glb';
 /* svgs */
 import lightningSVG from './assets/lightning.svg';
 import { useMemo } from 'react';
-import { ExtrudeGeometryOptions } from 'three';
+import type { ExtrudeGeometryOptions } from 'three';
 
 /* load draco locally (v1.5.7) */
 useGLTF.setDecoderPath('draco/');
 
 /* Constants */
 export const blue = '#105eff';
-const blackColor = new THREE.Color(0.08, 0.08, 0.08);
+const blackColor = new Color(0.08, 0.08, 0.08);
 
 /* Models */
 export function BlackMaterial() {
@@ -43,7 +43,7 @@ export function MetalMaterial() {
 
 export function BaseLogoModel() {
   const { nodes } = useGLTF(logoModel);
-  const model = nodes.Base_Logo as THREE.Mesh;
+  const model = nodes.Base_Logo as Mesh;
 
   return (
     <Center>
@@ -57,7 +57,7 @@ export function BaseLogoModel() {
 export function Lightning() {
   const svg = useLoader(SVGLoader, lightningSVG.src);
   const shapes = (svg as SVGResult).paths[0].toShapes(true);
-  const extrudeArguments: [shapes: THREE.Shape[], options: ExtrudeGeometryOptions] = useMemo(
+  const extrudeArguments: [shapes: Shape[], options: ExtrudeGeometryOptions] = useMemo(
     () => [
       shapes,
       {
@@ -85,7 +85,7 @@ export function Lightning() {
 
 export function Controller(props: MeshProps) {
   const { nodes } = useGLTF(controlerModel);
-  const model = nodes.Controller as THREE.Mesh;
+  const model = nodes.Controller as Mesh;
   return (
     <PhysicsMesh>
       <mesh {...props} geometry={model.geometry} castShadow receiveShadow scale={0.3}>
@@ -97,7 +97,7 @@ export function Controller(props: MeshProps) {
 
 export function Eth() {
   const { nodes } = useGLTF(ethModel);
-  const model = nodes.ETH as THREE.Mesh;
+  const model = nodes.ETH as Mesh;
   return (
     <PhysicsMesh>
       <mesh geometry={model.geometry} castShadow receiveShadow scale={0.25}>
@@ -109,7 +109,7 @@ export function Eth() {
 
 export function Globe() {
   const { nodes } = useGLTF(globeModel);
-  const model = nodes.Globe as THREE.Mesh;
+  const model = nodes.Globe as Mesh;
 
   return (
     <PhysicsMesh>
@@ -127,7 +127,7 @@ const phoneHeight = 0.86;
 const phoneDimension: [width?: number | undefined, height?: number] = [phoneWidth, phoneHeight];
 export function Phone() {
   const { nodes } = useGLTF(phoneModel);
-  const model = nodes.Cylinder as THREE.Mesh;
+  const model = nodes.Cylinder as Mesh;
   return (
     <PhysicsMesh>
       <mesh geometry={model.geometry} castShadow receiveShadow rotation={phoneRotation}>
@@ -143,7 +143,7 @@ export function Phone() {
 
 export function Headphones() {
   const { nodes } = useGLTF(headphonesModel);
-  const model = nodes.Headphones as THREE.Mesh;
+  const model = nodes.Headphones as Mesh;
   return (
     <PhysicsMesh>
       <mesh geometry={model.geometry} castShadow receiveShadow scale={0.2}>
@@ -155,7 +155,7 @@ export function Headphones() {
 
 export function Spikey() {
   const { nodes } = useGLTF(spikeyModel);
-  const model = nodes.Spikey as THREE.Mesh;
+  const model = nodes.Spikey as Mesh;
   return (
     <PhysicsMesh>
       <mesh geometry={model.geometry} castShadow receiveShadow scale={0.3}>
@@ -167,7 +167,7 @@ export function Spikey() {
 
 export function Play() {
   const { nodes } = useGLTF(playModel);
-  const model = nodes.Play as THREE.Mesh;
+  const model = nodes.Play as Mesh;
   return (
     <PhysicsMesh>
       <mesh geometry={model.geometry} castShadow receiveShadow scale={0.4}>
@@ -179,7 +179,7 @@ export function Play() {
 
 export function Blobby() {
   const { nodes } = useGLTF(objectModel);
-  const model = nodes.Object_02 as THREE.Mesh;
+  const model = nodes.Object_02 as Mesh;
   return (
     <PhysicsMesh>
       <mesh geometry={model.geometry} castShadow receiveShadow scale={0.3}>
@@ -191,8 +191,8 @@ export function Blobby() {
 
 export function Cursor() {
   const { nodes } = useGLTF(cursorModel);
-  const cursor = nodes.Cursor as THREE.Mesh;
-  const cursor1 = nodes.Cursor1 as THREE.Mesh;
+  const cursor = nodes.Cursor as Mesh;
+  const cursor1 = nodes.Cursor1 as Mesh;
   return (
     <PhysicsMesh>
       <Center>

--- a/apps/web/src/components/ThreeHero/models.tsx
+++ b/apps/web/src/components/ThreeHero/models.tsx
@@ -24,12 +24,11 @@ import type { Mesh, Shape, DirectionalLight, ExtrudeGeometryOptions } from 'thre
 import type { SVGResult } from 'three-stdlib';
 import type { MeshProps, Vector3, Euler } from '@react-three/fiber';
 import type { CylinderArgs, BallArgs, RapierRigidBody } from '@react-three/rapier';
-import { MathUtils, Group, Vector3 as ThreeVector3 } from 'three';
 
 // 3D Libraries - static - These cannot be dynamically imported
+import { Color, MathUtils, Group, Vector3 as ThreeVector3 } from 'three';
 import { useGLTF } from '@react-three/drei';
 import { useFrame, useLoader, useThree } from '@react-three/fiber';
-import { Color } from 'three';
 import { SVGLoader } from 'three-stdlib';
 
 // 3D libraries - dynamic imports


### PR DESCRIPTION
We are globally bundling most of the 3D libraries (three, react-three/rapier, etc..).

This PR leverages dynamic() loading and import() to load the heaviest import asynchronously, and within 3D hero component only.

Results in a 50% javascript reduction across all pages.
