### PR TITLE
docs: Updated WalletConnect to Reown Link Update 01_basename_social_d…

### DIFF
--- a/apps/base-docs/tutorials/docs/01_basename_social_dropdown.md
+++ b/apps/base-docs/tutorials/docs/01_basename_social_dropdown.md
@@ -79,7 +79,7 @@ NEXT_PUBLIC_CDP_API_KEY=<YOUR_CDP_API_KEY>
 # ~~~
 NEXT_PUBLIC_ENVIRONMENT=localhost
 
-# See https://cloud.walletconnect.com/
+# See https://cloud.reown.com
 NEXT_PUBLIC_WC_PROJECT_ID=<YOUR_WC_PROJECT_ID>
 
 ```


### PR DESCRIPTION
**What changed? Why?**

I noticed the WalletConnect link was outdated since they rebranded to Reown. I’ve updated the link to reflect this change. The fix ensures users are directed to the correct resource.

**Notes to reviewers**

Based.


