### PR TITLE
fix: typos in documentation files

### DIFF
--- a/apps/web/src/utils/logger.ts
+++ b/apps/web/src/utils/logger.ts
@@ -30,7 +30,7 @@ class CustomLogger {
     let traceId: string | undefined;
     let spanId: string | undefined;
 
-    //TODO: initialice ddTrace through dd-tracer
+    //TODO: initialize ddTrace through dd-tracer
     if (ddTrace) {
       // Access trace information server-side
       const currentSpan = ddTrace.scope().active();


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `initialice` to `initialize`.

Please review the changes and let me know if any additional changes are needed.


