### PR TITLE
Fix typos and spelling errors in documentation 

### DIFF
--- a/apps/web/app/(basenames)/name/[username]/opengraph-image.tsx
+++ b/apps/web/app/(basenames)/name/[username]/opengraph-image.tsx
@@ -71,7 +71,7 @@ export default async function OpenGraphImage(props: ImageRouteProps) {
   const chain = getChainForBasename(username as Basename);
   let imageSource = domainName + profilePicture.src;
 
-  // NOTE: Do we want to fail if the name doesn't exists?
+  // NOTE: Do we want to fail if the name doesn't exist?
   try {
     const client = getBasenamePublicClient(chain.id);
     const avatar = await client.getEnsText({

--- a/apps/web/pages/api/basenames/[name]/assets/cardImage.svg.tsx
+++ b/apps/web/pages/api/basenames/[name]/assets/cardImage.svg.tsx
@@ -73,7 +73,7 @@ export default async function handler(request: NextRequest) {
     logger.error('Error fetching basename Avatar:', error);
   }
 
-  // Using Satori for a SVG response
+  // Using Satori for an SVG response
   const svg = await satori(
     <div
       style={{

--- a/apps/web/pages/api/basenames/metadata/[tokenId].ts
+++ b/apps/web/pages/api/basenames/metadata/[tokenId].ts
@@ -56,7 +56,7 @@ export default async function GET(request: Request) {
     logger.error('Error getting token metadata', error);
   }
 
-  // Premints are hardcoded, the list will reduce when/if they get claimed
+  // Premints are hardcoded; the list will reduce when/if they are claimed
   if (!basenameFormatted && premintMapping[tokenId]) {
     basenameFormatted = formatBaseEthDomain(premintMapping[tokenId], chainId);
   }


### PR DESCRIPTION
This pull request addresses the following errors in the documentation:

"exists" -> "exist"
"a SVG" -> "an SVG"
"hardcoded, the list will reduce when/if they get claimed" -> "hardcoded; the list will reduce when/if they are claimed"
Thank you for your work, and I hope my pull request proves useful!