### PR TITLE
Update BridgeCards.tsx

### DIFF
--- a/apps/bridge/src/components/DeprecationContent/BridgeCards.tsx
+++ b/apps/bridge/src/components/DeprecationContent/BridgeCards.tsx
@@ -55,7 +55,7 @@ function BridgeCard({ name, url, logo, color, team }: (typeof bridges)[0]) {
       >
         <Image src={logo} alt={name} className="mb-4" />
       </div>
-      <div className="flex w-full flex-row items-start justify-between bg-gray p-12 group-hover:bg-hovergray">
+      <div className="flex w-full flex-row items-start justify-between bg-gray p-12 group-hover:bg-hover-gray">
         <div className="flex flex-col">
           <h2 className="font-mono text-3xl uppercase">{name}</h2>
           <p className="mt-2 text-xl text-muted">By {team}</p>


### PR DESCRIPTION
This update standardizes the CSS class naming convention by changing bg-hovergray to bg-hover-gray. The hyphenated version (bg-hover-gray) is more consistent with common CSS naming conventions and matches other similar class names in the codebase. This improves code maintainability and readability.