### PR TITLE
Fix URL

### DIFF
--- a/apps/base-docs/docs/contracts.md
+++ b/apps/base-docs/docs/contracts.md
@@ -81,7 +81,7 @@ This page lists contract addresses for onchain apps that we have deployed.
 | `v3Migrator`                         | [0xCbf8b7f80800bd4888Fbc7bf1713B80FE4E23E10](https://sepolia.basescan.org/address/0xCbf8b7f80800bd4888Fbc7bf1713B80FE4E23E10) |
 | `v3Staker`                           | [0x62725F55f50bdE240aCa3e740D47298CAc8d57D5](https://sepolia.basescan.org/address/0x62725F55f50bdE240aCa3e740D47298CAc8d57D5) |
 | `quoterV2`                           | [0xC5290058841028F1614F3A6F0F5816cAd0df5E27](https://sepolia.basescan.org/address/0xC5290058841028F1614F3A6F0F5816cAd0df5E27) |
-| `swapRouter`                         | [0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4](https://sepolia.basescan.org/0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4)         |
+| `swapRouter`                         | [0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4](https://sepolia.basescan.org/address/0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4) |        |
 
 #### Testnet interfaces
 


### PR DESCRIPTION
In the Base Testnet (Sepolia) section, the swapRouter contract link is missing "/address/" in the URL, which doesn't match the format of other links.
