### PR TITLE
chore: update Twitter link and labels to X branding

### DIFF
--- a/apps/web/src/components/GetConnected/GetConnected.tsx
+++ b/apps/web/src/components/GetConnected/GetConnected.tsx
@@ -25,10 +25,10 @@ export async function GetConnected() {
           />
           <GetConnectedButton
             iconName="twitter"
-            href="https://twitter.com/base"
+            href="https://x.com/base"
             eventName="twitter"
-            title="Join us on Twitter"
-            aria-label="Join us on Twitter"
+            title="Join us on X"
+            aria-label="Join us on X"
           />
           <GetConnectedButton
             iconName="github"


### PR DESCRIPTION
1. Changed `href` in GetConnectedButton from Twitter to X URL (https://x.com/base)
2. Updated `title` and `aria-label` to reflect "Join us on X" instead of "Join us on Twitter"
3. Kept `iconName` and `eventName` as "twitter" to ensure compatibility with existing icons and events

