### PR TITLE
Fix typos in Base Learn badge description and comments

### DIFF
--- a/apps/web/src/components/Basenames/UsernameProfileSectionBadges/Badges/index.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionBadges/Badges/index.tsx
@@ -104,7 +104,7 @@ export const BADGE_INFO: Record<
     name: 'Base Learn Newcomer',
     title: 'Base Learn Newcomer',
     description:
-      'You completed these Base Learn Modules: Basic Contracts, Storage, Control Structures, Arrays, Inheritance, Mappings, Structs, Error Triags, New Keyword, and Imports.',
+      'You completed these Base Learn Modules: Basic Contracts, Storage, Control Structures, Arrays, Inheritance, Mappings, Structs, Error Flags, New Keyword, and Imports.',
     cta: 'Go to Base Learn',
     ctaLink: 'https://guild.xyz/base/base-learn',
     image: baseLearnNewcomer,

--- a/apps/web/src/components/Basenames/UsernameProfileSectionBadges/hooks/useBuildathon.ts
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionBadges/hooks/useBuildathon.ts
@@ -18,6 +18,6 @@ export default function useBuildathonParticipant(address?: `0x${string}`): {
   });
 
   if (!balanceOf) return { isParticipant: false, isWinner: false };
-  // winners will have both a particpant SBT and a winner SBT
+  // winners will have both a participant SBT and a winner SBT
   return { isParticipant: balanceOf > 0, isWinner: balanceOf > 1 };
 }


### PR DESCRIPTION

- Fix "Error Triags" -> "Error Flags" in badge description
- Fix "particpant" -> "participant" in comment

These changes correct spelling errors in both user-facing content and code comments to improve clarity and professionalism.

Files changed:
- apps/web/src/components/Basenames/UsernameProfileSectionBadges/Badges/index.tsx
- apps/web/src/components/Basenames/UsernameProfileSectionBadges/hooks/useBuildathon.ts