### PR TITLE
Fix typos in typeScript files (`models.tsx`, `index.tsx`, `[alreadyClaimedName].ts`)

### DIFF
--- a/apps/web/pages/api/name/[alreadyClaimedName].ts
+++ b/apps/web/pages/api/name/[alreadyClaimedName].ts
@@ -63,7 +63,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ApiResponse>) {
     res.status(200).json({ suggestion: JSON.parse(suggestion.response) as string[] });
   } catch (e) {
     if (e instanceof Error) {
-      logger.error('error generating sugestions', e);
+      logger.error('error generating suggestions', e);
       res.status(500).json({ error: `failed to generate suggestions` });
     }
   }

--- a/apps/web/src/components/Basenames/UsernameTextRecordInlineField/index.tsx
+++ b/apps/web/src/components/Basenames/UsernameTextRecordInlineField/index.tsx
@@ -66,15 +66,15 @@ export default function UsernameTextRecordInlineField({
   disabled = false,
 }: UsernameTextRecordInlineFieldProps) {
   const usernameSocialHandleFieldId = useId();
-  const [validationError, setValiationHint] = useState<string>('');
+  const [validationError, setValidationHint] = useState<string>('');
   const onTextRecordChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       const textRecordValue = event.target.value;
 
       if (!validateTextRecordValue(textRecordKey, textRecordValue)) {
-        setValiationHint(textRecordHintForDisplay(textRecordKey));
+        setValidationHint(textRecordHintForDisplay(textRecordKey));
       } else {
-        setValiationHint('');
+        setValidationHint('');
       }
 
       if (onChange) onChange(textRecordKey, textRecordValue);

--- a/apps/web/src/components/ThreeHero/models.tsx
+++ b/apps/web/src/components/ThreeHero/models.tsx
@@ -7,7 +7,7 @@ import { useMediaQuery } from 'usehooks-ts';
 import dynamic from 'next/dynamic';
 
 // Assets
-import controlerModel from './assets/controller.glb';
+import controllerModel from './assets/controller.glb';
 import ethModel from './assets/eth.glb';
 import globeModel from './assets/globe.glb';
 import phoneModel from './assets/phone.glb';
@@ -229,7 +229,7 @@ export function Lightning() {
 }
 
 export function Controller(props: MeshProps) {
-  const { nodes } = useGLTF(controlerModel);
+  const { nodes } = useGLTF(controllerModel);
   const model = nodes.Controller as Mesh;
   return (
     <PhysicsMesh>


### PR DESCRIPTION
1. Fixed the spelling of "suggestions" in `[alreadyClaimedName].ts`.
2. Corrected the typo of "validationError" to "setValidationHint" in `index.tsx`.
3. Adjusted the spelling of "controllerModel" in `models.tsx` for consistency.

### _Summary_
- Fixed typographical errors to enhance code quality.