### PR TITLE
chore: add Indonesian translation of "Base is for everyone" on homepage

### DIFF
--- a/apps/web/src/components/base-org/root/SlidingTextSection/index.tsx
+++ b/apps/web/src/components/base-org/root/SlidingTextSection/index.tsx
@@ -9,7 +9,7 @@ export default function SlidingTextSection() {
   const containerRef = useRef<HTMLDivElement>(null);
 
   const text =
-    ' Base is for everyone - القاعدة للجميع - Base es para todos - 基地适合所有人 - La Base è per tutti - Base est pour tout le monde - Base ni ya kila mtu - ';
+    ' Base is for everyone - القاعدة للجميع - Base es para todos - 基地适合所有人 - La Base è per tutti - Base est pour tout le monde - Base ni ya kila mtu - Base adalah untuk semua orang - ';
 
   const containerClasses = classNames(
     'relative w-full overflow-hidden rounded-2xl bg-blue p-8',


### PR DESCRIPTION
**What changed? Why?**

Added translation of Base is for everyone in Indonesian.

**Notes to reviewers**

Pretty standard text ammendment

**How has it been tested?**

Simple string edit / no test required. Spelling + typo checked.
