### PR TITLE
Typo Update hardhat-verify-sbs.md

### DIFF
--- a/apps/base-docs/base-learn/docs/hardhat-verify/hardhat-verify-sbs.md
+++ b/apps/base-docs/base-learn/docs/hardhat-verify/hardhat-verify-sbs.md
@@ -42,7 +42,7 @@ In order to obtain an Etherscan API key, visit [Etherscan](https://etherscan.io/
 
 Then, go to [https://etherscan.io/myapikey](https://etherscan.io/myapikey) and create an API key by clicking the **Add** button:
 
-![Add key](../../assets/images/hardhat-verify/harhat-verify-create-key.png)
+![Add key](../../assets/images/hardhat-verify/hardhat-verify-create-key.png)
 
 Bear in mind that different networks have other Blockchain explorers. For example:
 


### PR DESCRIPTION
**What changed? Why?**

There is a typo in the "Getting an Etherscan key" section — the image filename and link use "harhat-verify-create-key.png" instead of "hardhat-verify-create-key.png". Fixed.

<img width="622" alt="Снимок экрана 2024-11-11 в 12 49 19" src="https://github.com/user-attachments/assets/ae1a4f24-4017-412d-8df5-2b345a12cf13">


**Notes to reviewers**

**How has it been tested?**
