### PR TITLE
Switch Base Explorer Link to Official Domain

### DIFF
--- a/apps/base-docs/docs/building-with-base/network-information.md
+++ b/apps/base-docs/docs/building-with-base/network-information.md
@@ -35,7 +35,7 @@ hide_table_of_contents: true
 | RPC Endpoint    | [https://mainnet.base.org](https://mainnet.base.org)<br/>_Rate limited and not for production systems._ |
 | Chain ID        | 8453                                                                                                    |
 | Currency Symbol | ETH                                                                                                     |
-| Block Explorer  | [https://base.blockscout.com/](https://base.blockscout.com/)                                            |
+| Block Explorer  | [https://explorer.base.org](https://explorer.base.org)                                            |
 
 ---
 


### PR DESCRIPTION
**Description:**
Updated the Base Network block explorer URL from `https://base.blockscout.com/` to the official explorer `https://explorer.base.org/.` This ensures users are directed to the latest and officially maintained resource.

**What changed? Why?:**
Replaced all occurrences of the outdated Blockscout URL with the new official Base Explorer URL.
Aligns with the latest updates to Base's infrastructure and ensures accuracy in the provided links.

**How has it been tested?:**
- Manually confirmed the new URL is functional and redirects correctly.
- Checked for consistent updates across all relevant files.
- Ensured no regressions in related functionality.

Let me know if further adjustments or tests are required!