### PR TITLE
fix: typos

### DIFF
--- a/apps/base-docs/tutorials/docs/5_basename-frames.md
+++ b/apps/base-docs/tutorials/docs/5_basename-frames.md
@@ -64,7 +64,7 @@ You can select any frame from the available options. For this tutorial, we’ll 
 
 Click on the dropdown menu to select the "Pay Me" Frame.
 
-![frame-payme-](../../assets/images/basenames-tutorial/show-preview.png)
+![frame-payme](../../assets/images/basenames-tutorial/show-preview.png)
 
 ## Preview the Frame
 


### PR DESCRIPTION
**Description correction:**
Corrected `frame-payme-` to `frame-payme`. In the image description, `frame-payme-` has an extra hyphen at the end of the word `payme`









