### PR TITLE
Update Greenhouse API URL

### DIFF
--- a/apps/web/src/constants.ts
+++ b/apps/web/src/constants.ts
@@ -5,7 +5,7 @@ export const nodeEnv = process.env.NODE_ENV;
 export const docsUrl = process.env.DOCS_URL ?? 'https://docs.base.org';
 export const bridgeUrl = process.env.BRIDGE_URL ?? 'https://bridge.base.org';
 export const greenhouseApiUrl =
-  process.env.GREENHOUSE_HTTPS ?? 'https://boards-api.greenhouse.io/v1';
+  process.env.GREENHOUSE_HTTPS ?? 'https://boards-api.greenhouse.io';
 export const mainnetLaunchBlogPostURL =
   process.env.MAINNET_LAUNCH_BLOG_POST_URL ?? 'https://base.mirror.xyz/';
 export const mainnetLaunchFlag = process.env.MAINNET_LAUNCH_FLAG ?? 'false';

--- a/libs/base-ui/constants.ts
+++ b/libs/base-ui/constants.ts
@@ -2,7 +2,7 @@ export const nodeEnv = process.env.NODE_ENV;
 export const docsUrl = process.env.DOCS_URL ?? 'https://docs.base.org';
 export const bridgeUrl = process.env.BRIDGE_URL ?? 'https://bridge.base.org';
 export const greenhouseApiUrl =
-  process.env.GREENHOUSE_HTTPS ?? 'https://boards-api.greenhouse.io/v1';
+  process.env.GREENHOUSE_HTTPS ?? 'https://boards-api.greenhouse.io';
 export const mainnetLaunchBlogPostURL =
   process.env.MAINNET_LAUNCH_BLOG_POST_URL ?? 'https://base.mirror.xyz/';
 export const mainnetLaunchFlag = process.env.MAINNET_LAUNCH_FLAG ?? 'false';


### PR DESCRIPTION

- Fixed non-working Greenhouse API endpoint by removing `/v1` suffix
- Changed URL from `https://boards-api.greenhouse.io/v1` to `https://boards-api.greenhouse.io`
- Verified the new endpoint is working correctly

This change ensures proper connectivity to the Greenhouse job board API.