### PR TITLE
Fix: broken links and update library names in documentation

### DIFF
--- a/apps/base-docs/base-learn/docs/imports/imports-sbs.md
+++ b/apps/base-docs/base-learn/docs/imports/imports-sbs.md
@@ -27,7 +27,7 @@ The [docs] start with installation instructions, which we'll return to when we s
 
 Find the documentation for the `EnumerableSet` under _Utils_. This library will allow you to create [sets] of `bytes32`, `address`, and `uint256`. Since they're enumerated, you can iterate through them. Neat!
 
-### Implementing the OpenZeppelin EnumeratedSet
+### Implementing the OpenZeppelin EnumerableSet
 
 Create a new file to work in and add the `pragma` and license identifier.
 

--- a/apps/base-docs/docs/tools/basenames-faq.md
+++ b/apps/base-docs/docs/tools/basenames-faq.md
@@ -88,7 +88,7 @@ Currently, only one address at a time can be linked to a Basename. However, we p
 
 ### 14. I am a builder. How do I integrate Basenames to my app?
 
-If you're a builder looking to integrate Basenames into your app, [OnchainKit](https://onchainkit.xyz/wallet/wallet-dropdown-basename) is the easiest way to get started (tutorial [here](https://docs.base.org/docs/tools/basenames-tutorial)). If you have ideas for new features or badges that you'd like to integrate with Basenames, we'd love to [hear from you](https://app.deform.cc/form/b9c1c39f-f238-459e-a765-5093ca638075/?page_number=0).
+If you're a builder looking to integrate Basenames into your app, [OnchainKit](https://onchainkit.xyz/wallet/wallet-dropdown-basename) is the easiest way to get started (tutorial [here](https://docs.base.org/docs/basenames-tutorial-with-onchainkit)). If you have ideas for new features or badges that you'd like to integrate with Basenames, we'd love to [hear from you](https://app.deform.cc/form/b9c1c39f-f238-459e-a765-5093ca638075/?page_number=0).
 
 ### 15. How do I get a Basename for my app or project?
 

--- a/apps/base-docs/docs/tools/cross-chain.md
+++ b/apps/base-docs/docs/tools/cross-chain.md
@@ -80,12 +80,12 @@ To get started with integrating Chainlink CCIP in your Base project, visit the C
 
 [LayerZero](https://layerzero.network/) is an omnichain interoperability protocol that enables cross-chain messaging. Applications built on Base can use the LayerZero protocol to connect to 35+ supported blockchains seamlessly.
 
-To get started with integrating LayerZero, visit the LayerZero [documentation](https://layerzero.gitbook.io/docs/evm-guides/master/how-to-send-a-message) and provided examples on [GitHub](https://github.com/LayerZero-Labs/solidity-examples).
+To get started with integrating LayerZero, visit the LayerZero [documentation](https://docs.layerzero.network/v1/developers/evm/evm-guides/send-messages) and provided examples on [GitHub](https://github.com/LayerZero-Labs/solidity-examples).
 
 #### Supported Networks
 
-- [Base Mainnet](https://layerzero.gitbook.io/docs/technical-reference/mainnet/supported-chain-ids)
-- [Base Sepolia](https://layerzero.gitbook.io/docs/technical-reference/testnet/testnet-addresses#layerzero-endpoints-testnet) (Testnet)
+- [Base Mainnet](https://docs.layerzero.network/v2/developers/evm/technical-reference/deployed-contracts#base)
+- [Base Sepolia](https://docs.layerzero.network/v2/developers/evm/technical-reference/deployed-contracts#base-sepolia) (Testnet)
 
 ---
 


### PR DESCRIPTION
This pull request fixes broken links and updates incorrect library names in the documentation to improve accuracy and relevance.

# What changed? Why?
- Corrected the library name in imports-sbs.md.
- Updated broken links in basenames-faq.md.
- Fixed outdated URLs for LayerZero in cross-chain.md.

# Notes to reviewers:
Please verify the correctness of the links and the accuracy of the information.

# How has it been tested?
Links and library names were manually checked.