### PR TITLE
fix: GasPriceDropdown denomination

### DIFF
--- a/apps/web/src/components/base-org/shared/TopNavigation/GasPriceDropdown.tsx
+++ b/apps/web/src/components/base-org/shared/TopNavigation/GasPriceDropdown.tsx
@@ -40,7 +40,7 @@ export function GasPriceDropdown() {
           <Icon name="blueCircle" color="currentColor" height="0.75rem" width="0.75rem" />
         </span>
         <strong>{baseGasPriceInWei ? convertWeiToMwei(baseGasPriceInWei) : <>&mdash;</>}</strong>
-        <small>Mgwei</small>
+        <small>Mwei</small>
       </div>
       <div className="absolute left-0 top-full hidden pt-2 group-hover:inline-block">
         <Card innerClassName="p-4 bg-[#191919]">
@@ -49,14 +49,14 @@ export function GasPriceDropdown() {
               <strong className="font-normal">{base.name}</strong>
               <span className="opacity-50">
                 {baseGasPriceInWei ? convertWeiToMwei(baseGasPriceInWei) : <>&mdash;</>}{' '}
-                <span>Mgwei</span>
+                <span>Mwei</span>
               </span>
             </li>
             <li className="flex gap-2">
               <strong className="font-normal">{mainnet.name}</strong>
               <span className="opacity-50">
                 {mainnetGasPriceInWei ? convertWeiToMwei(mainnetGasPriceInWei) : <>&mdash;</>}{' '}
-                <span>Mgwei</span>
+                <span>Mwei</span>
               </span>
             </li>
           </ul>


### PR DESCRIPTION
**What changed? Why?**
current:
![image](https://github.com/user-attachments/assets/6ef34da8-f4e8-4193-ace4-1066419d46c4)

This fixes the denomination from "Mgwei" to "Mwei":

**Notes to reviewers**

**How has it been tested?**
