### PR TITLE
docs: Fixing typos

### DIFF
--- a/apps/web/src/hooks/useRegisterNameCallback.ts
+++ b/apps/web/src/hooks/useRegisterNameCallback.ts
@@ -94,7 +94,7 @@ export function useRegisterNameCallback(
       owner: address, // The address of the owner for the name.
       duration: secondsInYears(years), // The duration of the registration in seconds.
       resolver: USERNAME_L2_RESOLVER_ADDRESSES[basenameChain.id], // The address of the resolver to set for this name.
-      data: [addressData, nameData], //  Multicallable data bytes for setting records in the associated resolver upon reigstration.
+      data: [addressData, nameData], //  Multicallable data bytes for setting records in the associated resolver upon registration.
       reverseRecord, // Bool to decide whether to set this name as the "primary" name for the `owner`.
     };
 

--- a/apps/web/src/hooks/useWriteBaseEnsTextRecords.ts
+++ b/apps/web/src/hooks/useWriteBaseEnsTextRecords.ts
@@ -18,11 +18,11 @@ export type UseWriteBaseEnsTextRecordsProps = {
 /*
   A hook to set update TextRecords in a batch
 
-  Responsabilities:
+  Responsibilities:
   - Get existing TextRecords
   - Keep track of TextRecords updates
   - Wait for the transaction to be processed
-  - Refetch records on successfull request  
+  - Refetch records on successful request  
   - Log errors and analytics accordingly
 
 */

--- a/apps/web/src/hooks/useWriteContractWithReceipt.ts
+++ b/apps/web/src/hooks/useWriteContractWithReceipt.ts
@@ -8,7 +8,7 @@ import { useAccount, useSwitchChain, useWaitForTransactionReceipt, useWriteContr
 /*
   A hook to request and track a wallet write transaction
 
-  Responsabilities:
+  Responsibilities:
   - Track the wallet request status
   - Track the transaction receipt and status
   - Log analytics & error


### PR DESCRIPTION
Hi! This PR fixes a few typos in comments across hook files:

- **`useRegisterNameCallback.ts`**: corrected "reigstration" to "registration".
- **`useWriteBaseEnsTextRecords.ts`**: corrected "Responsabilities" to "Responsibilities" and "successfull" to "successful".
- **`useWriteContractWithReceipt.ts`**: corrected "Responsabilities" to "Responsibilities".
