### PR TITLE
Fix Incorrect Font-Weight Value in CSS Variable

### DIFF
--- a/apps/base-docs/src/css/root.css
+++ b/apps/base-docs/src/css/root.css
@@ -223,7 +223,7 @@ html {
   --ifm-color-primary-lightest: rgb(146, 224, 208);
   --ifm-code-font-size: 95%;
   --search-font-size: 16px;
-  --search-font-weight: 16px;
+  --search-font-weight: 400;
 
   /* Base Docs Palette */
   --base-docs-color-fg: #000000;


### PR DESCRIPTION
**What changed? Why?**
This change is important because it ensures semantic correctness and proper styling in the CSS. The `--search-font-weight` variable was previously set to `16px`, which is incorrect because `font-weight` should be a numeric value (e.g., `400`, `700`) or a keyword (e.g., `normal`, `bold`). The old value could cause browsers to ignore the variable or render text incorrectly.

By updating the value to `400`, this fix aligns the variable with the expected format for `font-weight`, preventing visual inconsistencies and ensuring proper text rendering. This change improves the reliability and readability of the CSS.
