### PR TITLE
Fixed Update index.jsx

### DIFF
--- a/apps/base-docs/src/pages/tutorials/index.jsx
+++ b/apps/base-docs/src/pages/tutorials/index.jsx
@@ -149,7 +149,7 @@ export default function Tutorials() {
                 Object.values(tutorialData)
                   .filter((tutorial) => tutorial.tags)
                   .filter((tutorial) =>
-                    selectedTag == 'all' ? tutorial : tutorial.tags.includes(selectedTag),
+                    selectedTag === 'all' ? tutorial : tutorial.tags.includes(selectedTag),
                   )
                   .map((tutorial) => <TutorialListCell key={tutorial.slug} tutorial={tutorial} />)}
             </div>


### PR DESCRIPTION
**What changed? Why?**

In the line:
   ```jsx
   selectedTag == 'all' ? tutorial : tutorial.tags.includes(selectedTag)
   ```
   The `==` operator is used, which performs a loose equality check. For better safety and precision, it's recommended to use the strict equality `===`:
   ```jsx
   selectedTag === 'all' ? tutorial : tutorial.tags.includes(selectedTag)