### PR TITLE
chore: add stats page w/ datadog iframe

### DIFF
--- a/apps/web/app/(stats)/layout.tsx
+++ b/apps/web/app/(stats)/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+    metadataBase: new URL('https://base.org'),
+    title: `Base`,
+    description:
+        'Base is a secure, low-cost, builder-friendly Ethereum L2 built to bring the next billion users onchain.',
+    openGraph: {
+        type: 'website',
+        title: `Base`,
+        description:
+            'Base is a secure, low-cost, builder-friendly Ethereum L2 built to bring the next billion users onchain.',
+        url: `/`,
+        images: ['https://base.org/images/base-open-graph.png'],
+    },
+    twitter: {
+        site: '@base',
+        card: 'summary_large_image',
+    },
+};
+
+export default async function StatsLayout({
+  children, // will be a page or nested layout
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+      <div className="h-screen w-screen">
+          {children}
+      </div>
+  );
+}

--- a/apps/web/app/(stats)/stats/page.tsx
+++ b/apps/web/app/(stats)/stats/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  metadataBase: new URL('https://base.org'),
+  title: `Base | Stats`,
+  description: 'Live stats for the Base network',
+};
+
+export default async function Page() {
+  return (
+    <iframe
+        src="https://p.datadoghq.com/sb/883862235-507cea11844d0f5a35054427f4de4c38"
+        width="100%"
+        height="100%"
+    ></iframe>
+    );
+}

--- a/apps/web/app/(stats)/stats/page.tsx
+++ b/apps/web/app/(stats)/stats/page.tsx
@@ -9,9 +9,10 @@ export const metadata: Metadata = {
 export default async function Page() {
   return (
     <iframe
+        title="Base Stats"
         src="https://p.datadoghq.com/sb/883862235-507cea11844d0f5a35054427f4de4c38"
         width="100%"
         height="100%"
-    ></iframe>
+    />
     );
 }

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -119,6 +119,7 @@ const contentSecurityPolicy = {
     'https://unpkg.com/@lottiefiles/dotlottie-web@0.31.1/dist/dotlottie-player.wasm', // lottie player
     `https://${process.env.NEXT_PUBLIC_PINATA_GATEWAY_URL}`,
   ],
+  'frame-src': ["https://p.datadoghq.com"],
   'frame-ancestors': ["'self'", baseXYZDomains],
   'form-action': ["'self'", baseXYZDomains],
   'img-src': [


### PR DESCRIPTION
**What changed? Why?**
Setup a page on `base.org/stats`, that will embed our public datadog dashboard.

**How has it been tested?**
Ran locally.
![Screenshot 2024-11-07 at 4 30 52 PM](https://github.com/user-attachments/assets/73acd3f0-f135-41fa-ae81-c9c9c159ce59)
