### PR TITLE
Fix Neynar API naming

### DIFF
--- a/apps/web/src/components/NeymarFrame/index.tsx
+++ b/apps/web/src/components/NeymarFrame/index.tsx
@@ -1,7 +1,7 @@
 import ImageWithLoading from 'apps/web/src/components/ImageWithLoading';
 import { NeynarFrame } from 'apps/web/src/utils/frames';
 
-// Frame displayed from Neymar API data
+// Frame displayed from Neynar API data
 // No buttons or interactions for now, just a link to the frame source
 export default function NeymarFrame({ frame }: { hash: string; frame: NeynarFrame }) {
   return (


### PR DESCRIPTION



Reason: Correcting misspelling of the Neynar API service name (was incorrectly using "Neymar" - footballer's name). This ensures consistency across the codebase.

