### PR TITLE
Add verify.walletconnect.org to frame-src

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -119,7 +119,7 @@ const contentSecurityPolicy = {
     'https://unpkg.com/@lottiefiles/dotlottie-web@0.31.1/dist/dotlottie-player.wasm', // lottie player
     `https://${process.env.NEXT_PUBLIC_PINATA_GATEWAY_URL}`,
   ],
-  'frame-src': ['https://p.datadoghq.com', 'https://verify.walletconnect.org'],
+  'frame-src': ['https://p.datadoghq.com', 'https://verify.walletconnect.com', 'https://verify.walletconnect.org'],
   'frame-ancestors': ["'self'", baseXYZDomains],
   'form-action': ["'self'", baseXYZDomains],
   'img-src': [

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -119,7 +119,7 @@ const contentSecurityPolicy = {
     'https://unpkg.com/@lottiefiles/dotlottie-web@0.31.1/dist/dotlottie-player.wasm', // lottie player
     `https://${process.env.NEXT_PUBLIC_PINATA_GATEWAY_URL}`,
   ],
-  'frame-src': ['https://p.datadoghq.com'],
+  'frame-src': ['https://p.datadoghq.com', 'https://verify.walletconnect.org'],
   'frame-ancestors': ["'self'", baseXYZDomains],
   'form-action': ["'self'", baseXYZDomains],
   'img-src': [


### PR DESCRIPTION
Currently both WalletConnect and Rabby (which apparently uses WalletConnect) are broken on base.org. As a result, the BitBox02 hardware wallet is currently unusable with base.org.

I see blocked requests to both verify.walletconnect.com and verify.walletconnect.org to the same URL path; I have added both and confirmed (by locally overriding the response header) that this works with Rabby.

Fixes #1531.