### PR TITLE
Fix Incorrect Video Links in Documentation Files

### DIFF
--- a/apps/base-docs/base-learn/docs/deployment-to-testnet/deployment-to-base-sepolia-sbs.md
+++ b/apps/base-docs/base-learn/docs/deployment-to-testnet/deployment-to-base-sepolia-sbs.md
@@ -102,7 +102,7 @@ You now have the power to put smart contracts on the blockchain! You've only dep
 [coinbase]: https://www.coinbase.com/wallet
 [metamask]: https://metamask.io/
 [faucet]: https://docs.base.org/tools/network-faucets
-[set up]: https://www.youtube.com/watch?v=CZDgLG6jpgw
+[set up]: 
 [coinbase settings]: https://docs.cloud.coinbase.com/wallet-sdk/docs/developer-settings
 [Metamask Settings]: https://support.metamask.io/hc/en-us/articles/13946422437147-How-to-view-testnets-in-MetaMask
 [BaseScan]: https://sepolia.basescan.org/

--- a/apps/base-docs/tutorials/docs/0_deploy-with-remix.md
+++ b/apps/base-docs/tutorials/docs/0_deploy-with-remix.md
@@ -224,7 +224,7 @@ You now have the power to put smart contracts on the blockchain! You've only dep
 [`basescan.org`]: https://basescan.org/
 [coinbase]: https://www.coinbase.com/wallet
 [MetaMask]: https://metamask.io/
-[set up]: https://www.youtube.com/watch?v=CZDgLG6jpgw
+[set up]: 
 [coinbase settings]: https://docs.cloud.coinbase.com/wallet-sdk/docs/developer-settings
 [BaseScan]: https://sepolia.basescan.org/
 [faucets on the web]: https://coinbase.com/faucets


### PR DESCRIPTION
I found similar issues in other documentation files that need corrections. This pull request fixes incorrect video links in the following files:
apps/base-learn/docs/deployment-to-testnet/deployment-to-base-sepolia-sbs.md
apps/base-docs/tutorials/docs/0_deploy-with-remix.md
