### PR TITLE
docs: typo Update hardhat.md

### DIFF
--- a/apps/base-docs/docs/tools/hardhat.md
+++ b/apps/base-docs/docs/tools/hardhat.md
@@ -41,7 +41,7 @@ networks: {
      accounts: [process.env.PRIVATE_KEY as string],
      gasPrice: 1000000000,
    },
-   // for Sepolia testnet
+   // for Base Sepolia testnet
    "base-sepolia": {
      url: "https://sepolia.base.org",
      accounts: [process.env.PRIVATE_KEY as string],


### PR DESCRIPTION
This update addresses a minor inaccuracy in the Hardhat configuration documentation.  

In the section detailing network configuration for Base, the comment for the Sepolia-based testnet was previously written as:  
```tsx
// for Sepolia testnet
```  

This phrasing could cause confusion, as the context pertains to **Base Sepolia**, a testnet specific to the Base network built on Sepolia, rather than the Ethereum Sepolia testnet itself.  

The comment has been updated to the following for improved clarity:  
```tsx
// for Base Sepolia testnet
```  

This adjustment ensures that developers configuring their Hardhat projects understand that the testnet refers to Base's implementation and not the original Ethereum testnet.