### PR TITLE
Message Design Patterns

### DIFF
--- a/apps/base-docs/tutorials/docs/5_cross-chain-with-layerzero.md
+++ b/apps/base-docs/tutorials/docs/5_cross-chain-with-layerzero.md
@@ -354,7 +354,7 @@ contract ExampleContract is OApp {
 
 :::info
 
-Overriding the `_lzReceive` function allows you to provide any custom logic you wish when receiving messages, including making a call back to the source chain by invoking `_lzSend`. Visit the LayerZero [Message Design Patterns](https://docs.layerzero.network/contracts/message-design-patterns) for common messaging flows.
+Overriding the `_lzReceive` function allows you to provide any custom logic you wish when receiving messages, including making a call back to the source chain by invoking `_lzSend`. Visit the LayerZero [Message Design Patterns](https://docs.layerzero.network/v2/developers/evm/oapp/message-design-patterns) for common messaging flows.
 
 :::
 


### PR DESCRIPTION
Update LayerZero Message Design Patterns documentation link

Updated the outdated documentation URL to the new V2 path for Message Design Patterns in the cross-chain tutorial documentation.

Old: https://docs.layerzero.network/contracts/message-design-patterns
New: https://docs.layerzero.network/v2/developers/evm/oapp/message-design-patterns