### PR TITLE
Typo fix Update 2_paymaster-sponsor-using-wagi.md

### DIFF
--- a/apps/base-docs/tutorials/docs/2_paymaster-sponsor-using-wagi.md
+++ b/apps/base-docs/tutorials/docs/2_paymaster-sponsor-using-wagi.md
@@ -136,7 +136,7 @@ In this step, we’ll create a new page in our project where users can mint an N
 
 In your project’s `src/app` folder, create a new file called `mint/page.tsx`. This file will contain the code to manage wallet connection, check for paymaster capabilities, and execute the minting action.
 
-:::info Experimenal Hooks and Capabilities
+:::info Experimental Hooks and Capabilities
 
 To ensure a smooth, gas-free NFT minting experience, it’s important to understand the purpose of two key hooks from Wagmi:
 


### PR DESCRIPTION
I fixed a typo in the 2_paymaster-sponsor-using-wagi.md file by correcting the word "Experimenal" to "Experimental" in a section heading.

Specific Change:
Before:
:::info Experimenal Hooks and Capabilities
After:
:::info Experimental Hooks and Capabilities
This ensures accurate spelling and improves the readability of the documentation.