### PR TITLE
 Fix Typographical Errors in Documentation

### DIFF
--- a/apps/base-docs/tutorials/docs/2_ock-checkout-tutorial.md
+++ b/apps/base-docs/tutorials/docs/2_ock-checkout-tutorial.md
@@ -1,5 +1,5 @@
 ---
-title: 'Build a eCommerce App using Coinbase Commerce and OnchainKit'
+title: 'Build an eCommerce App using Coinbase Commerce and OnchainKit'
 slug: /coinbase-commerce-onchainkit-checkout
 description: Learn how to integrate Coinbase Commerce payments into your application using OnchainKit.
 author: hughescoin
@@ -24,7 +24,7 @@ displayed_sidebar: null
 # Build a eCommerce App using Coinbase Commerce and OnchainKit
 
 Looking to sell items and receive crypto on Base? Well, look no further!
-This tutorial will guide you through the process of integrating Coinbase Commerce products into your application using OnchainKit. By the end of the tutorial you will be able to spin up a demo store that allows you to sell products for crypto. If you customers do not have crypto wallets, they can easily sign up with a few clicks using [Passkeys].
+This tutorial will guide you through the process of integrating Coinbase Commerce products into your application using OnchainKit. By the end of the tutorial you will be able to spin up a demo store that allows you to sell products for crypto. If your customers do not have crypto wallets, they can easily sign up with a few clicks using [Passkeys].
 
 ## Prerequisites
 

--- a/apps/base-docs/tutorials/docs/2_ock-checkout-tutorial.md
+++ b/apps/base-docs/tutorials/docs/2_ock-checkout-tutorial.md
@@ -21,7 +21,7 @@ hide_table_of_contents: false
 displayed_sidebar: null
 ---
 
-# Build a eCommerce App using Coinbase Commerce and OnchainKit
+# Build an eCommerce App using Coinbase Commerce and OnchainKit
 
 Looking to sell items and receive crypto on Base? Well, look no further!
 This tutorial will guide you through the process of integrating Coinbase Commerce products into your application using OnchainKit. By the end of the tutorial you will be able to spin up a demo store that allows you to sell products for crypto. If your customers do not have crypto wallets, they can easily sign up with a few clicks using [Passkeys].

--- a/apps/base-docs/tutorials/docs/5_farcaster-to-openframe.md
+++ b/apps/base-docs/tutorials/docs/5_farcaster-to-openframe.md
@@ -271,7 +271,7 @@ export const dynamic = 'force-dynamic';
 
 Repeat this process for any of the additional routes you may want to convert from Farcaster Frames to Open Frames.
 
-## Redploy your frame
+## Redeploy your frame
 
 Before redeploying your Frame check how the routes differ using the [Frame Debugger]. The frame debugger should be used to validate that your frame follows the Openframe protocol spec.
 


### PR DESCRIPTION



### Changes Made
1. **File:** `apps/base-docs/tutorials/docs/5_farcaster-to-openframe.md`
   - **Old Word:** `Redploy`
   - **New Word:** `Redeploy`
   - **Reason:** Correct spelling for professionalism and clarity.

2. **File:** `apps/base-docs/tutorials/docs/5_farcaster-to-openframe.md`
   - **Old Header:** `# Build a eCommerce 
   - **New Header:** `# Build an eCommerce 
   - **Reason:** "an" is grammatically correct before "eCommerce" for better readability.

### Conclusion
These changes enhance the accuracy and professionalism of the documentation.