### PR TITLE
fix: update broken links in docs

### DIFF
--- a/apps/base-docs/docs/tools/onboarding.md
+++ b/apps/base-docs/docs/tools/onboarding.md
@@ -48,9 +48,9 @@ hide_table_of_contents: true
 
 ## Openfort
 
-[Openfort](https://openfort.xyz) is an infrastructure provider designed to simplify the development of games and gamified experiences across their suite of API endpoints. Authenticated users can instantly access the embedded, non-custodial [smart account](https://www.openfort.xyz/docs/guides/accounts/smart) natively in the game and sign blockchain transactions with one button. The Openfort platform is compatible with most EVM chains, including Base.
+[Openfort](https://openfort.xyz) is an infrastructure provider designed to simplify the development of games and gamified experiences across their suite of API endpoints. Authenticated users can instantly access the embedded, non-custodial [smart account](https://www.openfort.xyz/docs/guides/javascript/smart-wallet/connected-wallets) natively in the game and sign blockchain transactions with one button. The Openfort platform is compatible with most EVM chains, including Base.
 
-Use [Auth Guide](https://www.openfort.xyz/docs/guides/auth/overview) to allow several onboarding methods into your game regardless of the platform. 
+Use [Auth Guide](https://www.openfort.xyz/docs/guides/javascript/auth) to allow several onboarding methods into your game regardless of the platform. 
 
 ---
 

--- a/apps/base-docs/tutorials/docs/2_1_simple-onchain-nfts.md
+++ b/apps/base-docs/tutorials/docs/2_1_simple-onchain-nfts.md
@@ -1055,11 +1055,11 @@ contract RandomColorNFT is ERC721 {
 
 ---
 
-[Base Camp]: https://base.org.camp
-[ERC-721 Tokens]: https://docs.base.org/base-camp/docs/erc-721-token/erc-721-standard-video
+[Base Camp]: https://docs.base.org/base-learn/docs/welcome/
+[ERC-721 Tokens]: https://docs.base.org/base-learn/docs/erc-721-token/erc-721-standard-video/
 [IPFS]: https://ipfs.tech/
 [Base64]: https://en.wikipedia.org/wiki/Base64
-[Hardhat and Hardhat Deploy]: https://docs.base.org/base-camp/docs/hardhat-deploy/hardhat-deploy-sbs
+[Hardhat and Hardhat Deploy]: https://docs.base.org/base-learn/docs/hardhat-deploy/hardhat-deploy-sbs
 [testnet version of Opensea]: https://testnets.opensea.io/
 [sample project]: https://github.com/base-org/land-sea-and-sky
 [Sample Art]: https://github.com/base-org/land-sea-and-sky/tree/master/Final_SVGs


### PR DESCRIPTION
## What changed? Why?
Hi! This PR addresses broken links in the documentation, ensuring they now point to the correct and updated resources. The changes are focused on maintaining seamless navigation and providing accurate references.