### PR TITLE
feat: add AI ecosystem category

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,12 @@ If you're a builder who wants to add or update your project on the [Base Ecosyst
    - description: A brief description of your project, must be less than 200 characters
    - url: Your project's website URL
    - imageUrl: Path to your project's logo image
-   - category: Your project's category, _one_ of: `consumer`, `defi`, `infra`, `onramp`, `wallet`
+   - category: Your project's category, _one_ of: `ai`, `consumer`, `defi`, `infra`, `onramp`, `wallet`
    - subcategory: Your project's subcategory, with the following options associated with each category
+     - `ai`: Simply add `ai` as the subcategory as well
      - `consumer`: _One_ of `creator`, `crypto taxes`, `dao`, `gaming`, `messaging`, `music`, `nft`, `payments`, `real world`, `social`
      - `defi`: _One_ of `dex`, `dex aggregator`, `insurance`, `lending/borrowing`, `liquidity management`, `portfolio`, `stablecoin`, `yield vault`
-     - `infra`: _One_ of `ai`, `bridge`, `data`, `depin`, `developer tool`, `identity`, `node provider`, `raas`, `security`
+     - `infra`: _One_ of `bridge`, `data`, `depin`, `developer tool`, `identity`, `node provider`, `raas`, `security`
      - `onramp`: _One_ of `centralized exchange`, `fiat on-ramp`
      - `wallet`: _One_ of `account abstraction`, `multisig`, `self-custody`
 

