### PR TITLE
add marketing amplification guidelines

### DIFF
--- a/apps/web/src/components/GetStarted/GetNoticed.tsx
+++ b/apps/web/src/components/GetStarted/GetNoticed.tsx
@@ -22,12 +22,20 @@ export default async function GetNoticed() {
           classnames="bg-pink-60 border-pink-60"
         />
         <ResourceCard
-          title="Base Builds Channel"
-          description="Share your project on /base and /base-builds to get community feedback on Farcaster"
-          href="https://warpcast.com/~/channel/base-builds/?utm_source=dotorg&utm_medium=builderkit"
+          title="Marketing Amplification Guidelines"
+          description="Use our style guide and tag @base on X and Farcaster to be eligible for amplification"
+          href="https://github.com/base-org/brand-kit/blob/main/guides/editorial-style-guide.md"
           topLeft={<span className="font-mono">02</span>}
           topRight={<Icon name="diagonalUpArrow" width="16px" height="16px" />}
           classnames="bg-pink-80 border-pink-80"
+        />
+        <ResourceCard
+          title="Base Builds Channel"
+          description="Share your project on /base and /base-builds to get community feedback on Farcaster"
+          href="https://warpcast.com/~/channel/base-builds/?utm_source=dotorg&utm_medium=builderkit"
+          topLeft={<span className="font-mono">03</span>}
+          topRight={<Icon name="diagonalUpArrow" width="16px" height="16px" />}
+          classnames="bg-pink-60 border-pink-60"
         />
       </div>
     </div>


### PR DESCRIPTION
**What changed? Why?**
* Added marketing amplification guidelines to Get Noticed section of `/build`
![image](https://github.com/user-attachments/assets/bda45b56-d9f3-458d-8fa4-2de059a47e50)


**Notes to reviewers**

**How has it been tested?**
locally