### PR TITLE
Docs Update: Adding Reown to the Docs

### DIFF
--- a/apps/base-docs/docs/tools/account-abstraction.md
+++ b/apps/base-docs/docs/tools/account-abstraction.md
@@ -15,6 +15,9 @@ keywords:
     smart contract wallets,
     Alchemy,
     Biconomy,
+    Reown,
+    AppKit,
+    WalletConnect,
     Stackup,
     WalletKit,
     Zerodev,
@@ -54,6 +57,14 @@ The Coinbase Developer Platform [Account Abstraction Kit](https://www.coinbase.c
 ## Pimlico
 
 [Pimlico](https://pimlico.io/) provides an infrastructure platform that makes building smart accounts simpler. If you are developing, an ERC-4337 smart account, they provide bundlers, verifying paymasters, ERC-20 paymasters, and much more.
+
+---
+
+## Reown (prev. known as WalletConnect)
+
+**[Reown](https://reown.com/?utm_source=base&utm_medium=docs&utm_campaign=backlinks)** gives developers the tools to build user experiences that make digital ownership effortless, intuitive, and secure. One of Reown's offerings is the AppKit SDK. 
+
+**AppKit** is a powerful, free, and fully open-source SDK for developers looking to integrate wallet connections and other Web3 functionalities into their apps on any EVM and non-EVM chain. In just a few simple steps, you can provide your users with seamless wallet access, one-click authentication, social logins, and notifications—streamlining their experience while enabling advanced features like on-ramp functionality, in-app token swaps and smart accounts. Check out the [docs](https://docs.reown.com/appkit/overview?utm_source=base&utm_medium=docs&utm_campaign=backlinks) to get started.
 
 ---
 

--- a/apps/base-docs/docs/tools/onboarding.md
+++ b/apps/base-docs/docs/tools/onboarding.md
@@ -13,6 +13,10 @@ keywords:
     onboard,
     onboarding,
     Privy,
+    Reown,
+    AppKit,
+    WalletConnect,
+    WalletKit,
     Crossmint,
     Dynamic,
     Particle Network,
@@ -61,6 +65,30 @@ You can [get started with Privy here](https://docs.privy.io/guide/quickstart), a
 ## Particle Network
 
 [Particle Network](https://particle.network/) is the intent-centric, modular access layer of Web3. With Particle's Smart Wallet-as-a-Service, developers can curate a seamless user experience through modular and customizable EOA/AA embedded wallet components. Using MPC-TSS for key management, Particle can streamline user onboarding via familiar web2 accounts - such as Google accounts, email addresses, and phone numbers. Particle Network's Smart Wallet-as-a-Service is compatible with most EVM chains, including Base.
+
+---
+
+## Reown (prev. known as WalletConnect)
+
+**[Reown](https://reown.com/?utm_source=base&utm_medium=docs&utm_campaign=backlinks)** gives developers the tools to build user experiences that make digital ownership effortless, intuitive, and secure.
+
+Reown has two major product offerings, they are, **AppKit** and **WalletKit**.
+
+### AppKit
+
+AppKit is a powerful, free, and fully open-source SDK for developers looking to integrate wallet connections and other Web3 functionalities into their apps on any EVM and non-EVM chain. In just a few simple steps, you can provide your users with seamless wallet access, one-click authentication, social logins, and notifications—streamlining their experience while enabling advanced features like on-ramp functionality, in-app token swaps and smart accounts.
+
+### WalletKit
+WalletKit is a robust, open-source SDK designed to empower seamless wallet connections and interactions across any blockchain. With WalletKit, you can offer your users a simple and secure way to connect with thousands of apps, enabling features like one-click authentication, secure transaction signing, and streamlined wallet address verification. Its chain-agnostic design ensures effortless multi-chain support, eliminating the need for complex integrations while delivering unmatched connectivity and security.
+
+To summarize, **AppKit** is for **Web3 applications** and **WalletKit** is for **Web3 wallets**.
+
+You will be able to use Reown AppKit to power end-to-end wallet interactions on your Web3 app deployed on Base.
+
+Some links to learn more about Reown:
+- [Website](https://reown.com/?utm_source=base&utm_medium=docs&utm_campaign=backlinks)
+- [Blog](https://reown.com/blog?utm_source=base&utm_medium=docs&utm_campaign=backlinks)
+- [Docs](https://docs.reown.com/?utm_source=base&utm_medium=docs&utm_campaign=backlinks)
 
 ---
 


### PR DESCRIPTION
**What changed? Why?**

This PR adds Reown to the docs, under "Account Abstraction" and "User Onboarding" doc pages. Reown was previously known as WalletConnect and Reown provides fully free and open-sourced SDKs to build both Web3 apps and Web3 wallets.

**Notes to reviewers**

N/A

**How has it been tested?**

Tested locally
