### PR TITLE
chore: change `/registry` redirect link

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -270,7 +270,7 @@ module.exports = extendBaseConfig(
         },
         {
           source: '/registry',
-          destination: 'https://buildonbase.deform.cc/registry/',
+          destination: 'https://buildonbase.deform.cc/getstarted/',
           permanent: true,
         },
         {


### PR DESCRIPTION
**What changed? Why?**
* changed the link at base.org/registry to redirect to a new form

**Notes to reviewers**

**How has it been tested?**
locally