### PR TITLE
chore: add Polish & Dutch translations of `Base is for everyone` on the homepage

### DIFF
--- a/apps/web/src/components/base-org/root/SlidingTextSection/index.tsx
+++ b/apps/web/src/components/base-org/root/SlidingTextSection/index.tsx
@@ -8,7 +8,7 @@ import { CSSProperties, useRef } from 'react';
 export default function SlidingTextSection() {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const text = ' Base is for everyone - بایس للجمیع - Base es para todos - 基地适合所有人 - La Base è per tutti - Base est pour tout le monde - Base ni ya kila mtu - Base yɛ ma obiara - Base nye amesiame tɔ - Base ji he ni mɔ fɛɛ mɔ yɔɔ - Base är för alla - Base สำหรับทุกคน - Бейз для каждого - Бейз для кожного - Base ist für alle - Base herkes içindir - ';
+  const text = ' Base is for everyone - بایس للجمیع - Base es para todos - 基地适合所有人 - La Base è per tutti - Base est pour tout le monde - Base ni ya kila mtu - Base yɛ ma obiara - Base nye amesiame tɔ - Base ji he ni mɔ fɛɛ mɔ yɔɔ - Base är för alla - Base สำหรับทุกคน - Бейз для каждого - Бейз для кожного - Base ist für alle - Base herkes içindir - Base jest dla każdego - Base is voor iedereen - ';
 
   const containerClasses = classNames(
     'relative w-full overflow-hidden rounded-2xl bg-blue p-8',


### PR DESCRIPTION
**What changed? Why?**
add Polish & Dutch translations of `Base is for everyone` on the homepage
