### PR TITLE
fix: typos

### DIFF
--- a/apps/web/src/components/ThreeHero/DynamicRigidBody.tsx
+++ b/apps/web/src/components/ThreeHero/DynamicRigidBody.tsx
@@ -10,7 +10,7 @@ export const DynamicRigidBody = forwardRef<RapierRigidBody, RigidBodyProps>(
     const [RigidBodyDynamic, setRigidBody] = useState<typeof RigidBody>();
     const { logError } = useErrors();
 
-    // Import needs to happens on render
+    // Import needs to happen on render
     useEffect(() => {
       import('@react-three/rapier')
         .then((mod) => {


### PR DESCRIPTION
Updated the comment from "Import needs to `happens` on render" to "Import needs to `happen` on render" for correct grammatical structure