### PR TITLE
docs: Fix incorrect URL in Routescan doc Update block-explorers.md

### DIFF
--- a/apps/base-docs/docs/tools/block-explorers.md
+++ b/apps/base-docs/docs/tools/block-explorers.md
@@ -84,7 +84,7 @@ A testnet explorer for [Base Sepolia](https://sepolia.basescan.org/) is also ava
 
 ## Routescan
 
-[Routescan](https://superscan.network/) superchain explorer allows you to search for transactions, addresses, tokens, prices and other activities taking place across all Superchain blockchains, including Base.
+[Routescan](https://routescan.io) superchain explorer allows you to search for transactions, addresses, tokens, prices and other activities taking place across all Superchain blockchains, including Base.
 
 ---
 


### PR DESCRIPTION
**What changed? Why?**

I noticed a small typo in the Routescan section where the URL was pointing to `superscan.network` instead of the correct `routescan.io`.

I've updated the link to the proper destination.

**Notes to reviewers**

This should help avoid any confusion for users trying to access Routescan.

