### PR TITLE
docs(tutorials): Remove geth archive snapshot url as we deprecated it

### DIFF
--- a/apps/base-docs/tutorials/docs/0_run-a-base-node.md
+++ b/apps/base-docs/tutorials/docs/0_run-a-base-node.md
@@ -117,7 +117,7 @@ We will be deprecating the Public Geth Archive Snapshots on _December 15th, 2024
 | Testnet | Geth   | Archive       | `wget https://sepolia-archive-snapshots.base.org/$(curl https://sepolia-archive-snapshots.base.org/latest)`           |
 | Testnet | Reth   | Archive       | `wget https://sepolia-reth-archive-snapshots.base.org/$(curl https://sepolia-reth-archive-snapshots.base.org/latest)` |
 | Mainnet | Geth   | Full          | `wget https://mainnet-full-snapshots.base.org/$(curl https://mainnet-full-snapshots.base.org/latest)`                 |
-| Mainnet | Geth   | Archive       | `wget https://mainnet-archive-snapshots.base.org/$(curl https://mainnet-archive-snapshots.base.org/latest)`           |
+| Mainnet | Geth   | Archive       | No longer supported           |
 | Mainnet | Reth   | Archive       | `wget https://mainnet-reth-archive-snapshots.base.org/$(curl https://mainnet-reth-archive-snapshots.base.org/latest)` |
 
 You'll then need to untar the downloaded snapshot and place the `geth` subfolder inside of it in the `geth-data` folder you created (unless you changed the location of your data directory).


### PR DESCRIPTION
**What changed? Why?**
Remove geth archive snapshot url as we deprecated it
**Notes to reviewers**
N/A
**How has it been tested?**
localhost