### PR TITLE
Improve Error Message Clarity and Grammar in `503 Page`

### DIFF
--- a/apps/bridge/pages/503.tsx
+++ b/apps/bridge/pages/503.tsx
@@ -20,9 +20,9 @@ export default memo(function ServerError() {
           <div className="mt-2 mb-2 flex h-full min-h-[440px] w-full flex-row items-center justify-center">
             <div className="flex flex-col items-center justify-center text-center">
               <Image src="/icons/empty-transaction.png" width="240" height="240" alt="" />
-              <h3 className="pt-16 font-display text-2xl text-white">Error has occurred</h3>
+              <h3 className="pt-16 font-display text-2xl text-white">An error has occurred</h3>
               <span className="pt-2 text-base text-[#8A919E]">
-                We encountered a problem with our servers. Please try refreshing.
+                We encountered a problem with our servers. Please try refreshing the page.
               </span>
               <Link
                 href="/"


### PR DESCRIPTION
**What changed?**
The error message in the `h3` tag was updated:
*From:* `Error has occurred`
*To:* `An error has occurred`
The error description in the `span` tag was updated:
*From:* `We encountered a problem with our servers. Please try refreshing.`
*To:* `We encountered a problem with our servers. Please try refreshing the page.`

**Why?**
1. Grammatical Improvement:
- The phrase "An error has occurred" is grammatically correct because it requires the indefinite article "An" before "error." This improves clarity and professionalism.
2. Improved Clarity in Instructions:
- Adding "the page" to "Please try refreshing" makes the instruction clearer, as users are explicitly directed to refresh the web page. This avoids potential confusion.

**Notes to reviewers**
- The changes aim to improve the user experience by making the error message more professional and clear.
- Ensure that the grammar updates are reflected consistently across the application if similar phrases exist elsewhere.
- Confirm that the design and alignment of text (e.g., with `className` styles) remain unaffected after these updates.