--- a/apps/web/src/components/Ecosystem/Card.tsx
+++ b/apps/web/src/components/Ecosystem/Card.tsx
@@ -58,9 +58,11 @@ export default function EcosystemCard({
               </span>
             </div>
             <div className="flex h-6 flex-col justify-center rounded-[100px] bg-black px-2 py-1">
-              <span className="rounded-full border border-gray-muted px-2 py-1 font-mono text-[10px] uppercase text-gray-muted">
-                {subcategory}
-              </span>
+              {subcategory !== category && (
+                <span className="rounded-full border border-gray-muted px-2 py-1 font-mono text-[10px] uppercase text-gray-muted">
+                  {subcategory}
+                </span>
+              )}
             </div>
           </div>
         </div>

--- a/apps/web/src/components/Ecosystem/Content.tsx
+++ b/apps/web/src/components/Ecosystem/Content.tsx
@@ -19,6 +19,7 @@ export type EcosystemApp = {
 };
 
 const config: Record<string, string[]> = {
+  ai: ['ai'],
   wallet: ['account abstraction', 'multisig', 'self-custody'],
   defi: [
     'dex',

--- a/apps/web/src/components/Ecosystem/EcosystemFilters.tsx
+++ b/apps/web/src/components/Ecosystem/EcosystemFilters.tsx
@@ -70,6 +70,21 @@ export function EcosystemFilters({
             >
               {category}
             </button>
+          ) : category === 'ai' ? (
+            <button
+              type="button"
+              key={category}
+              onClick={() => handleCategorySelect('ai')}
+              className={classNames(
+                'h-10 whitespace-nowrap rounded-full border border-white/20 px-4 uppercase tracking-wider transition-colors',
+                {
+                  'bg-white text-black': categoryIsSelected,
+                  'text-white/50 hover:bg-white/20 hover:text-white': !categoryIsSelected,
+                },
+              )}
+            >
+              {category}
+            </button>
           ) : (
             <Popover.Root key={category}>
               <div className="flex h-10 items-stretch">

--- a/apps/web/src/data/ecosystem.json
+++ b/apps/web/src/data/ecosystem.json
@@ -332,7 +332,7 @@
     "description": "Brian offers a non custodial solution to perform transactions, research web3 info and deploy smart contracts via prompting.",
     "url": "https://www.brianknows.org/",
     "imageUrl": "/images/partners/brian.webp",
-    "category": "infra",
+    "category": "ai",
     "subcategory": "ai"
   },
   {
@@ -2436,7 +2436,7 @@
     "description": "Non-custodial trading bot powered by smart contract wallets. Offers advanced DEX trading tools: from limit and trailing orders to DCA, Grid, Gems Sniper bots and much more",
     "url": "https://goodcrypto.app/x",
     "imageUrl": "/images/partners/goodcryptox.png",
-    "category": "infra",
+    "category": "ai",
     "subcategory": "ai"
   },
   {
@@ -3044,7 +3044,7 @@
     "description": "OpenCoin AI is a series of AI-powered applications fueled by real-time cross-chain data.",
     "url": "https://opencoin.ai",
     "imageUrl": "/images/partners/opencoin.png",
-    "category": "infra",
+    "category": "ai",
     "subcategory": "ai"
   },
   {
@@ -3228,7 +3228,7 @@
     "description": "AI-Optimized Yield and Liquidity Strategies",
     "url": "https://mozaic.finance/",
     "imageUrl": "/images/partners/mozaic.jpg",
-    "category": "infra",
+    "category": "ai",
     "subcategory": "ai"
   },
   {
@@ -3657,7 +3657,7 @@
   },
   {
     "name": "BlockAI",
-    "category": "infra",
+    "category": "ai",
     "subcategory": "ai",
     "description": "BlockAI combines blockchain and AI to offer decentralized access to innovative tools like Text and image generation, video summarization, games, etc.",
     "url": "https://base.blockai.dev",
@@ -3681,7 +3681,7 @@
   },
   {
     "name": "Virtuals Protocol",
-    "category": "infra",
+    "category": "ai",
     "subcategory": "ai",
     "description": "Virtuals Protocol is building a Society of AI Agents onchain",
     "url": "https://app.virtuals.io/",
@@ -3704,10 +3704,10 @@
     "subcategory": "gaming"
   },
   {
-    "category": "infra",
     "description": "Venice is a private, uncensored AI app with an API for agents and developers. Powered by decentralized inference and open-source models, Venice delivers unrestricted access to AI without storing your data.",
     "imageUrl": "/images/partners/venice.svg",
     "name": "Venice",
+    "category": "ai",
     "subcategory": "ai",
     "url": "https://venice.ai/"
   },
@@ -3756,7 +3756,7 @@
     "description": "TIG redefines the frontier of computational research by transforming proof-of-work into a global engine for open, autonomous innovation.",
     "url": "https://www.tig.foundation/",
     "imageUrl": "/images/partners/the-innovation-game.png",
-    "category": "infra",
+    "category": "ai",
     "subcategory": "ai"
   },
   {
@@ -3916,7 +3916,7 @@
     "description": "Masa is a leading real-time data network for AI agents and applications. Get free, structured, high-quality, real-time data for your AI Agents today.",
     "url": "https://masa.ai",
     "imageUrl": "/images/partners/masa.png",
-    "category": "infra",
+    "category": "ai",
     "subcategory": "ai"
   },
   {
@@ -3956,7 +3956,7 @@
     "description": "Xenocognitive Finance: Autonomous financial agents that transform DeFi complexity into optimized strategies, combining continuous market intelligence with non-custodial security.",
     "url": "https://arma.xyz/",
     "imageUrl": "/images/partners/giza.svg",
-    "category": "infra",
+    "category": "ai",
     "subcategory": "ai"
   },
   {
@@ -3964,7 +3964,7 @@
     "description": "Warden Protocol enables developers to build autonomous, smart contract-native AI agents on Base. Our protocol seamlessly integrates verified AI inferences directly into smart contracts, allowing you to create sophisticated automated agents that execute complex strategies based on AI model outputs. With Warden, your agents can process and verify multiple AI inferences in a single transaction and make autonomous on-chain decisions. Build the next wave of AI agents on Base with enterprise-grade security and cross-chain compatibility.",
     "url": "https://docs.wardenprotocol.org/build-an-agent/warden-agent-kit/introduction",
     "imageUrl": "/images/partners/warden.png",
-    "category": "infra",
+    "category": "ai",
     "subcategory": "ai"
   },
   {
@@ -3972,7 +3972,7 @@
     "description": "Bitte Protocol powers embeddable AI agents, enabling your community to seamlessly chat and transact with any smart contract.",
     "url": "https://bitte.ai/",
     "imageUrl": "/images/partners/bitte-protocol.png",
-    "category": "infra",
+    "category": "ai",
     "subcategory": "ai"
   },
   {


### PR DESCRIPTION
**What changed? Why?**
* add AI as a top-level ecosystem category
* move projects from `category: infra, subcategory: ai` to AI category
* update card component to only show a single chip if the category and subcategory have the same value

**Notes to reviewers**

**How has it been tested?**
