### PR TITLE
Update LayerZero Endpoint documentation links

### DIFF
--- a/apps/base-docs/tutorials/docs/5_cross-chain-with-layerzero.md
+++ b/apps/base-docs/tutorials/docs/5_cross-chain-with-layerzero.md
@@ -215,12 +215,12 @@ The code snippet above defines a new smart contract named `ExampleContract` that
 
 The contract's constructor expects two arguments:
 
-- `_endpoint`: The [LayerZero Endpoint](https://docs.layerzero.network/explore/layerzero-endpoint) `address` for the chain the smart contract is deployed to.
+- `_endpoint`: The [LayerZero Endpoint](https://docs.layerzero.network/v2/home/protocol/layerzero-endpoint) `address` for the chain the smart contract is deployed to.
 - `_owner`: The `address` of the owner of the smart contract.
 
 :::info
 
-[LayerZero Endpoints](https://docs.layerzero.network/explore/layerzero-endpoint) are smart contracts that expose an interface for OApp contracts to manage security configurations and send and receive messages via the LayerZero protocol.
+[LayerZero Endpoints](https://docs.layerzero.network/v2/home/protocol/layerzero-endpoint) are smart contracts that expose an interface for OApp contracts to manage security configurations and send and receive messages via the LayerZero protocol.
 
 :::
 


### PR DESCRIPTION
Updated outdated LayerZero documentation links to the new V2 documentation structure.

Changes made:
- Updated endpoint documentation link from `/explore/layerzero-endpoint` to `/v2/home/protocol/layerzero-endpoint`
- This change reflects the current LayerZero V2 documentation structure
- Ensures users are directed to the correct, up-to-date documentation

The old link was no longer working, and this update points to the current valid documentation page.