### PR TITLE
OpenSea Testnet URL

### DIFF
--- a/apps/base-docs/tutorials/docs/2_dynamic-nfts.md
+++ b/apps/base-docs/tutorials/docs/2_dynamic-nfts.md
@@ -314,6 +314,6 @@ Dynamic NFTs are commonly used with gaming projects, similar to the one we built
 [Download a zip containing PNGs]: https://gateway.irys.xyz/MoOvEzePMwFgc_v6Gw3U8ovV6ostgrkWb9tS4baAJhc
 [Irys CLI]: https://docs.irys.xyz/build/d/storage-cli/installation
 [mutability features]: https://docs.irys.xyz/build/d/features/mutability
-[Opensea Testnet]: https://testnets.opensea.io/accoun
+[Opensea Testnet]: https://testnets.opensea.io/account
 [Remix]: https://docs.base.org/tutorials/deploy-with-remix
 [server]: https://docs.irys.xyz/build/d/quickstart


### PR DESCRIPTION

Fixed a typo in the OpenSea Testnet URL:

Old URL: https://testnets.opensea.io/accoun

New URL: https://testnets.opensea.io/account

Reason for Change
The original URL was missing the 't' at the end of 'account', which resulted in a broken link. This fix ensures users can properly access their NFTs on OpenSea's testnet interface.
