### PR TITLE
docs(hardhat): Clarify API key is required

### DIFF
--- a/apps/base-docs/tutorials/docs/0_deploy-with-hardhat.md
+++ b/apps/base-docs/tutorials/docs/0_deploy-with-hardhat.md
@@ -291,7 +291,7 @@ etherscan: {
 
 :::info
 
-When verifying a contract with Basescan on testnet (Sepolia), an API key is not required. You can leave the value as `PLACEHOLDER_STRING`. On mainnet, you can get your Basescan API key from [here](https://basescan.org/myapikey) after you sign up for an account.
+You can get your Basescan API key from [basescan.org](https://basescan.org/myapikey) when you sign up for an account.
 
 :::
 


### PR DESCRIPTION
**What changed? Why?**

Basescan now requires an API key to verify contracts on Base Sepolia; this change updates to clarify where to get one

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost