### PR TITLE
Remove duplicate import statements

### DIFF
--- a/apps/base-docs/docs/tools/basenames-onchainkit-tutorial.md
+++ b/apps/base-docs/docs/tools/basenames-onchainkit-tutorial.md
@@ -102,8 +102,6 @@ Ensure Chain is Set to Base Be sure to set the `chain={base}` parameter; otherwi
 ```typescript title="src/components/basename.tsx"
 'use client';
 import React from 'react';
-'use client';
-import React from 'react';
 import { Avatar, Identity, Name, Address } from '@coinbase/onchainkit/identity';
 import { base } from 'viem/chains';
 

--- a/apps/base-docs/docs/tools/basenames-tutorial.md
+++ b/apps/base-docs/docs/tools/basenames-tutorial.md
@@ -58,7 +58,7 @@ To interact with the Base blockchain, you will need to update the wagmi configur
 
 Update your wagmi.ts file as follows:
 
-```typescript tile="wagmi.ts"
+```typescript title="wagmi.ts"
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';


### PR DESCRIPTION
Reason: Fixed incorrect attribute name from tile to title for proper code block metadata formatting. This ensures correct syntax highlighting and documentation rendering.

Reason: Removed duplicate 'use client' directive and React import statements. These declarations only need to appear once at the top of the file. Duplicate imports are unnecessary and can cause confusion in code maintenance.