### PR TITLE
fix: update broken links in `tutorials/docs`

### DIFF
--- a/apps/base-docs/tutorials/docs/4_account-abstraction-with-privy-and-base-paymaster.md
+++ b/apps/base-docs/tutorials/docs/4_account-abstraction-with-privy-and-base-paymaster.md
@@ -773,9 +773,8 @@ In this article, we've explored the transformative potential of Account Abstract
 [Base Learn]: https://base.org/learn
 [Next.js]: https://nextjs.org/
 [Base Paymaster]: https://github.com/base-org/paymaster
-[Privy]: https://www.privy.dev/
+[Privy]: https://www.privy.io/
 [Alchemy's Account Kit]: https://www.alchemy.com/account-kit
-[Privy]: https://www.privy.dev/
 [https://docs.privy.io/guide/frontend/embedded/overview]: https://docs.privy.io/guide/frontend/embedded/overview
 [Alchemy's Account Kit]: https://www.alchemy.com/account-kit
 [Privy's Quick Start]: https://docs.privy.io/guide/quickstart

--- a/apps/base-docs/tutorials/docs/5_cross-chain-with-layerzero.md
+++ b/apps/base-docs/tutorials/docs/5_cross-chain-with-layerzero.md
@@ -171,11 +171,11 @@ abstract contract OApp is OAppSender, OAppReceiver {
 
 :::info
 
-You can view the source code for this contract on [GitHub](https://github.com/LayerZero-Labs/LayerZero-v2/blob/main/oapp/contracts/oapp/OApp.sol).
+You can view the source code for this contract on [GitHub](https://github.com/LayerZero-Labs/LayerZero-v2/blob/main/packages/layerzero-v2/evm/oapp/contracts/oapp/OApp.sol).
 
 :::
 
-To get started using LayerZero, developers simply need to inherit from the [OApp](https://github.com/LayerZero-Labs/LayerZero-v2/blob/main/oapp/contracts/oapp/OApp.sol) contract, and implement the following two inherited functions:
+To get started using LayerZero, developers simply need to inherit from the [OApp](https://github.com/LayerZero-Labs/LayerZero-v2/blob/main/packages/layerzero-v2/evm/oapp/contracts/oapp/OApp.sol) contract, and implement the following two inherited functions:
 
 - `_lzSend`: A function used to send an omnichain message
 - `_lzReceive`: A function used to receive an omnichain message


### PR DESCRIPTION
**What changed? Why?**
Hi! I updated incorrect and outdated links in two tutorial files:
  - Fixed duplicate and broken links in `4_account-abstraction-with-privy-and-base-paymaster.md`.
  - Corrected a broken link in `5_cross-chain-with-layerzero.md`.
