### PR TITLE
Fix minor typos in documentation and styles

### DIFF
--- a/apps/base-docs/base-learn/docs/introduction-to-solidity/introduction-to-remix.md
+++ b/apps/base-docs/base-learn/docs/introduction-to-solidity/introduction-to-remix.md
@@ -33,7 +33,7 @@ The editor pane loads with the Remix home screen, which contains news, helpful l
 
 ![Remix Editor](../../assets/images/introduction-to-solidity/editor-pane.png)
 
-You'll edit your code in the editor pane. It also has most of the features you're expecting, such as syntax and error highlighting. Note that in Remix, errors are not underlines. Instead, you'll see an❗to the left of the line number where the error is present.
+You'll edit your code in the editor pane. It also has most of the features you're expecting, such as syntax and error highlighting. Note that in Remix, errors are not underlined. Instead, you'll see an❗to the left of the line number where the error is present.
 
 At the top, you'll see a large green arrow similar to the _Run_ button in other editors. In Solidity, this compiles your code, but it does not run it because you must first deploy your code to the simulated blockchain.
 

--- a/apps/base-docs/docusaurus.config.js
+++ b/apps/base-docs/docusaurus.config.js
@@ -317,7 +317,7 @@ const config = {
             },
           ],
         },
-        // Langauge selection dropdown will be supported in the future
+        // Language selection dropdown will be supported in the future
         // {
         //   type: 'localeDropdown',
         //   navposition: 'bottomRight',
@@ -344,7 +344,7 @@ const config = {
       respectPrefersColorScheme: false,
     },
   },
-  // Langauge selection dropdown will be supported in the future
+  // Language selection dropdown will be supported in the future
   // i18n: {
   //   defaultLocale: 'en',
   //   locales: ['en', 'fr'],

--- a/apps/base-docs/src/components/DocFeedback/styles.module.css
+++ b/apps/base-docs/src/components/DocFeedback/styles.module.css
@@ -71,7 +71,7 @@
   transform: scale(-1, 1);
 }
 
-/* Feedbak Modal Header/Footer */
+/* feedback Modal Header/Footer */
 .feedbackModalHeader {
   display: flex;
   justify-content: center;
@@ -91,7 +91,7 @@
   gap: 0.75rem;
 }
 
-/* Feedback Modal Submit/Cancel Buttons */
+/* Feedbacck Modal Submit/Cancel Buttons */
 .feedbackModalSubmit,
 .feedbackModalCancel {
   font-size: 1rem;

--- a/apps/base-docs/tutorials/docs/1_verify-contract-with-basescan.md
+++ b/apps/base-docs/tutorials/docs/1_verify-contract-with-basescan.md
@@ -155,7 +155,7 @@ To verify a contract you will use the `verifysourcecode` route, with the `contra
 
 :::tip Unsure what data to input?
 
-In every foundry project you will have a `.json` file that contains the conrtacts metadata and ABI. For this particular project, this information is located in the `/verify_contracts/out/Counter.sol/Counter.json`
+In every foundry project you will have a `.json` file that contains the contracts metadata and ABI. For this particular project, this information is located in the `/verify_contracts/out/Counter.sol/Counter.json`
 
 Under the `Metadata` object you will find the compiler version under `evmversion`
 :::

--- a/apps/base-docs/tutorials/docs/1_verify-contract-with-basescan.md
+++ b/apps/base-docs/tutorials/docs/1_verify-contract-with-basescan.md
@@ -42,7 +42,7 @@ The [Coinbase Developer Platform] provides access to tools and services necessar
 
 ## Jump Right In
 
-For this turotial, you will deploy a simple contract that is included in the Foundry quickstart. To do so, ensure that you have Foundry installed.
+For this tutorial, you will deploy a simple contract that is included in the Foundry quickstart. To do so, ensure that you have Foundry installed.
 
 If you don't have Foundry install it:
 


### PR DESCRIPTION
### Changes
- Corrected typos in four files:
  - `1_verify-contract-with-basescan.md`
  - `introduction-to-remix.md`
  - `styles.module.css`
  - `docusaurus.config.js`