### PR TITLE
fix: typos in documentation files

### DIFF
--- a/apps/base-docs/tutorials/docs/1_verify-contract-with-basescan.md
+++ b/apps/base-docs/tutorials/docs/1_verify-contract-with-basescan.md
@@ -71,7 +71,7 @@ You should have a folder structure similar to this:
 └── test
 ```
 
-The `src` folder will contain a `Counter.sol` file which will serve as the country you want to deploy.
+The `src` folder will contain a `Counter.sol` file which will serve as the contract you want to deploy.
 
 :::note You will need ETH on Base to deploy
 You (the deployer wallet) will need some ETH in order to broadcast the transaction to the Base network. Fortunately, transactions are usually < 1 cent on Base mainnet.


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected: the `country` you want to deploy → the `contract` you want to deploy.

Please review the changes and let me know if any additional changes are needed.