### PR TITLE
fix: dynamic crypto providers

### DIFF
--- a/apps/web/app/(base-org)/builder-anniversary-nft/page.tsx
+++ b/apps/web/app/(base-org)/builder-anniversary-nft/page.tsx
@@ -1,3 +1,4 @@
+import CryptoProviders from 'apps/web/app/CryptoProviders';
 import { BuilderNftHero } from 'apps/web/src/components/BuilderNft/BuilderNftHero';
 import type { Metadata } from 'next';
 
@@ -13,7 +14,9 @@ export const metadata: Metadata = {
 export default async function About() {
   return (
     <main className="flex w-full flex-col items-center bg-black">
-      <BuilderNftHero />
+      <CryptoProviders>
+        <BuilderNftHero />
+      </CryptoProviders>
     </main>
   );
 }

--- a/apps/web/app/(basenames)/layout.tsx
+++ b/apps/web/app/(basenames)/layout.tsx
@@ -1,3 +1,4 @@
+import CryptoProviders from 'apps/web/app/CryptoProviders';
 import ErrorsProvider from 'apps/web/contexts/Errors';
 import UsernameNav from 'apps/web/src/components/Layout/UsernameNav';
 
@@ -27,10 +28,12 @@ export default async function BasenameLayout({
 }) {
   return (
     <ErrorsProvider context="basenames">
-      <div className="max-w-screen flex min-h-screen flex-col">
-        <UsernameNav />
-        {children}
-      </div>
+      <CryptoProviders>
+        <div className="max-w-screen flex min-h-screen flex-col">
+          <UsernameNav />
+          {children}
+        </div>
+      </CryptoProviders>
     </ErrorsProvider>
   );
 }

--- a/apps/web/app/AppProviders.tsx
+++ b/apps/web/app/AppProviders.tsx
@@ -1,6 +1,4 @@
 'use client';
-import '@rainbow-me/rainbowkit/styles.css';
-import '@coinbase/onchainkit/styles.css';
 
 import {
   Provider as CookieManagerProvider,
@@ -8,28 +6,14 @@ import {
   TrackingCategory,
   TrackingPreference,
 } from '@coinbase/cookie-manager';
-import { AppConfig, OnchainKitProvider } from '@coinbase/onchainkit';
 import { Provider as TooltipProvider } from '@radix-ui/react-tooltip';
-import { connectorsForWallets, RainbowKitProvider } from '@rainbow-me/rainbowkit';
-import {
-  coinbaseWallet,
-  metaMaskWallet,
-  phantomWallet,
-  rainbowWallet,
-  uniswapWallet,
-  walletConnectWallet,
-} from '@rainbow-me/rainbowkit/wallets';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ExperimentsProvider from 'base-ui/contexts/Experiments';
 import useSprig from 'base-ui/hooks/useSprig';
 import { useCallback, useRef } from 'react';
-import { createConfig, http, WagmiProvider } from 'wagmi';
-import { base, baseSepolia, mainnet } from 'wagmi/chains';
 import { cookieManagerConfig } from '../src/utils/cookieManagerConfig';
 import ClientAnalyticsScript from 'apps/web/src/components/ClientAnalyticsScript/ClientAnalyticsScript';
 import dynamic from 'next/dynamic';
 import ErrorsProvider from 'apps/web/contexts/Errors';
-import { isDevelopment } from 'apps/web/src/constants';
 import { logger } from 'apps/web/src/utils/logger';
 
 const DynamicCookieBannerWrapper = dynamic(
@@ -39,50 +23,7 @@ const DynamicCookieBannerWrapper = dynamic(
   },
 );
 
-coinbaseWallet.preference = 'all';
-
-const connectors = connectorsForWallets(
-  [
-    {
-      groupName: 'Recommended',
-      wallets: [
-        coinbaseWallet,
-        metaMaskWallet,
-        uniswapWallet,
-        rainbowWallet,
-        phantomWallet,
-        walletConnectWallet,
-      ],
-    },
-  ],
-  {
-    projectId: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID ?? 'dummy-id',
-    walletConnectParameters: {},
-    appName: 'Base.org',
-    appDescription: '',
-    appUrl: 'https://www.base.org/',
-    appIcon: '',
-  },
-);
-
-const config = createConfig({
-  connectors,
-  chains: [base, baseSepolia, mainnet],
-  transports: {
-    [base.id]: http(),
-    [baseSepolia.id]: http(),
-    [mainnet.id]: http(),
-  },
-  ssr: true,
-});
-const queryClient = new QueryClient();
 const sprigEnvironmentId = process.env.NEXT_PUBLIC_SPRIG_ENVIRONMENT_ID;
-
-const onchainKitConfig: AppConfig = {
-  appearance: {
-    mode: 'light',
-  },
-};
 
 type AppProvidersProps = {
   children: React.ReactNode;
@@ -142,26 +83,14 @@ export default function AppProviders({ children }: AppProvidersProps) {
         config={cookieManagerConfig}
       >
         <ClientAnalyticsScript />
-        <WagmiProvider config={config}>
-          <QueryClientProvider client={queryClient}>
-            <OnchainKitProvider
-              chain={isDevelopment ? baseSepolia : base}
-              apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}
-              config={onchainKitConfig}
-            >
-              <RainbowKitProvider modalSize="compact">
-                <TooltipProvider>
-                  <ExperimentsProvider>
-                    <>
-                      {children}
-                      <DynamicCookieBannerWrapper />
-                    </>
-                  </ExperimentsProvider>
-                </TooltipProvider>
-              </RainbowKitProvider>
-            </OnchainKitProvider>
-          </QueryClientProvider>
-        </WagmiProvider>
+        <TooltipProvider>
+          <ExperimentsProvider>
+            <>
+              {children}
+              <DynamicCookieBannerWrapper />
+            </>
+          </ExperimentsProvider>
+        </TooltipProvider>
       </CookieManagerProvider>
     </ErrorsProvider>
   );

--- a/apps/web/app/CryptoProviders.dynamic.tsx
+++ b/apps/web/app/CryptoProviders.dynamic.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useErrors } from 'apps/web/contexts/Errors';
+
+export function DynamicCryptoProviders({ children }: { children: React.ReactNode }) {
+  const [CryptoProvidersDynamic, setCryptoProvidersDynamic] =
+    useState<React.ComponentType<{ children: React.ReactNode }>>();
+  const { logError } = useErrors();
+
+  useEffect(() => {
+    import('apps/web/app/CryptoProviders')
+      .then((mod) => {
+        setCryptoProvidersDynamic(() => mod.default);
+      })
+      .catch((error) => logError(error, 'Failed to load CryptoProviders'));
+  }, [logError]);
+
+  if (!CryptoProvidersDynamic) return null;
+
+  return <CryptoProvidersDynamic>{children}</CryptoProvidersDynamic>;
+}

--- a/apps/web/app/CryptoProviders.tsx
+++ b/apps/web/app/CryptoProviders.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { AppConfig, OnchainKitProvider } from '@coinbase/onchainkit';
+import { connectorsForWallets, RainbowKitProvider } from '@rainbow-me/rainbowkit';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { isDevelopment } from 'apps/web/src/constants';
+import { createConfig, http, WagmiProvider } from 'wagmi';
+import { base, baseSepolia, mainnet } from 'wagmi/chains';
+import {
+  coinbaseWallet,
+  metaMaskWallet,
+  phantomWallet,
+  rainbowWallet,
+  uniswapWallet,
+  walletConnectWallet,
+} from '@rainbow-me/rainbowkit/wallets';
+
+const connectors = connectorsForWallets(
+  [
+    {
+      groupName: 'Recommended',
+      wallets: [
+        coinbaseWallet,
+        metaMaskWallet,
+        uniswapWallet,
+        rainbowWallet,
+        phantomWallet,
+        walletConnectWallet,
+      ],
+    },
+  ],
+  {
+    projectId: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID ?? 'dummy-id',
+    walletConnectParameters: {},
+    appName: 'Base.org',
+    appDescription: '',
+    appUrl: 'https://www.base.org/',
+    appIcon: '',
+  },
+);
+
+const config = createConfig({
+  connectors,
+  chains: [base, baseSepolia, mainnet],
+  transports: {
+    [base.id]: http(),
+    [baseSepolia.id]: http(),
+    [mainnet.id]: http(),
+  },
+  ssr: true,
+});
+const queryClient = new QueryClient();
+
+type CryptoProvidersProps = {
+  children: React.ReactNode;
+};
+
+const onchainKitConfig: AppConfig = {
+  appearance: {
+    mode: 'light',
+  },
+};
+
+export default function CryptoProviders({ children }: CryptoProvidersProps) {
+  return (
+    <WagmiProvider config={config}>
+      <QueryClientProvider client={queryClient}>
+        <OnchainKitProvider
+          chain={isDevelopment ? baseSepolia : base}
+          apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}
+          config={onchainKitConfig}
+        >
+          <RainbowKitProvider modalSize="compact">{children}</RainbowKitProvider>
+        </OnchainKitProvider>
+      </QueryClientProvider>
+    </WagmiProvider>
+  );
+}

