### PR TITLE
chore: add disclaimer to basenames profiles

### DIFF
--- a/apps/web/app/(basenames)/name/[username]/page.tsx
+++ b/apps/web/app/(basenames)/name/[username]/page.tsx
@@ -39,7 +39,7 @@ export default async function Username({ params }: UsernameProfileProps) {
   await redirectIfNotNameOwner(username);
 
   const usernameProfilePageClasses = classNames(
-    'mx-auto mt-32 flex min-h-screen w-full max-w-[1440px] flex-col justify-between gap-10 px-4 px-4 pb-40 md:flex-row md:px-8',
+    'mx-auto mt-32 flex min-h-screen w-full max-w-[1440px] flex-col justify-between gap-10 px-4 px-4 pb-16 md:flex-row md:px-8',
   );
 
   return (

--- a/apps/web/src/components/Basenames/UsernameProfile/index.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfile/index.tsx
@@ -17,13 +17,19 @@ export default function UsernameProfile() {
     );
 
   return (
-    <div className="mx-auto grid min-h-screen grid-cols-1 gap-10 md:grid-cols-[25rem_minmax(0,1fr)]">
-      <div className="w-full">
-        <UsernameProfileSidebar />
+    <div className="flex flex-col gap-10 items-center">
+      <div className="mx-auto grid min-h-screen grid-cols-1 gap-10 md:grid-cols-[25rem_minmax(0,1fr)]">
+        <div className="w-full">
+          <UsernameProfileSidebar />
+        </div>
+        <div className="w-full">
+          <UsernameProfileContent />
+        </div>
       </div>
-      <div className="w-full">
-        <UsernameProfileContent />
-      </div>
+      <span className="mt-24">
+        Content displayed on this profile page is rendered directly from the decentralized Basenames
+        protocol, and is not maintained or moderated by, nor under the control of, Coinbase.
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
**What changed? Why?**
* Added legal disclaimer on basenames profile pages (eg `base.org/name/shrekislife`)
![image](https://github.com/user-attachments/assets/e7de7e9b-934d-4f96-8713-246a903f9e04)


**Notes to reviewers**

**How has it been tested?**
locally