### PR TITLE
Fix Tutorial Links in Farcaster Frames Documentation

### DIFF
--- a/apps/base-docs/tutorials/docs/1_7_farcaster-frames-gating-and-redirects.md
+++ b/apps/base-docs/tutorials/docs/1_7_farcaster-frames-gating-and-redirects.md
@@ -254,7 +254,7 @@ In this tutorial, you learned how to use the main features of Frames - text inpu
 [Vercel]: https://vercel.com
 [Frame Validator]: https://warpcast.com/~/developers/frames
 [Base channel]: https://warpcast.com/~/channel/base
-[deploying with Vercel]: /tutorials/farcaster-frames-deploy-to-vercel
+[deploying with Vercel]: https://docs.base.org/tutorials/farcaster-frames-deploy-to-vercel/
 [NFT Minting Frame]: /tutorials/farcaster-frames-nft-minting
 [Frames]: https://warpcast.notion.site/Farcaster-Frames-4bd47fe97dc74a42a48d3a234636d8c5
 [viem]: https://viem.sh/

--- a/apps/base-docs/tutorials/docs/1_8_farcaster-frames-transactions.md
+++ b/apps/base-docs/tutorials/docs/1_8_farcaster-frames-transactions.md
@@ -367,7 +367,7 @@ contract ClickTheButton is Ownable {
 [Vercel]: https://vercel.com
 [Frame Validator]: https://warpcast.com/~/developers/frames
 [Base channel]: https://warpcast.com/~/channel/base
-[deploying with Vercel]: /tutorials/farcaster-frames-deploy-to-vercel
+[deploying with Vercel]: https://docs.base.org/tutorials/farcaster-frames-deploy-to-vercel/
 [NFT airdrop Frame]: /tutorials/farcaster-frames-nft-minting
 [Frames]: https://warpcast.notion.site/Farcaster-Frames-4bd47fe97dc74a42a48d3a234636d8c5
 [viem]: https://viem.sh/


### PR DESCRIPTION
## Changes Made

Old:
[deploying with Vercel]: /tutorials/farcaster-frames-deploy-to-vercel

New:
[deploying with Vercel]: https://docs.base.org/tutorials/farcaster-frames-deploy-to-vercel

## Reason for Changes
The relative links in the documentation were not working correctly. I updated them to use absolute URLs pointing to the Base documentation website. This ensures that users can access the referenced tutorials regardless of where they're viewing the documentation from.

## Verification
I've tested the new links and they now correctly redirect to the proper documentation pages.

![image](https://github.com/user-attachments/assets/bcbbe5b6-583c-4a17-8a80-2d98a3d0ee4e)

These changes will improve the documentation navigation experience for users following the Farcaster Frames tutorials.