### PR TITLE
update README steps for updating the base ecosystem page - categories/subcategories

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ If you're a builder who wants to add or update your project on the [Base Ecosyst
       - `consumer`: _One_ of `creator`, `crypto taxes`, `dao`, `gaming`, `messaging`, `music`, `nft`, `payments`, `real world`, `social`
       - `defi`: _One_ of `dex`, `dex aggregator`, `insurance`, `lending/borrowing`, `liquidity management`, `portfolio`, `stablecoin`, `yield vault`
       - `infra`: _One_ of `ai`, `bridge`, `data`, `depin`, `developer tool`, `identity`, `node provider`, `raas`, `security`
-      - `onramp`: _One_ of `centralized-exchange`, `fiat on-ramp`
+      - `onramp`: _One_ of `centralized exchange`, `fiat on-ramp`
       - `wallet`: _One_ of `account abstraction`, `multisig`, `self-custody`
 
 4. When adding and/or updating a logo, place a 192x192 pixel PNG file in the `web/apps/web/public/images/partners/`. The file should be named appropriately (e.g., your-project-name.png). The logo should be an App Store or Play Store iconographic version, not a full wordmark.

--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ If you're a builder who wants to add or update your project on the [Base Ecosyst
    - imageUrl: Path to your project's logo image
    - category: Your project's category, _one_ of: `consumer`, `defi`, `infra`, `onramp`, `wallet`
    - subcategory: Your project's subcategory, with the following options associated with each category
-    - `consumer`: _One_ of `creator`, `crypto taxes`, `dao`, `gaming`, `messaging`, `music`, `nft`, `payments`, `real world`, `social`
-    - `defi`: _One_ of `dex`, `dex aggregator`, `insurance`, `lending/borrowing`, `liquidity management`, `portfolio`, `stablecoin`, `yield vault`
-    - `infra`: _One_ of `ai`, `bridge`, `data`, `depin`, `developer tool`, `identity`, `node provider`, `raas`, `security`
-    - `onramp`: _One_ of `centralized-exchange`, `fiat on-ramp`
-    - `wallet`: _One_ of `account abstraction`, `multisig`, `self-custody`
+      - `consumer`: _One_ of `creator`, `crypto taxes`, `dao`, `gaming`, `messaging`, `music`, `nft`, `payments`, `real world`, `social`
+      - `defi`: _One_ of `dex`, `dex aggregator`, `insurance`, `lending/borrowing`, `liquidity management`, `portfolio`, `stablecoin`, `yield vault`
+      - `infra`: _One_ of `ai`, `bridge`, `data`, `depin`, `developer tool`, `identity`, `node provider`, `raas`, `security`
+      - `onramp`: _One_ of `centralized-exchange`, `fiat on-ramp`
+      - `wallet`: _One_ of `account abstraction`, `multisig`, `self-custody`
 
 4. When adding and/or updating a logo, place a 192x192 pixel PNG file in the `web/apps/web/public/images/partners/`. The file should be named appropriately (e.g., your-project-name.png). The logo should be an App Store or Play Store iconographic version, not a full wordmark.
 

--- a/README.md
+++ b/README.md
@@ -86,18 +86,25 @@ If you're a builder who wants to add or update your project on the [Base Ecosyst
    ```json
    {
      "name": "Your Project Name",
-     "tags": ["category"],
      "description": "A brief description of your project (less than 200 characters)",
      "url": "https://your-project-url.com",
-     "imageUrl": "/images/partners/your-project-logo.png"
+     "imageUrl": "/images/partners/your-project-logo.png",
+     "category": "Your Project Category",
+     "subcategory": "Your Project Subcategory"
    }
    ```
 
    - name: Your project's name
-   - tags: An array with _one_ of the following categories: `bridge`, `dao`, `defi`, `gaming`, `infra`, `nft`, `onramp`, `social`, `wallet`, `security`
    - description: A brief description of your project, must be less than 200 characters
    - url: Your project's website URL
    - imageUrl: Path to your project's logo image
+   - category: Your project's category, _one_ of: `consumer`, `defi`, `infra`, `onramp`, `wallet`
+   - subcategory: Your project's subcategory, with the following options associated with each category
+    - `consumer`: _One_ of `creator`, `crypto taxes`, `dao`, `gaming`, `messaging`, `music`, `nft`, `payments`, `real world`, `social`
+    - `defi`: _One_ of `dex`, `dex aggregator`, `insurance`, `lending/borrowing`, `liquidity management`, `portfolio`, `stablecoin`, `yield vault`
+    - `infra`: _One_ of `ai`, `bridge`, `data`, `depin`, `developer tool`, `identity`, `node provider`, `raas`, `security`
+    - `onramp`: _One_ of `centralized-exchange`, `fiat on-ramp`
+    - `wallet`: _One_ of `account abstraction`, `multisig`, `self-custody`
 
 4. When adding and/or updating a logo, place a 192x192 pixel PNG file in the `web/apps/web/public/images/partners/`. The file should be named appropriately (e.g., your-project-name.png). The logo should be an App Store or Play Store iconographic version, not a full wordmark.
 

--- a/apps/web/src/data/ecosystem.json
+++ b/apps/web/src/data/ecosystem.json
@@ -1,10 +1,11 @@
 [
   {
     "name": "MADNFT",
-    "tags": ["nft"],
     "description": "MADNFT is a creator-first NFT platform empowering artists, collectors, and communities with tools to mint, list, and engage while earning XP points and rewards.",
     "url": "https://madnft.io",
-    "imageUrl": "/images/partners/madnft.png"
+    "imageUrl": "/images/partners/madnft.png",
+    "category": "consumer",
+    "subcategory": "nft"
   },
   {
     "name": "Coinbase",


### PR DESCRIPTION
**What changed? Why?**

Updated the steps in the `README` file related to the [Updating the Base Ecosystem Page
](https://github.com/base-org/web?tab=readme-ov-file#updating-the-base-ecosystem-page) to reflect the change from `tags` to `categories` and `subcategories`!

**Notes to reviewers**

I've also fixed the `ecosystem.json` entry for `MADNFT` which was using the previous `tags` key.

**How has it been tested?**

See screenshot of the updated `README` below:

![Screenshot from 2024-12-09 09-44-39](https://github.com/user-attachments/assets/9d056f62-1187-4c4e-949e-1c1579aae5ea)