--- a/apps/web/app/global.css
+++ b/apps/web/app/global.css
@@ -2,6 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
+@import '@rainbow-me/rainbowkit/styles.css';
+@import '@coinbase/onchainkit/styles.css';
+
 /* For Webkit-based browsers (Chrome, Safari and Opera) */
 :not(.scrollbar)::-webkit-scrollbar {
   display: none;

--- a/apps/web/src/components/ConnectWalletButton/ConnectWalletButton.tsx
+++ b/apps/web/src/components/ConnectWalletButton/ConnectWalletButton.tsx
@@ -27,6 +27,7 @@ import { useCopyToClipboard, useMediaQuery } from 'usehooks-ts';
 import { useAccount, useSwitchChain } from 'wagmi';
 import ChainDropdown from 'apps/web/src/components/ChainDropdown';
 import { useSearchParams } from 'next/navigation';
+import { DynamicCryptoProviders } from 'apps/web/app/CryptoProviders.dynamic';
 
 export enum ConnectWalletButtonVariants {
   BaseOrg,
@@ -36,6 +37,16 @@ export enum ConnectWalletButtonVariants {
 type ConnectWalletButtonProps = {
   connectWalletButtonVariant: ConnectWalletButtonVariants;
 };
+
+export function DynamicWrappedConnectWalletButton({
+  connectWalletButtonVariant = ConnectWalletButtonVariants.BaseOrg,
+}: ConnectWalletButtonProps) {
+  return (
+    <DynamicCryptoProviders>
+      <ConnectWalletButton connectWalletButtonVariant={connectWalletButtonVariant} />
+    </DynamicCryptoProviders>
+  )
+}
 
 export function ConnectWalletButton({
   connectWalletButtonVariant = ConnectWalletButtonVariants.BaseOrg,

--- a/apps/web/src/components/base-org/shared/TopNavigation/GasPriceDropdown.tsx
+++ b/apps/web/src/components/base-org/shared/TopNavigation/GasPriceDropdown.tsx
@@ -2,6 +2,7 @@ import Card from 'apps/web/src/components/base-org/Card';
 import { Icon } from 'apps/web/src/components/Icon/Icon';
 import { base, mainnet } from 'viem/chains';
 import { useGasPrice } from 'wagmi';
+import { DynamicCryptoProviders } from 'apps/web/app/CryptoProviders.dynamic';
 
 const convertWeiToMwei = (weiValue: bigint): number => {
   // 1 mwei = 10^6 wei
@@ -9,7 +10,15 @@ const convertWeiToMwei = (weiValue: bigint): number => {
   return Number(mweiValue.toFixed(2)); // Round to 2 decimal places
 };
 
-export default function GasPriceDropdown() {
+export function DynamicWrappedGasPriceDropdown() {
+  return (
+    <DynamicCryptoProviders>
+      <GasPriceDropdown />
+    </DynamicCryptoProviders>
+  );
+}
+
+export function GasPriceDropdown() {
   const { data: baseGasPriceInWei } = useGasPrice({
     chainId: base.id,
     query: {

--- a/apps/web/src/components/base-org/shared/TopNavigation/GasPriceDropdown.tsx
+++ b/apps/web/src/components/base-org/shared/TopNavigation/GasPriceDropdown.tsx
@@ -35,7 +35,7 @@ export function GasPriceDropdown() {
 
   return (
     <div className="group relative hidden md:block">
-      <div className="flex flex cursor-pointer items-center gap-2 rounded-xl bg-black px-4 py-3 transition-all group-hover:bg-[#333]">
+      <div className="flex flex-row cursor-pointer items-center gap-2 rounded-xl bg-black px-4 py-3 transition-all group-hover:bg-[#333]">
         <span className="animate-pulse text-palette-positive">
           <Icon name="blueCircle" color="currentColor" height="0.75rem" width="0.75rem" />
         </span>

--- a/apps/web/src/components/base-org/shared/TopNavigation/index.tsx
+++ b/apps/web/src/components/base-org/shared/TopNavigation/index.tsx
@@ -1,17 +1,18 @@
 'use client';
 
-import AnalyticsProvider from 'apps/web/contexts/Analytics';
-import Link from 'next/link';
-import logo from './assets/logo.svg';
+import { Suspense } from 'react';
 import Image, { StaticImageData } from 'next/image';
-import {
-  ConnectWalletButton,
-  ConnectWalletButtonVariants,
-} from 'apps/web/src/components/ConnectWalletButton/ConnectWalletButton';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import AnalyticsProvider from 'apps/web/contexts/Analytics';
+import logo from 'apps/web/src/components/base-org/shared/TopNavigation/assets/logo.svg';
 import MenuDesktop from 'apps/web/src/components/base-org/shared/TopNavigation/MenuDesktop';
 import MenuMobile from 'apps/web/src/components/base-org/shared/TopNavigation/MenuMobile';
-import GasPriceDropdown from 'apps/web/src/components/base-org/shared/TopNavigation/GasPriceDropdown';
-import { Suspense } from 'react';
+import { DynamicWrappedGasPriceDropdown } from 'apps/web/src/components/base-org/shared/TopNavigation/GasPriceDropdown';
+import {
+  ConnectWalletButtonVariants,
+  DynamicWrappedConnectWalletButton,
+} from 'apps/web/src/components/ConnectWalletButton/ConnectWalletButton';
 
 export type SubItem = {
   name: string;
@@ -91,7 +92,11 @@ const links: TopNavigationLink[] = [
   },
 ];
 
+const cryptoExcludedPaths = ['/jobs', '/about', '/ecosystem', '/getstarted'];
+
 export default function TopNavigation() {
+  const pathname = usePathname();
+  const showGasDropdownAndConnectWallet = !cryptoExcludedPaths.includes(pathname ?? '');
   return (
     <AnalyticsProvider context="navbar">
       <nav className="fixed top-0 z-50 w-full shrink-0 px-[1rem] py-4 md:px-[1.5rem] lg:px-[2rem]">
@@ -101,7 +106,7 @@ export default function TopNavigation() {
             <Link href="/" className="flex min-h-[3rem] min-w-[3rem]">
               <Image src={logo as StaticImageData} alt="Base Logo" />
             </Link>
-            <GasPriceDropdown />
+            {showGasDropdownAndConnectWallet && <DynamicWrappedGasPriceDropdown />}
           </div>
 
           <div className="hidden md:inline-block">
@@ -114,11 +119,13 @@ export default function TopNavigation() {
 
           {/* Connect Wallet button */}
           <div className="flex items-end justify-end md:min-w-[16rem]">
-            <Suspense>
-              <ConnectWalletButton
-                connectWalletButtonVariant={ConnectWalletButtonVariants.BaseOrg}
-              />
-            </Suspense>
+            {showGasDropdownAndConnectWallet && (
+              <Suspense>
+                <DynamicWrappedConnectWalletButton
+                  connectWalletButtonVariant={ConnectWalletButtonVariants.BaseOrg}
+                />
+              </Suspense>
+            )}
           </div>
         </div>
       </nav>


### PR DESCRIPTION
**What changed? Why?**
* split providers into app-level and crypto, moved crypto providers down stack to be present only when needed
* created `DynamicCryptoProviders` that are created at page-load instead of build-time
* removed `ConnectWalletButton` and `GasPriceEstimator` from certain pages
* created crypto-provider-wrapped versions of `ConnectWalletButton` and `GasPriceEstimator` for conditional rendering in the navbar

**Notes to reviewers**

**How has it been tested?**
locally

homepage layout correct (incorrect style had large metallic icons)
![image](https://github.com/user-attachments/assets/6ad61fdd-260a-43cf-8ed7-4c5586548512)

`/getstarted` layout correct (incorrect style forced flex-col instead of flex-row)
![image](https://github.com/user-attachments/assets/50bf9a49-46c5-43fb-8ced-dff6d0411b60)
