### PR TITLE
fix JSON syntax typo in tutorial examples

### DIFF
--- a/apps/base-docs/tutorials/docs/2_dynamic-nfts.md
+++ b/apps/base-docs/tutorials/docs/2_dynamic-nfts.md
@@ -187,7 +187,7 @@ irys upload image-level-3.png \
 
 Create three metadata files similar to the ones below. Make sure to change the value of the image field to match the URLs generated in the previous step.
 
-```jason filename="metadata-level-1.json"
+```json filename="metadata-level-1.json"
 {
   "name": "SuperMon",
   "symbol": "SMON",
@@ -202,7 +202,7 @@ Create three metadata files similar to the ones below. Make sure to change the v
 }
 ```
 
-```jason filename="metadata-level-2.json"
+```json filename="metadata-level-2.json"
 {
   "name": "SuperMon",
   "symbol": "SMON",
@@ -218,7 +218,7 @@ Create three metadata files similar to the ones below. Make sure to change the v
 }
 ```
 
-```jason filename="metadata-level-3.json"
+```json filename="metadata-level-3.json"
 {
   "name": "SuperMon",
   "symbol": "SMON",


### PR DESCRIPTION
**What changed? Why?**
In this PR, the word `jason` has been corrected to `json` in several tutorial code examples. This was done to ensure consistency and accuracy in the documentation, as `json` is the correct term for the JavaScript Object Notation format used in the examples.

**Notes to reviewers**
Please review all code examples in the affected tutorial sections to ensure that the correction does not impact other content. The change is purely cosmetic and should not affect the functionality or logic of the tutorial.

**How has it been tested?**
The change has been reviewed manually by checking all affected sections. Since this is a typo fix, no additional testing is required beyond reviewing the content to ensure clarity and correctness.
