### PR TITLE
chore(sidebar): Add link to base.org/stats

### DIFF
--- a/apps/base-docs/sidebars.js
+++ b/apps/base-docs/sidebars.js
@@ -95,6 +95,11 @@ module.exports = {
     },
     {
       type: 'link',
+      label: 'Metrics',
+      href: 'https://base.org/stats',
+    },
+    {
+      type: 'link',
       label: 'Status',
       href: 'https://status.base.org',
     },


### PR DESCRIPTION
**What changed? Why?**

Add a link to base.org/stats in our docs

**Notes to reviewers**

![2025-01-23 at 11 08 05@2x](https://github.com/user-attachments/assets/f850dd7d-b78f-49a8-9995-c64be2714eae)

**How has it been tested?**

Localhost