### PR TITLE
Fix: Remove UK from EU countries list post-Brexit

### DIFF
--- a/apps/bridge/pages/api/tos.ts
+++ b/apps/bridge/pages/api/tos.ts
@@ -13,7 +13,6 @@ const EU_COUNTRIES = [
   'ES', // Spain
   'FI', // Finland
   'FR', // France
-  'GB', // United Kingdom
   'GR', // Greece
   'HU', // Hungary
   'HR', // Croatia


### PR DESCRIPTION
**What changed? Why?**
Removed `GB` (United Kingdom) from the EU countries list as the UK is no longer a member of the European Union since Brexit (January 31, 2020).

