### PR TITLE
Fixed in the comment from “desposit” to “deposit”.

### DIFF
--- a/apps/bridge/src/utils/transactions/isETHOrERC20Deposit.ts
+++ b/apps/bridge/src/utils/transactions/isETHOrERC20Deposit.ts
@@ -70,7 +70,7 @@ export function isETHOrERC20OrCCTPDeposit(tx: BlockExplorerTransaction) {
     return true;
   }
 
-  // ERC-20 desposit
+  // ERC-20 deposit
   if (tx.to === ERC20_DEPOSIT_ADDRESS) {
     const { functionName, args } = decodeFunctionData({
       abi: l1StandardBridgeABI,


### PR DESCRIPTION
**What changed? Why?**
Fixed a typo in the comment from “desposit” to “deposit”.
