### PR TITLE
typo improvement

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   // Prettier
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true, // use ⌘-K S to format without saving
+  "editor.formatOnSave": true, // use ⌘-K S (or Ctrl-K S) to format without saving
 
   // Disable built-in formatters
   "html.format.enable": false,


### PR DESCRIPTION
"// use ⌘-K S to format without saving": It might be clearer to say "// use ⌘-K S (or Ctrl-K S) to format without saving", to ensure users who aren't using macOS can also understand the keyboard shortcut.


