### PR TITLE
Update URL Structure, Correct Section Titles, and Fix Formatting Issues

### DIFF
--- a/apps/base-docs/docs/contracts.md
+++ b/apps/base-docs/docs/contracts.md
@@ -81,7 +81,7 @@ This page lists contract addresses for onchain apps that we have deployed.
 | `v3Migrator`                         | [0xCbf8b7f80800bd4888Fbc7bf1713B80FE4E23E10](https://sepolia.basescan.org/address/0xCbf8b7f80800bd4888Fbc7bf1713B80FE4E23E10) |
 | `v3Staker`                           | [0x62725F55f50bdE240aCa3e740D47298CAc8d57D5](https://sepolia.basescan.org/address/0x62725F55f50bdE240aCa3e740D47298CAc8d57D5) |
 | `quoterV2`                           | [0xC5290058841028F1614F3A6F0F5816cAd0df5E27](https://sepolia.basescan.org/address/0xC5290058841028F1614F3A6F0F5816cAd0df5E27) |
-| `swapRouter`                         | [0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4](https://sepolia.basescan.org/0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4)         |
+| `swapRouter`                         | [0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4](https://sepolia.basescan.org/address/0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4) |
 
 #### Testnet interfaces
 

--- a/apps/base-docs/docs/terms-of-service.md
+++ b/apps/base-docs/docs/terms-of-service.md
@@ -113,7 +113,7 @@ We reserve the right, in our sole discretion, to change these Terms at any time 
 
 Any notices or other communications provided by us under these Terms, including those regarding modifications to these Terms, will be posted online, in the Services, or through other electronic communication. You agree and consent to receive electronically all communications, agreements, documents, notices and disclosures that we provide in connection with your use of the Services.
 
-### 19. Entire Agreement.
+### 19. Entire Agreement
 
 These Terms and any other documents incorporated by reference comprise the entire understanding and agreement between you and Coinbase as to the subject matter hereof, and supersedes any and all prior discussions, agreements and understandings of any kind (including without limitation any prior versions of these Terms), between you and Coinbase. Section headings in these Terms are for convenience only and shall not govern the meaning or interpretation of any provision of these Terms.
 
@@ -145,7 +145,7 @@ These Terms shall not be construed to waive rights that cannot be waived under a
 
 Coinbase is an independent contractor for all purposes. Nothing in these Terms is intended to or shall operate to create a partnership or joint venture between you and Coinbase, or authorize you to act as agent of Coinbase. These Terms are not intended to, and do not, create or impose any fiduciary duties on us. To the fullest extent permitted by law, you acknowledge and agree that we owe no fiduciary duties or liabilities to you or any other party, and that to the extent any such duties or liabilities may exist at law or in equity, those duties and liabilities are hereby irrevocably disclaimed, waived, and foregone. You further agree that the only duties and obligations that we owe you are those set out expressly in these Terms.
 
-### 26. Dispute Resolution, Arbitration Agreement, Class Action Waiver, And Jury Trial Waiver
+### 27. Dispute Resolution, Arbitration Agreement, Class Action Waiver, And Jury Trial Waiver
 
 If you have a dispute with us, you agree to first contact Coinbase Support via our Customer Support page (https://help.coinbase.com). If Coinbase Support is unable to resolve your dispute, you agree to follow our Formal Complaint Process. You begin this process by submitting our [complaint form](https://help.coinbase.com/en/coinbase/other-topics/other/how-to-send-a-complaint). If you would prefer to send a written complaint via mail, please include as much information as possible in describing your complaint, including your support ticket number, how you would like us to resolve the complaint, and any other relevant information to us at 82 Nassau St #61234, New York, NY 10038. The Formal Complaint Process is completed when Coinbase responds to your complaint or 45 business days after the date we receive your complaint, whichever occurs first. You agree to complete the Formal Complaint Process before filing an arbitration demand or action in small claims court.
 

--- a/apps/base-docs/docs/tools/onboarding.md
+++ b/apps/base-docs/docs/tools/onboarding.md
@@ -44,7 +44,7 @@ hide_table_of_contents: true
 
 ## Openfort
 
-[Openfort](https://openfort.xyz) is an infrastructure provider designed to simplify the development of games and gamified experiences across their suite of API endpoints. Authenticated users can instantly access the embedded, non-custodial [smart account](https://www.openfort.xyz/docs/guides/accounts/smart) natively in the game and sign blockchain transactions with one button. The Oepnfort platform is compatible with most EVM chains, including Base.
+[Openfort](https://openfort.xyz) is an infrastructure provider designed to simplify the development of games and gamified experiences across their suite of API endpoints. Authenticated users can instantly access the embedded, non-custodial [smart account](https://www.openfort.xyz/docs/guides/accounts/smart) natively in the game and sign blockchain transactions with one button. The Openfort platform is compatible with most EVM chains, including Base.
 
 Use [Auth Guide](https://www.openfort.xyz/docs/guides/auth/overview) to allow several onboarding methods into your game regardless of the platform. 
 
@@ -72,7 +72,7 @@ You can [get started with Privy here](https://docs.privy.io/guide/quickstart), a
 
 ## thirdweb
 
-[thirdweb](https://thirdweb.com/) is the full stack open source web3 solution for bringing web3 into ANY consumer application on ANY platform. Utilize our wide range of sdks on web, mobile, Unity/Unreal or through our cloud hosted engine service! Connect your users with EOA or social logins, create contracts for marketplaces or tokenize in-game items, handle thousands of transactions to build apps that scale, and provide a fiat onramper for your users. 
+[thirdweb](https://thirdweb.com/) is the full stack open source web3 solution for bringing web3 into ANY consumer application on ANY platform. Utilize our wide range of SDKs on web, mobile, Unity/Unreal or through our cloud hosted engine service! Connect your users with EOA or social logins, create contracts for marketplaces or tokenize in-game items, handle thousands of transactions to build apps that scale, and provide a fiat onramper for your users. 
 
 ---
 


### PR DESCRIPTION
1. **URL Format Fix:**
   - **Before**: [0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4](https://sepolia.basescan.org/0x94cC0AaC535CCDB3C01d6787D6413C739ae12b)
   - **After**: [0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4](https://sepolia.basescan.org/address/0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4)
   - **Explanation**: The URL format has been corrected by adding the `/address/` prefix before the contract address. This change ensures compliance with the standard URL format used on BaseScan, where all contract addresses should start with `/address/`.

2. **Formatting Correction in Section Title**:
   - **Before**: `### 19. Entire Agreement.`
   - **After**: `### 19. Entire Agreement`
   - **Explanation**: The period at the end of the section title was removed to ensure consistency in the formatting of section headers.

3. **Section Number Adjustment**:
   - **Before**: `### 26. Dispute Resolution, Arbitration Agreement, Class Action Waiver, And Jury Trial Waiver`
   - **After**: `### 27. Dispute Resolution, Arbitration Agreement, Class Action Waiver, And Jury Trial Waiver`
   - **Explanation**: The section number was updated from 26 to 27 to correct the sequential numbering of sections in the document.

4. **Fix for Typos:**
   - **Before**: `Oepnfort-Openfort`
   - **After**: `Openfort-Openfort`
   - **Explanation**: Fixed the typo "Oepnfort" to "Openfort" to maintain consistency and correct spelling.

5. **Fix for SDKs Typo**:
   - **Before**: `sdks-SDKs`
   - **After**: `SDKs-SDKs`
   - **Explanation**: Corrected the typo in the term "sdks" to ensure consistency in capitalization.