### PR TITLE
Update 5_cross-chain-with-ccip.md

### DIFF
--- a/apps/base-docs/tutorials/docs/5_cross-chain-with-ccip.md
+++ b/apps/base-docs/tutorials/docs/5_cross-chain-with-ccip.md
@@ -66,7 +66,7 @@ The ETH is required for covering gas fees associated with deploying smart contra
 
 - To fund your wallet with ETH on Base Goerli, visit a faucet listed on the [Base Faucets](https://docs.base.org/tools/network-faucets) page.
 - To fund your wallet with ETH on Optimism Goerli, visit a faucet listed on the [Optimism Faucets](https://docs.optimism.io/builders/tools/faucets) page.
-- To fund your wallet with LINK, visit the [Chainlink Faucet](https://faucets.chain.link/base-testnet).
+- To fund your wallet with LINK, visit the [Chainlink Faucet](https://faucets.chain.link/base-sepolia).
 
 :::info
 


### PR DESCRIPTION
Updated deprecated Chainlink faucet URL from base-testnet to base-sepolia to reflect Base's transition to Sepolia testnet. The old URL was non-functional and returned a 404 error.
![image](https://github.com/user-attachments/assets/ab0d4c5f-4113-4bd9-98f0-092fc1727f00)
