### PR TITLE
chore: add Nigerian translations (Igbo, Yoruba, Hausa) of "Base is for everyone

### DIFF
--- a/apps/web/src/components/base-org/root/SlidingTextSection/index.tsx
+++ b/apps/web/src/components/base-org/root/SlidingTextSection/index.tsx
@@ -8,7 +8,7 @@ import { CSSProperties, useRef } from 'react';
 export default function SlidingTextSection() {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const text = ' Base is for everyone - بایس للجمیع - Base es para todos - 基地适合所有人 - La Base è per tutti - Base est pour tout le monde - Base ni ya kila mtu - Base yɛ ma obiara - Base nye amesiame tɔ - Base ji he ni mɔ fɛɛ mɔ yɔɔ - Base är för alla - Base สำหรับทุกคน - Бейз для каждого - Бейз для кожного - ';
+  const text = ' Base is for everyone - بایس للجمیع - Base es para todos - 基地适合所有人 - La Base è per tutti - Base est pour tout le monde - Base ni ya kila mtu - Base yɛ ma obiara - Base nye amesiame tɔ - Base ji he ni mɔ fɛɛ mɔ yɔɔ - Base är för alla - Base สำหรับทุกคน - Бейз для каждого - Бейз для кожного - Base bụ maka onye ọ bụla - Base jẹ fun gbogbo eniyan - Base na kowa - ';
 
   const containerClasses = classNames(
     'relative w-full overflow-hidden rounded-2xl bg-blue p-8',


### PR DESCRIPTION
**What changed? Why?**
Added Igbo, Yoruba, and Hausa translations of "Base is for everyone" to improve accessibility for Nigerian users.

**Notes to reviewers**
N/A

**How has it been tested?**
Verified correct display of translations in the string and proper rendering on the homepage.