### PR TITLE
chore: limit usage of gas estimator and connect wallet

### DIFF
--- a/apps/web/app/(base-org)/builder-anniversary-nft/page.tsx
+++ b/apps/web/app/(base-org)/builder-anniversary-nft/page.tsx
@@ -1,3 +1,4 @@
+import CryptoProviders from 'apps/web/app/CryptoProviders';
 import { BuilderNftHero } from 'apps/web/src/components/BuilderNft/BuilderNftHero';
 import type { Metadata } from 'next';
 
@@ -13,7 +14,9 @@ export const metadata: Metadata = {
 export default async function About() {
   return (
     <main className="flex w-full flex-col items-center bg-black">
-      <BuilderNftHero />
+      <CryptoProviders>
+        <BuilderNftHero />
+      </CryptoProviders>
     </main>
   );
 }

--- a/apps/web/app/(basenames)/layout.tsx
+++ b/apps/web/app/(basenames)/layout.tsx
@@ -1,3 +1,4 @@
+import CryptoProviders from 'apps/web/app/CryptoProviders';
 import ErrorsProvider from 'apps/web/contexts/Errors';
 import UsernameNav from 'apps/web/src/components/Layout/UsernameNav';
 
@@ -27,10 +28,12 @@ export default async function BasenameLayout({
 }) {
   return (
     <ErrorsProvider context="basenames">
-      <div className="max-w-screen flex min-h-screen flex-col">
-        <UsernameNav />
-        {children}
-      </div>
+      <CryptoProviders>
+        <div className="max-w-screen flex min-h-screen flex-col">
+          <UsernameNav />
+          {children}
+        </div>
+      </CryptoProviders>
     </ErrorsProvider>
   );
 }

--- a/apps/web/app/AppProviders.tsx
+++ b/apps/web/app/AppProviders.tsx
@@ -1,6 +1,4 @@
 'use client';
-import '@rainbow-me/rainbowkit/styles.css';
-import '@coinbase/onchainkit/styles.css';
 
 import {
   Provider as CookieManagerProvider,
@@ -8,28 +6,14 @@ import {
   TrackingCategory,
   TrackingPreference,
 } from '@coinbase/cookie-manager';
-import { OnchainKitProvider } from '@coinbase/onchainkit';
 import { Provider as TooltipProvider } from '@radix-ui/react-tooltip';
-import { connectorsForWallets, RainbowKitProvider } from '@rainbow-me/rainbowkit';
-import {
-  coinbaseWallet,
-  metaMaskWallet,
-  phantomWallet,
-  rainbowWallet,
-  uniswapWallet,
-  walletConnectWallet,
-} from '@rainbow-me/rainbowkit/wallets';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ExperimentsProvider from 'base-ui/contexts/Experiments';
 import useSprig from 'base-ui/hooks/useSprig';
 import { useCallback, useRef } from 'react';
-import { createConfig, http, WagmiProvider } from 'wagmi';
-import { base, baseSepolia, mainnet } from 'wagmi/chains';
 import { cookieManagerConfig } from '../src/utils/cookieManagerConfig';
 import ClientAnalyticsScript from 'apps/web/src/components/ClientAnalyticsScript/ClientAnalyticsScript';
 import dynamic from 'next/dynamic';
 import ErrorsProvider from 'apps/web/contexts/Errors';
-import { isDevelopment } from 'apps/web/src/constants';
 import { logger } from 'apps/web/src/utils/logger';
 
 const DynamicCookieBannerWrapper = dynamic(
@@ -39,43 +23,6 @@ const DynamicCookieBannerWrapper = dynamic(
   },
 );
 
-coinbaseWallet.preference = 'all';
-
-const connectors = connectorsForWallets(
-  [
-    {
-      groupName: 'Recommended',
-      wallets: [
-        coinbaseWallet,
-        metaMaskWallet,
-        uniswapWallet,
-        rainbowWallet,
-        phantomWallet,
-        walletConnectWallet,
-      ],
-    },
-  ],
-  {
-    projectId: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID ?? 'dummy-id',
-    walletConnectParameters: {},
-    appName: 'Base.org',
-    appDescription: '',
-    appUrl: 'https://www.base.org/',
-    appIcon: '',
-  },
-);
-
-const config = createConfig({
-  connectors,
-  chains: [base, baseSepolia, mainnet],
-  transports: {
-    [base.id]: http(),
-    [baseSepolia.id]: http(),
-    [mainnet.id]: http(),
-  },
-  ssr: true,
-});
-const queryClient = new QueryClient();
 const sprigEnvironmentId = process.env.NEXT_PUBLIC_SPRIG_ENVIRONMENT_ID;
 
 type AppProvidersProps = {
@@ -136,25 +83,14 @@ export default function AppProviders({ children }: AppProvidersProps) {
         config={cookieManagerConfig}
       >
         <ClientAnalyticsScript />
-        {/* <WagmiProvider config={config}>
-          <QueryClientProvider client={queryClient}>
-            <OnchainKitProvider
-              chain={isDevelopment ? baseSepolia : base}
-              apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}
-            >
-              <RainbowKitProvider modalSize="compact"> */}
-                <TooltipProvider>
-                  <ExperimentsProvider>
-                    <>
-                      {children}
-                      <DynamicCookieBannerWrapper />
-                    </>
-                  </ExperimentsProvider>
-                </TooltipProvider>
-              {/* </RainbowKitProvider>
-            </OnchainKitProvider>
-          </QueryClientProvider>
-        </WagmiProvider> */}
+        <TooltipProvider>
+          <ExperimentsProvider>
+            <>
+              {children}
+              <DynamicCookieBannerWrapper />
+            </>
+          </ExperimentsProvider>
+        </TooltipProvider>
       </CookieManagerProvider>
     </ErrorsProvider>
   );

--- a/apps/web/app/AppProviders.tsx
+++ b/apps/web/app/AppProviders.tsx
@@ -136,13 +136,13 @@ export default function AppProviders({ children }: AppProvidersProps) {
         config={cookieManagerConfig}
       >
         <ClientAnalyticsScript />
-        <WagmiProvider config={config}>
+        {/* <WagmiProvider config={config}>
           <QueryClientProvider client={queryClient}>
             <OnchainKitProvider
               chain={isDevelopment ? baseSepolia : base}
               apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}
             >
-              <RainbowKitProvider modalSize="compact">
+              <RainbowKitProvider modalSize="compact"> */}
                 <TooltipProvider>
                   <ExperimentsProvider>
                     <>
@@ -151,10 +151,10 @@ export default function AppProviders({ children }: AppProvidersProps) {
                     </>
                   </ExperimentsProvider>
                 </TooltipProvider>
-              </RainbowKitProvider>
+              {/* </RainbowKitProvider>
             </OnchainKitProvider>
           </QueryClientProvider>
-        </WagmiProvider>
+        </WagmiProvider> */}
       </CookieManagerProvider>
     </ErrorsProvider>
   );

--- a/apps/web/app/CryptoProviders.tsx
+++ b/apps/web/app/CryptoProviders.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import '@rainbow-me/rainbowkit/styles.css';
 import '@coinbase/onchainkit/styles.css';
 

--- a/apps/web/app/CryptoProviders.tsx
+++ b/apps/web/app/CryptoProviders.tsx
@@ -1,3 +1,6 @@
+import '@rainbow-me/rainbowkit/styles.css';
+import '@coinbase/onchainkit/styles.css';
+
 import { OnchainKitProvider } from '@coinbase/onchainkit';
 import { connectorsForWallets, RainbowKitProvider } from '@rainbow-me/rainbowkit';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/apps/web/app/CryptoProviders.tsx
+++ b/apps/web/app/CryptoProviders.tsx
@@ -1,0 +1,69 @@
+import { OnchainKitProvider } from '@coinbase/onchainkit';
+import { connectorsForWallets, RainbowKitProvider } from '@rainbow-me/rainbowkit';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { isDevelopment } from 'apps/web/src/constants';
+import { createConfig, http, WagmiProvider } from 'wagmi';
+import { base, baseSepolia, mainnet } from 'wagmi/chains';
+import {
+  coinbaseWallet,
+  metaMaskWallet,
+  phantomWallet,
+  rainbowWallet,
+  uniswapWallet,
+  walletConnectWallet,
+} from '@rainbow-me/rainbowkit/wallets';
+
+const connectors = connectorsForWallets(
+  [
+    {
+      groupName: 'Recommended',
+      wallets: [
+        coinbaseWallet,
+        metaMaskWallet,
+        uniswapWallet,
+        rainbowWallet,
+        phantomWallet,
+        walletConnectWallet,
+      ],
+    },
+  ],
+  {
+    projectId: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID ?? 'dummy-id',
+    walletConnectParameters: {},
+    appName: 'Base.org',
+    appDescription: '',
+    appUrl: 'https://www.base.org/',
+    appIcon: '',
+  },
+);
+
+const config = createConfig({
+  connectors,
+  chains: [base, baseSepolia, mainnet],
+  transports: {
+    [base.id]: http(),
+    [baseSepolia.id]: http(),
+    [mainnet.id]: http(),
+  },
+  ssr: true,
+});
+const queryClient = new QueryClient();
+
+type CryptoProvidersProps = {
+  children: React.ReactNode;
+};
+
+export default function CryptoProviders({ children }: CryptoProvidersProps) {
+  return (
+    <WagmiProvider config={config}>
+      <QueryClientProvider client={queryClient}>
+        <OnchainKitProvider
+          chain={isDevelopment ? baseSepolia : base}
+          apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}
+        >
+          <RainbowKitProvider modalSize="compact">{children}</RainbowKitProvider>
+        </OnchainKitProvider>
+      </QueryClientProvider>
+    </WagmiProvider>
+  );
+}

--- a/apps/web/src/components/ConnectWalletButton/ConnectWalletButton.tsx
+++ b/apps/web/src/components/ConnectWalletButton/ConnectWalletButton.tsx
@@ -27,6 +27,7 @@ import { useCopyToClipboard } from 'usehooks-ts';
 import { useAccount, useSwitchChain } from 'wagmi';
 import ChainDropdown from 'apps/web/src/components/ChainDropdown';
 import { useSearchParams } from 'next/navigation';
+import CryptoProviders from 'apps/web/app/CryptoProviders';
 
 export enum ConnectWalletButtonVariants {
   BaseOrg,
@@ -37,7 +38,17 @@ type ConnectWalletButtonProps = {
   connectWalletButtonVariant: ConnectWalletButtonVariants;
 };
 
-export function ConnectWalletButton({
+export function WrappedConnectWalletButton({
+  connectWalletButtonVariant = ConnectWalletButtonVariants.BaseOrg,
+}: ConnectWalletButtonProps) {
+  return (
+    <CryptoProviders>
+      <ConnectWalletButton connectWalletButtonVariant={connectWalletButtonVariant} />
+    </CryptoProviders>
+  )
+}
+
+function ConnectWalletButton({
   connectWalletButtonVariant = ConnectWalletButtonVariants.BaseOrg,
 }: ConnectWalletButtonProps) {
   // Rainbow kit

--- a/apps/web/src/components/ConnectWalletButton/ConnectWalletButton.tsx
+++ b/apps/web/src/components/ConnectWalletButton/ConnectWalletButton.tsx
@@ -48,7 +48,7 @@ export function WrappedConnectWalletButton({
   )
 }
 
-function ConnectWalletButton({
+export function ConnectWalletButton({
   connectWalletButtonVariant = ConnectWalletButtonVariants.BaseOrg,
 }: ConnectWalletButtonProps) {
   // Rainbow kit

--- a/apps/web/src/components/base-org/shared/TopNavigation/GasPriceDropdown.tsx
+++ b/apps/web/src/components/base-org/shared/TopNavigation/GasPriceDropdown.tsx
@@ -1,3 +1,4 @@
+import CryptoProviders from 'apps/web/app/CryptoProviders';
 import Card from 'apps/web/src/components/base-org/Card';
 import { Icon } from 'apps/web/src/components/Icon/Icon';
 import { base, mainnet } from 'viem/chains';
@@ -9,7 +10,15 @@ const convertWeiToMwei = (weiValue: bigint): number => {
   return Number(mweiValue.toFixed(2)); // Round to 2 decimal places
 };
 
-export default function GasPriceDropdown() {
+export function WrappedGasPriceDropdown() {
+  return (
+    <CryptoProviders>
+      <GasPriceDropdown />
+    </CryptoProviders>
+  );
+}
+
+function GasPriceDropdown() {
   const { data: baseGasPriceInWei } = useGasPrice({
     chainId: base.id,
     query: {

--- a/apps/web/src/components/base-org/shared/TopNavigation/index.tsx
+++ b/apps/web/src/components/base-org/shared/TopNavigation/index.tsx
@@ -94,11 +94,12 @@ const links: TopNavigationLink[] = [
 
 export default function TopNavigation() {
   const pathname = usePathname();
-  const showGasDropdownAndConnectWallet =
-    pathname !== '/jobs' &&
-    pathname !== '/about' &&
-    pathname !== '/ecosystem' &&
-    pathname !== '/getstarted';
+  const showGasDropdownAndConnectWallet = ![
+    '/jobs',
+    '/about',
+    '/ecosystem',
+    '/getstarted',
+  ].includes(pathname ?? '');
   return (
     <AnalyticsProvider context="navbar">
       <nav className="fixed top-0 z-50 w-full shrink-0 px-[1rem] py-4 md:px-[1.5rem] lg:px-[2rem]">

--- a/apps/web/src/components/base-org/shared/TopNavigation/index.tsx
+++ b/apps/web/src/components/base-org/shared/TopNavigation/index.tsx
@@ -5,13 +5,14 @@ import Link from 'next/link';
 import logo from './assets/logo.svg';
 import Image, { StaticImageData } from 'next/image';
 import {
-  ConnectWalletButton,
+  WrappedConnectWalletButton,
   ConnectWalletButtonVariants,
 } from 'apps/web/src/components/ConnectWalletButton/ConnectWalletButton';
 import MenuDesktop from 'apps/web/src/components/base-org/shared/TopNavigation/MenuDesktop';
 import MenuMobile from 'apps/web/src/components/base-org/shared/TopNavigation/MenuMobile';
-import GasPriceDropdown from 'apps/web/src/components/base-org/shared/TopNavigation/GasPriceDropdown';
+import { WrappedGasPriceDropdown } from 'apps/web/src/components/base-org/shared/TopNavigation/GasPriceDropdown';
 import { Suspense } from 'react';
+import { usePathname } from 'next/navigation';
 
 export type SubItem = {
   name: string;
@@ -92,6 +93,12 @@ const links: TopNavigationLink[] = [
 ];
 
 export default function TopNavigation() {
+  const pathname = usePathname();
+  const showGasDropdownAndConnectWallet =
+    pathname !== '/jobs' &&
+    pathname !== '/about' &&
+    pathname !== '/ecosystem' &&
+    pathname !== '/getstarted';
   return (
     <AnalyticsProvider context="navbar">
       <nav className="fixed top-0 z-50 w-full shrink-0 px-[1rem] py-4 md:px-[1.5rem] lg:px-[2rem]">
@@ -101,7 +108,7 @@ export default function TopNavigation() {
             <Link href="/" className="flex min-h-[3rem] min-w-[3rem]">
               <Image src={logo as StaticImageData} alt="Base Logo" />
             </Link>
-            <GasPriceDropdown />
+            {showGasDropdownAndConnectWallet && <WrappedGasPriceDropdown />}
           </div>
 
           <div className="hidden md:inline-block">
@@ -114,11 +121,13 @@ export default function TopNavigation() {
 
           {/* Connect Wallet button */}
           <div className="flex items-end justify-end md:min-w-[16rem]">
-            <Suspense>
-              <ConnectWalletButton
-                connectWalletButtonVariant={ConnectWalletButtonVariants.BaseOrg}
-              />
-            </Suspense>
+            {showGasDropdownAndConnectWallet && (
+              <Suspense>
+                <WrappedConnectWalletButton
+                  connectWalletButtonVariant={ConnectWalletButtonVariants.BaseOrg}
+                />
+              </Suspense>
+            )}
           </div>
         </div>
       </nav>


### PR DESCRIPTION
**What changed? Why?**
* removed gas estimator and connect wallet button from `/about`, `/jobs`, `/ecosystem`, and `/getstarted`
* removed Wagmi, QueryClient, RainbowKit, and OnchainKit from `<AppProviders>`, moved into `<CryptoProviders>`

**Notes to reviewers**

**How has it been tested?**
locally