### PR TITLE
Update Link

### DIFF
--- a/apps/base-docs/tutorials/docs/4_account-abstraction-with-biconomy.md
+++ b/apps/base-docs/tutorials/docs/4_account-abstraction-with-biconomy.md
@@ -805,7 +805,7 @@ To add the ABI, create a new directory named `src/utils` and create a new file n
 
 :::info
 
-If your deployed contract is verified, you can also get the ABI for the contract from [BaseScan](https://goerli.basescan.org/).
+If your deployed contract is verified, you can also get the ABI for the contract from [BaseScan](https://basescan.org/).
 
 :::
 


### PR DESCRIPTION
Updated the BaseScan link to the correct URL (https://basescan.org/)
     
     
 - Fixed incorrect link for BaseScan explorer
     