### PR TITLE
fix: Remove 'GB' from EU_COUNTRIES array post-Brexit

### DIFF
--- a/apps/bridge/pages/api/tos.ts
+++ b/apps/bridge/pages/api/tos.ts
@@ -13,7 +13,7 @@ const EU_COUNTRIES = [
   'ES', // Spain
   'FI', // Finland
   'FR', // France
-  'GB', // United Kingdom
+// 'GB', // United Kingdom (no longer an EU member)
   'GR', // Greece
   'HU', // Hungary
   'HR', // Croatia


### PR DESCRIPTION
**What changed? Why?**

I noticed that the `EU_COUNTRIES` array still includes 'GB' (United Kingdom) as a member. Since the UK is no longer part of the European Union, this is no longer accurate.

I've removed 'GB' from the array to reflect this change.