### PR TITLE
Simplified ARIA Label Description for Clarity

### DIFF
--- a/apps/base-docs/src/theme/Navbar/Layout/index.js
+++ b/apps/base-docs/src/theme/Navbar/Layout/index.js
@@ -29,7 +29,7 @@ export default function NavbarLayout({children}) {
       aria-label={translate({
         id: 'theme.NavBar.navAriaLabel',
         message: 'Main',
-        description: 'The ARIA label for the main navigation',
+        description: 'ARIA label for the main navigation',
       })}
       className={clsx(
         'navbar',


### PR DESCRIPTION
**What changed? Why?**

I noticed a small area for improvement in the code where the description of the ARIA label for the main navigation contains the word "The":  

```javascript
description: 'The ARIA label for the main navigation',
```

This wording is perfectly functional, but the word "The" doesn't add significant value and can be omitted to make the code more concise. The revised version is:  

```javascript
description: 'ARIA label for main navigation',
```

**Notes to reviewers**

- **Clarity:** Simplifying this phrase improves readability without sacrificing meaning.  
- **Consistency:** It aligns better with common ARIA description practices, which often favor concise and direct language.  
- **Code Quality:** Small refinements like this contribute to maintaining clean, professional, and user-friendly code.

**Thank you for considering this improvement!**

**How has it been tested?**

Localy.
