### PR TITLE
Update 5_cross-chain-with-layerzero.md

### DIFF
--- a/apps/base-docs/tutorials/docs/5_cross-chain-with-layerzero.md
+++ b/apps/base-docs/tutorials/docs/5_cross-chain-with-layerzero.md
@@ -184,13 +184,13 @@ In this tutorial, you will be implementing the [OApp](https://docs.layerzero.net
 
 :::info
 
-An extension of the [OApp](https://docs.layerzero.network/contracts/oapp) contract standard known as [OFT](https://docs.layerzero.network/contracts/oft) is also available for supporting omnichain fungible token transfers.
+An extension of the [OApp](https://docs.layerzero.network/contracts/oapp) contract standard known as [OFT](https://docs.layerzero.network/v2/developers/evm/oapp/overview) is also available for supporting omnichain fungible token transfers.
 
 :::
 
 :::info
 
-For more information on transferring tokens across chains using LayerZero, visit the [LayerZero documentation](https://docs.layerzero.network/contracts/oft).
+For more information on transferring tokens across chains using LayerZero, visit the [LayerZero documentation](https://docs.layerzero.network/v2/developers/evm/oapp/overview).
 
 :::
 


### PR DESCRIPTION
Update LayerZero V2 documentation links

File changed: apps/base-docs/tutorials/docs/5_cross-chain-with-layerzero.md

Old link:
https://docs.layerzero.network/contracts/oapp

New link: 
https://docs.layerzero.network/v2/contracts/oapp

Reason: LayerZero has upgraded to V2 and moved documentation to new structure. Updated links to ensure users can access current documentation.
